### PR TITLE
feat(P38): section-aware snippets + entity bridging

### DIFF
--- a/packages/mcp-server/src/core/read/snippets.ts
+++ b/packages/mcp-server/src/core/read/snippets.ts
@@ -17,11 +17,15 @@ import { tokenize, stem } from '../shared/stemmer.js';
 export interface Snippet {
   text: string;
   score: number;
+  /** Which ## heading contains this snippet (null if top-level) */
+  section?: string;
+  /** Normalised relevance confidence 0-1 */
+  confidence?: number;
 }
 
 export interface SnippetOptions {
   maxSnippets?: number;     // default 1
-  maxChunkChars?: number;   // default 500
+  maxChunkChars?: number;   // default 800
 }
 
 // =============================================================================
@@ -34,32 +38,73 @@ function stripFrontmatter(content: string): string {
   return match ? match[1] : content;
 }
 
-/** Split content into paragraphs, merging short ones with successor. */
-function splitIntoParagraphs(content: string, maxChunkChars: number): string[] {
+interface ParagraphInfo {
+  text: string;
+  section: string | undefined;
+}
+
+/** Split content into paragraphs with section heading context. */
+function splitIntoParagraphs(content: string, maxChunkChars: number): ParagraphInfo[] {
   const MIN_PARAGRAPH_CHARS = 50;
   const raw = content.split(/\n\n+/).map(p => p.trim()).filter(p => p.length > 0);
 
-  // Merge short paragraphs with successor
-  const merged: string[] = [];
-  let buffer = '';
+  // Track current section heading
+  let currentSection: string | undefined;
+  const withSections: Array<{ text: string; section: string | undefined }> = [];
   for (const paragraph of raw) {
+    const headingMatch = paragraph.match(/^#{1,6}\s+(.+)/);
+    if (headingMatch) {
+      currentSection = headingMatch[1].trim();
+    }
+    withSections.push({ text: paragraph, section: currentSection });
+  }
+
+  // Merge short paragraphs with successor
+  const merged: ParagraphInfo[] = [];
+  let buffer = '';
+  let bufferSection: string | undefined;
+  for (const { text: paragraph, section } of withSections) {
     if (buffer) {
       buffer += '\n\n' + paragraph;
       if (buffer.length >= MIN_PARAGRAPH_CHARS) {
-        merged.push(buffer.slice(0, maxChunkChars));
+        merged.push({ text: buffer.slice(0, maxChunkChars), section: bufferSection });
         buffer = '';
       }
     } else if (paragraph.length < MIN_PARAGRAPH_CHARS) {
       buffer = paragraph;
+      bufferSection = section;
     } else {
-      merged.push(paragraph.slice(0, maxChunkChars));
+      merged.push({ text: paragraph.slice(0, maxChunkChars), section });
     }
   }
   if (buffer) {
-    merged.push(buffer.slice(0, maxChunkChars));
+    merged.push({ text: buffer.slice(0, maxChunkChars), section: bufferSection });
   }
 
   return merged;
+}
+
+/** Expand a matched paragraph with surrounding context (±2 paragraphs, capped at 800 chars). */
+function expandWindow(paragraphs: ParagraphInfo[], matchIdx: number, maxChars: number = 800): string {
+  let result = paragraphs[matchIdx].text;
+  let lo = matchIdx;
+  let hi = matchIdx;
+
+  // Try to expand up to 2 paragraphs in each direction
+  for (let step = 0; step < 2; step++) {
+    // Try expanding backward
+    if (lo > 0) {
+      const candidate = paragraphs[lo - 1].text + '\n\n' + result;
+      if (candidate.length <= maxChars) { result = candidate; lo--; }
+    }
+    // Try expanding forward
+    if (hi < paragraphs.length - 1) {
+      const candidate = result + '\n\n' + paragraphs[hi + 1].text;
+      if (candidate.length <= maxChars) { result = candidate; hi++; }
+    }
+  }
+
+  return result;
 }
 
 /** Score a chunk by keyword overlap with query tokens. */
@@ -101,7 +146,7 @@ export async function extractBestSnippets(
   options?: SnippetOptions,
 ): Promise<Snippet[]> {
   const maxSnippets = options?.maxSnippets ?? 1;
-  const maxChunkChars = options?.maxChunkChars ?? 500;
+  const maxChunkChars = options?.maxChunkChars ?? 800;
 
   // Read file
   let content: string;
@@ -113,8 +158,7 @@ export async function extractBestSnippets(
 
   const body = stripFrontmatter(content);
   if (body.length < 50) {
-    // Short note — return entire body
-    return body.length > 0 ? [{ text: body, score: 1 }] : [];
+    return body.length > 0 ? [{ text: body, score: 1, confidence: 1 }] : [];
   }
 
   const paragraphs = splitIntoParagraphs(body, maxChunkChars);
@@ -124,37 +168,45 @@ export async function extractBestSnippets(
   const queryStems = queryTokens.map(t => stem(t));
 
   // Score all chunks by keyword overlap
-  const scored = paragraphs.map((text, idx) => ({
-    text,
+  const scored = paragraphs.map((para, idx) => ({
+    ...para,
     idx,
-    keywordScore: scoreByKeywords(text, queryTokens, queryStems),
+    keywordScore: scoreByKeywords(para.text, queryTokens, queryStems),
   }));
 
   // Sort by keyword score descending
   scored.sort((a, b) => b.keywordScore - a.keywordScore);
 
+  // Max possible keyword score (all tokens exact match)
+  const maxPossibleScore = queryTokens.length * 10;
+
   // Take top 5 keyword matches for semantic re-ranking
   const topKeyword = scored.slice(0, 5);
+
+  // Build snippet with window expansion, section heading, and confidence
+  const buildSnippet = (match: typeof topKeyword[0], score: number): Snippet => ({
+    text: expandWindow(paragraphs, match.idx, maxChunkChars),
+    score,
+    section: match.section,
+    confidence: maxPossibleScore > 0 ? Math.min(1, score / maxPossibleScore) : 0,
+  });
 
   // If we have a query embedding and embeddings are available, re-rank by cosine similarity
   if (queryEmbedding && hasEmbeddingsIndex()) {
     try {
-      const reranked: Array<{ text: string; score: number }> = [];
+      const reranked: Array<{ match: typeof topKeyword[0]; sim: number }> = [];
       for (const chunk of topKeyword) {
         const chunkEmbedding = await embedTextCached(chunk.text);
         const sim = cosineSimilarity(queryEmbedding, chunkEmbedding);
-        reranked.push({ text: chunk.text, score: sim });
+        reranked.push({ match: chunk, sim });
       }
-      reranked.sort((a, b) => b.score - a.score);
-      return reranked.slice(0, maxSnippets);
+      reranked.sort((a, b) => b.sim - a.sim);
+      return reranked.slice(0, maxSnippets).map(r => buildSnippet(r.match, r.sim));
     } catch {
       // Fall through to keyword-only
     }
   }
 
   // Keyword-only fallback
-  return topKeyword.slice(0, maxSnippets).map(c => ({
-    text: c.text,
-    score: c.keywordScore,
-  }));
+  return topKeyword.slice(0, maxSnippets).map(c => buildSnippet(c, c.keywordScore));
 }

--- a/packages/mcp-server/src/tools/read/query.ts
+++ b/packages/mcp-server/src/tools/read/query.ts
@@ -105,6 +105,58 @@ function applySandwichOrdering(results: Array<Record<string, unknown>>): void {
 }
 
 /**
+ * Compute entity-mediated bridges between results.
+ * For each result pair, find entities (outlink targets) that appear in both notes.
+ * This is the key signal for multi-hop reasoning — tells the agent HOW results connect.
+ */
+function applyEntityBridging(
+  results: Array<Record<string, unknown>>,
+  stateDb: StateDb | null,
+  maxBridgesPerResult: number = 3,
+): void {
+  if (!stateDb || results.length < 2) return;
+
+  // Build map: note_path → set of outlink targets
+  const linkMap = new Map<string, Set<string>>();
+  try {
+    const paths = results.map(r => r.path as string).filter(Boolean);
+    for (const path of paths) {
+      const rows = stateDb.db.prepare(
+        'SELECT target FROM note_links WHERE note_path = ?'
+      ).all(path) as Array<{ target: string }>;
+      linkMap.set(path, new Set(rows.map(r => r.target)));
+    }
+  } catch { return; /* best-effort */ }
+
+  // For each result, find entities shared with other results
+  for (const r of results) {
+    const myPath = r.path as string;
+    const myLinks = linkMap.get(myPath);
+    if (!myLinks || myLinks.size === 0) continue;
+
+    const bridges: Array<{ entity: string; in_result: string }> = [];
+    for (const other of results) {
+      const otherPath = other.path as string;
+      if (otherPath === myPath) continue;
+      const otherLinks = linkMap.get(otherPath);
+      if (!otherLinks) continue;
+
+      // Find intersection
+      for (const entity of myLinks) {
+        if (otherLinks.has(entity) && bridges.length < maxBridgesPerResult) {
+          bridges.push({ entity, in_result: otherPath });
+        }
+      }
+      if (bridges.length >= maxBridgesPerResult) break;
+    }
+
+    if (bridges.length > 0) {
+      r.bridges = bridges;
+    }
+  }
+}
+
+/**
  * Strip internal scoring/provenance fields that waste context tokens.
  * Results are already sorted by these scores; exposing them adds no agent value.
  */
@@ -136,6 +188,8 @@ async function enhanceSnippets(
       const snippets = await extractBestSnippets(`${vaultPath}/${r.path}`, queryEmb, queryTokens);
       if (snippets.length > 0 && snippets[0].text.length > 0) {
         r.snippet = snippets[0].text;
+        if (snippets[0].section) r.section = snippets[0].section;
+        if (snippets[0].confidence != null) r.snippet_confidence = Math.round(snippets[0].confidence * 100) / 100;
       }
     } catch { /* non-fatal */ }
   }
@@ -518,8 +572,9 @@ export function registerQueryTools(
               results.push(...hopResults, ...expansionResults);
             }
 
-            // Graph re-ranking + sandwich ordering + enhanced snippets
+            // Graph re-ranking + bridging + sandwich ordering + enhanced snippets
             applyGraphReranking(results, stateDb);
+            applyEntityBridging(results, stateDb);
             applySandwichOrdering(results);
             await enhanceSnippets(results, query, vaultPath);
             stripInternalFields(results);
@@ -568,8 +623,9 @@ export function registerQueryTools(
             results.push(...hopResults, ...expansionResults);
           }
 
-          // Graph re-ranking + sandwich ordering + enhanced snippets
+          // Graph re-ranking + bridging + sandwich ordering + enhanced snippets
           applyGraphReranking(results, stateDb);
+          applyEntityBridging(results, stateDb);
           applySandwichOrdering(results);
           await enhanceSnippets(results, query, vaultPath);
           stripInternalFields(results);
@@ -594,8 +650,9 @@ export function registerQueryTools(
           results.push(...hopResults, ...expansionResults);
         }
 
-        // Graph re-ranking + sandwich ordering + enhanced snippets
+        // Graph re-ranking + bridging + sandwich ordering + enhanced snippets
         applyGraphReranking(results, stateDbFts);
+        applyEntityBridging(results, stateDbFts);
         applySandwichOrdering(results);
         await enhanceSnippets(results, query, vaultPath);
         stripInternalFields(results);


### PR DESCRIPTION
## Summary

Two context engineering features for improving multi-hop answer quality:

- **Section-aware snippets (T1)**: `section` heading provenance, `snippet_confidence` score, expanded window (±2 paragraphs, 800 char cap)
- **Entity bridging (T3)**: `bridges` field showing shared entities between results via `note_links`

## Test plan

- [ ] CI passes
- [ ] Search results include `section` and `snippet_confidence` when enhanced snippets run
- [ ] Results sharing outlink targets show `bridges` metadata

Generated with [Claude Code](https://claude.com/claude-code)