### PR TITLE
chore: release v2.0.146

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,7 +5945,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.0.145",
+      "version": "2.0.146",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5971,13 +5971,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.0.145",
+      "version": "2.0.146",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@velvetmonkey/vault-core": "^2.0.145",
+        "@velvetmonkey/vault-core": "^2.0.146",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.0.145",
+  "version": "2.0.146",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.0.145",
+  "version": "2.0.146",
   "description": "MCP server that gives Claude full read/write access to your Obsidian vault. Select from 74 tools for search, backlinks, graph queries, mutations, agent memory, and hybrid semantic search.",
   "type": "module",
   "main": "dist/index.js",
@@ -54,7 +54,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.0.145",
+    "@velvetmonkey/vault-core": "^2.0.146",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Release v2.0.146

Version bump for vault-core + flywheel-memory.

### Changes since v2.0.145

- **perf**: Connect MCP transport before vault boot (60s → <1s handshake) (#29)
- **feat**: Learning report, calibration export, custom entity categories (#28)
- **feat**: CLA, WSL path guidance, policy vault context (#28)
- **feat(P38)**: Section-aware snippets, entity bridging, date extraction (#22-#26)
- **fix**: FTS5 test isolation, CI benchmark exclusion (#21, #25)
- **docs**: Benchmark updates, startup times, troubleshooting (#17, #18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)