### PR TITLE
feat(P38/T4): extract dates from snippets

### DIFF
--- a/packages/mcp-server/src/core/read/snippets.ts
+++ b/packages/mcp-server/src/core/read/snippets.ts
@@ -210,3 +210,48 @@ export async function extractBestSnippets(
   // Keyword-only fallback
   return topKeyword.slice(0, maxSnippets).map(c => buildSnippet(c, c.keywordScore));
 }
+
+// =============================================================================
+// Date Extraction (T4)
+// =============================================================================
+
+const MONTH_MAP: Record<string, string> = {
+  jan: '01', feb: '02', mar: '03', apr: '04', may: '05', jun: '06',
+  jul: '07', aug: '08', sep: '09', oct: '10', nov: '11', dec: '12',
+  january: '01', february: '02', march: '03', april: '04',
+  june: '06', july: '07', august: '08', september: '09',
+  october: '10', november: '11', december: '12',
+};
+
+/**
+ * Extract dates mentioned in text. Returns deduplicated ISO date strings.
+ * Handles: 2024-01-15, Jan 15 2024, January 15, 2024, 15 Jan 2024, etc.
+ */
+export function extractDates(text: string): string[] {
+  const dates = new Set<string>();
+
+  // ISO dates: 2024-01-15
+  for (const m of text.matchAll(/\b(\d{4})-(\d{2})-(\d{2})\b/g)) {
+    dates.add(m[0]);
+  }
+
+  // "Jan 15, 2024" or "January 15 2024"
+  for (const m of text.matchAll(/\b((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w*)\s+(\d{1,2}),?\s+(\d{4})\b/gi)) {
+    const month = MONTH_MAP[m[1].toLowerCase()];
+    if (month) dates.add(`${m[3]}-${month}-${m[2].padStart(2, '0')}`);
+  }
+
+  // "15 Jan 2024" or "15 January 2024"
+  for (const m of text.matchAll(/\b(\d{1,2})\s+((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w*)\s+(\d{4})\b/gi)) {
+    const month = MONTH_MAP[m[2].toLowerCase()];
+    if (month) dates.add(`${m[3]}-${month}-${m[1].padStart(2, '0')}`);
+  }
+
+  // "March 2024" (month + year, no day — use day 01)
+  for (const m of text.matchAll(/\b((?:January|February|March|April|May|June|July|August|September|October|November|December))\s+(\d{4})\b/gi)) {
+    const month = MONTH_MAP[m[1].toLowerCase()];
+    if (month) dates.add(`${m[2]}-${month}-01`);
+  }
+
+  return [...dates].sort();
+}

--- a/packages/mcp-server/src/tools/read/query.ts
+++ b/packages/mcp-server/src/tools/read/query.ts
@@ -39,7 +39,7 @@ import { getCooccurrenceBoost } from '../../core/shared/cooccurrence.js';
 import { getCooccurrenceIndex } from '../../core/write/wikilinks.js';
 import { getRecencyBoost, loadRecencyFromStateDb } from '../../core/shared/recency.js';
 import { getEntityEdgeWeightMap } from '../../core/write/edgeWeights.js';
-import { extractBestSnippets } from '../../core/read/snippets.js';
+import { extractBestSnippets, extractDates } from '../../core/read/snippets.js';
 import { selectByMmr } from '../../core/read/mmr.js';
 import { tokenize } from '../../core/shared/stemmer.js';
 
@@ -190,6 +190,9 @@ async function enhanceSnippets(
         r.snippet = snippets[0].text;
         if (snippets[0].section) r.section = snippets[0].section;
         if (snippets[0].confidence != null) r.snippet_confidence = Math.round(snippets[0].confidence * 100) / 100;
+        // Extract dates from snippet text
+        const dates = extractDates(snippets[0].text);
+        if (dates.length > 0) r.dates_mentioned = dates;
       }
     } catch { /* non-fatal */ }
   }


### PR DESCRIPTION
## Summary

Extract dates from snippet text as structured `dates_mentioned` metadata. Handles ISO, natural, and month-year formats. Addresses LoCoMo temporal category (41% accuracy).

## Test plan

- [ ] CI passes
- [ ] Search for time-sensitive queries shows `dates_mentioned` on results

Generated with [Claude Code](https://claude.com/claude-code)