### PR TITLE
fix: strip stray wikilinks from docs

### DIFF
--- a/docs/ALGORITHM.md
+++ b/docs/ALGORITHM.md
@@ -111,7 +111,7 @@ Before scoring begins, candidates are pruned. This keeps the hot path fast and p
 
 ### Layer 1: Length & Pattern Filter
 
-**Length filter** -- Entity names longer than 25 characters are dropped. Article titles like "Complete Guide to [[ADF|Azure Data Factory]]" are not concepts worth linking.
+**Length filter** -- Entity names longer than 25 characters are dropped. Article titles like "Complete Guide to Azure Data Factory" are not concepts worth linking.
 
 **Word count filter** -- Entity names with more than 3 words are dropped. Real concepts are 1-3 words: "Marcus Johnson", "MCP", "Turbopump".
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 [← Back to docs](README.md)
 
-[[Flywheel]] Memory is a single MCP server that gives AI agents full read/write access to Obsidian vaults. It builds an in-memory index of every note, then exposes 74 tools for search, graph queries, and mutations.
+Flywheel Memory is a single MCP server that gives AI agents full read/write access to Obsidian vaults. It builds an in-memory index of every note, then exposes 74 tools for search, graph queries, and mutations.
 
 - [Source Structure](#source-structure)
 - [Startup Flow](#startup-flow)
@@ -125,10 +125,10 @@ packages/
 1. **Detect vault root** -- `findVaultRoot()` walks up from cwd looking for `.obsidian/` or `.claude/`
 2. **Open StateDb** -- `openStateDb(vaultPath)` creates/opens `.flywheel/state.db` (SQLite with WAL mode)
 3. **Initialize entity index** -- Loads entities from StateDb for auto-wikilinks
-4. **Connect MCP transport** -- `StdioServerTransport` for [[CLAUDE]] Code / Claude Desktop
+4. **Connect MCP transport** -- `StdioServerTransport` for Claude Code / Claude Desktop
 5. **Load index from cache** -- Checks `vault_index_cache` table in StateDb (valid if note count matches within 5% and age < 24h)
 6. **Build index if cache miss** -- Scans all `.md` files, parses notes in parallel (concurrency limit: 50), builds backlink/entity/tag maps
-7. **Post-index work** -- Scans vault entities, exports hub scores, infers config (periodic note folders, templates, etc.), starts file [[watcher]]
+7. **Post-index work** -- Scans vault entities, exports hub scores, infers config (periodic note folders, templates, etc.), starts file watcher
 
 ---
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -2,7 +2,7 @@
 
 [← Back to docs](README.md)
 
-Measured performance characteristics of [[Flywheel]] Memory at various vault sizes. Use these to set expectations for your vault.
+Measured performance characteristics of Flywheel Memory at various vault sizes. Use these to set expectations for your vault.
 
 > **Last measured:** 2026-03-19 | **Node:** 22.x | **Platform:** WSL2 (Linux 6.6) on Windows 11 | **Model:** all-MiniLM-L6-v2 (default embeddings)
 
@@ -38,7 +38,7 @@ Incremental update after a file change (18-step pipeline):
 | Any | 30–80ms | Hash gate skips unchanged files |
 | Any (with embeddings) | 50–150ms | +1 embedding update per changed file |
 
-The [[watcher]] uses content hashing (SHA-256) to skip unchanged files entirely. Batch latency is dominated by the number of *changed* files, not total vault size.
+The watcher uses content hashing (SHA-256) to skip unchanged files entirely. Batch latency is dominated by the number of *changed* files, not total vault size.
 
 ## Semantic Embedding Build
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,7 +2,7 @@
 
 [← Back to docs](README.md)
 
-Two layers of configuration: **environment variables** set in your [[Claude Desktop Config|MCP config]] (startup-time), and **runtime config** adjustable via the `flywheel_config` tool (persisted in StateDb). No config files to manage.
+Two layers of configuration: **environment variables** set in your MCP config (startup-time), and **runtime config** adjustable via the `flywheel_config` tool (persisted in StateDb). No config files to manage.
 
 - [MCP Config](#mcp-config)
 - [Windows](#windows)
@@ -47,7 +47,7 @@ No `FLYWHEEL_TOOLS` needed — defaults to `default` (16 tools). Add it only to 
 }
 ```
 
-Note: [[CLAUDE]] Desktop requires `VAULT_PATH` because it doesn't launch from the vault directory. Claude Code auto-detects the vault root from the working directory.
+Note: Claude Desktop requires `VAULT_PATH` because it doesn't launch from the vault directory. Claude Code auto-detects the vault root from the working directory.
 
 ---
 
@@ -59,7 +59,7 @@ On Windows, three things differ from macOS/Linux: the command, the vault path, a
 
 **`VAULT_PATH`** — Set this to your vault's Windows path. Claude Code can auto-detect it if you `cd` into the vault first, but setting it explicitly avoids issues.
 
-**`FLYWHEEL_WATCH_POLL`** — Required on Windows. Native file system events are unreliable on Windows, so you must enable polling for the file [[watcher]] to track changes. Without it, Flywheel starts fine and searches work, but edits you make in Obsidian won't appear in search results until you manually refresh. This is the most common source of "stale index" issues on Windows.
+**`FLYWHEEL_WATCH_POLL`** — Required on Windows. Native file system events are unreliable on Windows, so you must enable polling for the file watcher to track changes. Without it, Flywheel starts fine and searches work, but edits you make in Obsidian won't appear in search results until you manually refresh. This is the most common source of "stale index" issues on Windows.
 
 ```json
 {

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -2,9 +2,9 @@
 
 [← Back to docs](README.md)
 
-Example prompts organized by use case. Copy these directly into [[Claude Code]] or Claude Desktop.
+Example prompts organized by use case. Copy these directly into Claude Code or Claude Desktop.
 
-All examples assume [[Flywheel]] is connected to your vault. See [SETUP.md](SETUP.md) if you haven't configured it yet.
+All examples assume Flywheel is connected to your vault. See [SETUP.md](SETUP.md) if you haven't configured it yet.
 
 - [Daily Capture](#daily-capture)
 - [Research](#research)
@@ -54,7 +54,7 @@ Find connections and navigate the knowledge graph.
 
 ### Search by topic
 
-> "Find all notes about [[AI|machine learning]]"
+> "Find all notes about machine learning"
 
 > "Search for notes tagged #project and #active"
 
@@ -120,7 +120,7 @@ Hybrid search that combines keyword matching with conceptual similarity.
 
 > "Build the semantic search index for my vault"
 
-Runs locally, no [[API Management|API]] keys needed. Only needs to be done once — all subsequent searches automatically upgrade to hybrid ranking.
+Runs locally, no API keys needed. Only needs to be done once — all subsequent searches automatically upgrade to hybrid ranking.
 
 ### Search by concept
 

--- a/docs/PROVE-IT.md
+++ b/docs/PROVE-IT.md
@@ -22,7 +22,7 @@ No screenshots. No demos on someone else's machine. Clone the repo, run the test
 ## Prerequisites
 
 - **Node.js 22–24** -- check with `node --version`.
-- **[[CLAUDE]] Code** -- authenticated and working (`claude --version`)
+- **Claude Code** -- authenticated and working (`claude --version`)
 - **git** -- to clone the repo
 
 ---
@@ -77,7 +77,7 @@ Watch the tool trace (Claude's exact path varies between runs):
       frontmatter: { amount: 12000, status: "pending" }
 ```
 
-**What happened:** [[Flywheel]]'s enriched search returned frontmatter (amounts, status), backlinks, and outlinks for every hit -- all in one call. Zero file reads needed. The answer was in the search result itself.
+**What happened:** Flywheel's enriched search returned frontmatter (amounts, status), backlinks, and outlinks for every hit -- all in one call. Zero file reads needed. The answer was in the search result itself.
 
 Without Flywheel, Claude would grep for "Acme" and scan matching files. The real win shows in structural queries like "what are the hub notes?" or "what's the shortest path between X and Y?" — those need a graph, not file reads.
 
@@ -87,7 +87,7 @@ Without Flywheel, Claude would grep for "Acme" and scan matching files. The real
 
 Still in carter-strategy, tell Claude:
 
-> Log that Stacy Thompson is starting on the Beta Corp Dashboard and reviewed the [[API]] Security Checklist
+> Log that Stacy Thompson is starting on the Beta Corp Dashboard and reviewed the API Security Checklist
 
 Watch the output:
 
@@ -172,7 +172,7 @@ Same tools, completely different domain. Outlinks in search results trace the ci
 
 Ready to point Flywheel at your own vault? See the [full setup guide](SETUP.md) for:
 
-- [[Claude Desktop Config|MCP config]] for [[Claude Code]] and Claude Desktop
+- MCP config for Claude Code and Claude Desktop
 - Tool preset recommendations
 - Semantic search enablement
 

--- a/docs/QUALITY_REPORT.md
+++ b/docs/QUALITY_REPORT.md
@@ -142,4 +142,4 @@
 - Layer ablation: each scoring layer disabled individually; F1 delta measures contribution
 - Scoring layers (12): length_filter, article_filter, exact_match, stem_match, cooccurrence, type_boost, context_boost, recency, cross_folder, hub_boost, feedback, semantic
 - Run: `npm run test:quality:report`
-- Engine: [[Flywheel|flywheel-memory]] v2.0.139
+- Engine: flywheel-memory v2.0.139

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -2,7 +2,7 @@
 
 [← Back to docs](README.md)
 
-After trying the [demo vaults](../demos/), point [[Flywheel]] at your own Obsidian vault.
+After trying the [demo vaults](../demos/), point Flywheel at your own Obsidian vault.
 
 - [Prerequisites](#prerequisites)
 - [Windows](#windows)
@@ -21,13 +21,13 @@ After trying the [demo vaults](../demos/), point [[Flywheel]] at your own Obsidi
 
 - **Node.js 22–24** -- check with `node --version`.
 - **An Obsidian vault** -- any folder with `.md` files works, but Flywheel detects Obsidian conventions (`.obsidian/` folder, periodic notes, templates)
-- **An MCP-compatible client** -- [[CLAUDE]] Code, Claude Desktop, Cursor, Windsurf, VS Code + [[Github]] Copilot, Continue, [OpenClaw](https://github.com/openclaw/openclaw), or any Streamable HTTP client
+- **An MCP-compatible client** -- Claude Code, Claude Desktop, Cursor, Windsurf, VS Code + GitHub Copilot, Continue, [OpenClaw](https://github.com/openclaw/openclaw), or any Streamable HTTP client
 
 ---
 
 ## Windows
 
-On Windows, the [[Claude Desktop Config|MCP config]] differs from macOS/Linux in three ways:
+On Windows, the MCP config differs from macOS/Linux in three ways:
 
 1. **`cmd /c` wrapper** — use `"command": "cmd"` with `"args": ["/c", "npx", ...]` instead of `"command": "npx"`. Windows installs npx as a batch script (`npx.cmd`) which MCP clients can't execute directly — without this wrapper the server silently fails.
 2. **`VAULT_PATH`** — set to your vault's Windows path (e.g. `C:\Users\you\obsidian\MyVault`)
@@ -84,7 +84,7 @@ Edit `claude_desktop_config.json` (Settings > Developer > Edit Config):
 }
 ```
 
-Claude Desktop requires `VAULT_PATH` because it doesn't launch from the vault directory. [[Claude Code]] auto-detects the vault root from the working directory.
+Claude Desktop requires `VAULT_PATH` because it doesn't launch from the vault directory. Claude Code auto-detects the vault root from the working directory.
 
 Restart Claude Desktop after editing the config. Flywheel appears in the MCP server list.
 
@@ -238,7 +238,7 @@ See [CONFIGURATION.md](CONFIGURATION.md#multi-vault) for all multi-vault options
 
 On first run, Flywheel creates a `.flywheel/` directory containing its SQLite index and rotated backups. Add `.flywheel/` to your `.gitignore` if your vault is version-controlled. Flywheel automatically backs up its database on each startup (3 rotated copies) and recovers feedback data from backups if corruption occurs — see [TROUBLESHOOTING.md](TROUBLESHOOTING.md#statedb-corruption) for details.
 
-> **Proactive linking is on by default.** Flywheel's file [[watcher]] monitors your vault for changes and automatically inserts high-confidence wikilinks into notes you edit -- even outside of Claude. Only strong matches are applied (score >= 20, max 5 per file, max 10 per day). This is the core flywheel: edits you make in Obsidian get linked without you asking. If you prefer links only through explicit Claude tool calls, disable it:
+> **Proactive linking is on by default.** Flywheel's file watcher monitors your vault for changes and automatically inserts high-confidence wikilinks into notes you edit -- even outside of Claude. Only strong matches are applied (score >= 20, max 5 per file, max 10 per day). This is the core flywheel: edits you make in Obsidian get linked without you asking. If you prefer links only through explicit Claude tool calls, disable it:
 >
 > ```
 > flywheel_config({ mode: "set", key: "proactive_linking", value: false })

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -164,8 +164,8 @@ The read path is where users interact most. These tests verify that the index, s
 
 Honesty about coverage gaps:
 
-- **No automated Obsidian plugin testing.** [[Flywheel|Flywheel Crank]] (the Obsidian plugin) is tested manually. Browser/plugin automation is not part of CI.
-- **Live AI tests are not part of CI.** They require Claude [[API]] credits and are run on-demand before releases. Results are committed as markdown reports.
+- **No automated Obsidian plugin testing.** Flywheel Crank (the Obsidian plugin) is tested manually. Browser/plugin automation is not part of CI.
+- **Live AI tests are not part of CI.** They require Claude API credits and are run on-demand before releases. Results are committed as markdown reports.
 - **No load testing above 100 concurrent operations.** Flywheel is a single-user vault tool. 100 parallel writes is well beyond any realistic usage pattern.
 - **Edge weight and retrieval co-occurrence are newer.** These layers (added in schema v22 and v30) have less test coverage than older layers like FTS5 and entity scoring.
 
@@ -173,7 +173,7 @@ Honesty about coverage gaps:
 
 ## Retrieval Benchmark (HotpotQA)
 
-End-to-end retrieval quality measured on [HotpotQA](https://hotpotqa.github.io/) — a standard multi-hop question answering [[Benchmark]] from CMU/Stanford. Real Claude + Flywheel via `claude -p`, no pre-processing, no cherry-picking.
+End-to-end retrieval quality measured on [HotpotQA](https://hotpotqa.github.io/) — a standard multi-hop question answering benchmark from CMU/Stanford. Real Claude + Flywheel via `claude -p`, no pre-processing, no cherry-picking.
 
 ### Results (500 hard questions, 4,960 documents)
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -61,12 +61,12 @@ Every search result includes:
 | **tags, aliases** | Tags and alternative names | Understand categorization and find notes by alternate names. |
 | **category, hub_score** | Entity type and graph importance | Know if this is a person, project, or concept — and how central it is in the vault. |
 
-This is the key design: **one search call returns not just file paths, but the full neighborhood of each result.** That's why [[CLAUDE]] can answer "How much have I billed [[Acme Corp]]?" from a single search — the client's frontmatter has the totals, and the backlinks show every invoice.
+This is the key design: **one search call returns not just file paths, but the full neighborhood of each result.** That's why Claude can answer "How much have I billed [[Acme Corp]]?" from a single search — the client's frontmatter has the totals, and the backlinks show every invoice.
 
 **How matching works** (always start with just a query, no filters):
 
-1. **Full-text search (FTS5)** — BM25 ranking over note content. Handles stemming ("[[billing]]" matches "billed"), phrases, and boolean operators.
-2. **Entity search** — Matches against the entity database (names, aliases, categories). If "[[Sarah Mitchell|Sarah]] Chen" is an alias for `users/sarah-chen.md`, it finds it.
+1. **Full-text search (FTS5)** — BM25 ranking over note content. Handles stemming ("billing" matches "billed"), phrases, and boolean operators.
+2. **Entity search** — Matches against the entity database (names, aliases, categories). If "Sarah Chen" is an alias for `users/sarah-chen.md`, it finds it.
 3. **Hybrid ranking** — When semantic embeddings are built (via `init_semantic`), results from all three channels are merged using Reciprocal Rank Fusion. Notes can surface by meaning even without keyword overlap.
 
 The enrichment step is the same regardless of how a note matched — every result gets its full frontmatter, backlinks, and outlinks attached. Top results (controlled by `detail_count`, default 5) get full metadata; remaining results get lightweight summaries (counts only).
@@ -317,7 +317,7 @@ Deep analysis of a single note:
 
 ## Corrections
 
-Record mistakes that should persist across sessions. [[Flywheel]] [[processes]] these into feedback that improves future suggestions.
+Record mistakes that should persist across sessions. Flywheel processes these into feedback that improves future suggestions.
 
 | Tool | What it does |
 |------|-------------|

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 [← Back to docs](README.md)
 
-Error recovery and diagnostics for [[Flywheel]] Memory.
+Error recovery and diagnostics for Flywheel Memory.
 
 **Safety model:** Your markdown files are the source of truth. Everything in `.flywheel/` is derived data and can be safely deleted -- Flywheel rebuilds it on next startup.
 
@@ -64,7 +64,7 @@ The StateDb at `.flywheel/state.db` stores everything Flywheel learns about your
 
 Flywheel has four layers of protection:
 
-1. **Rotated WAL-safe backups** — After each successful startup (and every 6 hours during operation), Flywheel creates a backup using SQLite's backup [[API]], which is safe even during active WAL writes. Three rotated copies are kept: `state.db.backup` (most recent), `.backup.1`, `.backup.2`, `.backup.3`. This means even if the most recent backup is bad, older ones are available.
+1. **Rotated WAL-safe backups** — After each successful startup (and every 6 hours during operation), Flywheel creates a backup using SQLite's backup API, which is safe even during active WAL writes. Three rotated copies are kept: `state.db.backup` (most recent), `.backup.1`, `.backup.2`, `.backup.3`. This means even if the most recent backup is bad, older ones are available.
 
 2. **Integrity checks** — `PRAGMA quick_check` runs after every startup and every 6 hours in the watcher pipeline. If corruption is detected, recovery triggers immediately.
 
@@ -149,7 +149,7 @@ This happens when a previous git operation was interrupted (crash, forced kill, 
 ps aux | grep git
 ```
 
-2. If no git [[processes]] are running, the lock is stale. Remove it:
+2. If no git processes are running, the lock is stale. Remove it:
 
 ```bash
 rm /path/to/your/vault/.git/index.lock
@@ -159,7 +159,7 @@ rm /path/to/your/vault/.git/index.lock
 
 ### Prevention
 
-- Avoid force-killing [[CLAUDE]] Code or the MCP server during write operations
+- Avoid force-killing Claude Code or the MCP server during write operations
 - If you see this error frequently, check if another tool (Obsidian git plugin, cron job, etc.) is running git commands on the same vault
 
 ---
@@ -206,7 +206,7 @@ This forces a complete rebuild from scratch including the StateDb schema.
 Flywheel detects the vault root by walking up from the working directory, looking for `.obsidian/` or `.claude/`.
 
 **Fixes:**
-- **[[Claude Code]]:** Run `cd /path/to/your/vault && claude`
+- **Claude Code:** Run `cd /path/to/your/vault && claude`
 - **Claude Desktop:** Set `VAULT_PATH` in `claude_desktop_config.json`
 - Verify the vault directory contains `.obsidian/` or `.claude/`
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -4,7 +4,7 @@
 
 Your vault is the most valuable dataset you own. It holds your professional memory, your decision history, your relationship map, the accumulated context of every project you've ever worked on. It deserves infrastructure as serious as a production database -- indexed, queryable, and aware of its own structure.
 
-[[Flywheel]] Memory is that infrastructure.
+Flywheel Memory is that infrastructure.
 
 - [The State of Knowledge Work](#the-state-of-knowledge-work)
 - [How It Works in Practice](#how-it-works-in-practice)
@@ -67,7 +67,7 @@ See the main [README](../packages/mcp-server/README.md#the-flywheel-effect) for 
 
 ### Local-first: your trust guarantee
 
-Everything runs on your machine. No cloud services, no [[API Management|API]] keys (beyond [[CLAUDE]] itself), no data leaving your disk. The SQLite databases live inside your vault directory. Delete them and they rebuild from your markdown. You are always in control.
+Everything runs on your machine. No cloud services, no API keys (beyond Claude itself), no data leaving your disk. The SQLite databases live inside your vault directory. Delete them and they rebuild from your markdown. You are always in control.
 
 ### Markdown is truth: zero lock-in
 
@@ -91,7 +91,7 @@ Flywheel is for anyone who uses a vault as working memory and wants compound ret
 
 **The researcher** navigating 300 literature notes, 50 experiment logs, and a citation network that keeps growing. Flywheel finds citation chains -- "Which papers connect AlphaFold to my CRISPR experiment?" -- that manual search would miss entirely.
 
-**The founder** running a SaaS startup with standups, OKRs, decision records, and [[onboarding]] playbooks. Flywheel turns the vault into an operational dashboard: "What's blocking the Q1 launch?" pulls from milestones, meeting notes, and team assignments simultaneously.
+**The founder** running a SaaS startup with standups, OKRs, decision records, and onboarding playbooks. Flywheel turns the vault into an operational dashboard: "What's blocking the Q1 launch?" pulls from milestones, meeting notes, and team assignments simultaneously.
 
 **The student** connecting concepts across 5 textbooks and 100 lecture notes. Flywheel surfaces structural connections -- "How does spaced repetition connect to active recall?" -- by traversing the link graph across notebooks, not just matching keywords.
 
@@ -111,4 +111,4 @@ Shared library used by Flywheel Memory and other tools in the ecosystem. Handles
 
 ### MCP
 
-Flywheel implements the [Model Context Protocol](https://modelcontextprotocol.io/). Any MCP-compatible client -- [[Claude Code]], Claude Desktop, or third-party tools -- can connect and use the full tool surface. The protocol is the integration layer; Flywheel is the intelligence layer.
+Flywheel implements the [Model Context Protocol](https://modelcontextprotocol.io/). Any MCP-compatible client -- Claude Code, Claude Desktop, or third-party tools -- can connect and use the full tool surface. The protocol is the integration layer; Flywheel is the intelligence layer.


### PR DESCRIPTION
## Summary

Flywheel's auto-linker inserted `[[wikilinks]]` into 12 doc files. Stripped ~40 accidental insertions. Preserved intentional ones in example blocks.

## Test plan

- [x] `grep -rn '\[\[' docs/` — only example/demo wikilinks remain

Generated with [Claude Code](https://claude.com/claude-code)