### PR TITLE
docs: add learning telemetry documentation and sharing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,10 @@ Your PR submission serves as your electronic signature. No separate form or bot 
 
 Keep PRs focused -- one logical change per PR.
 
+## Sharing Calibration Data
+
+Sharing your vault's scoring statistics is a non-code contribution that helps tune default thresholds and layer weights. Run `flywheel_calibration_export` (fully anonymized — no entity names, no paths, no content) and paste the JSON in the [Calibration Data](https://github.com/velvetmonkey/flywheel-memory/discussions/categories/calibration-data) discussion category. See [docs/SHARING.md](docs/SHARING.md) for what's safe to share.
+
 ## Releasing
 
 Releases are manual. Before tagging:

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ Every sentence you write through Flywheel makes your graph denser. A denser grap
 
 Static tools give you the same results on day 1 and day 100. Flywheel's suggestions on day 100 are informed by everything you've written and edited since day 1. No retraining, no configuration, no manual curation. This isn't a claim - it's [measured](docs/TESTING.md#graph-quality-266-tests-31-files): 266 graph quality tests track F1 across 6 vault archetypes, a [50-generation stress test](docs/TESTING.md#multi-generation-stress-test) proves F1 doesn't collapse under 15% hostile feedback, and CI fails if any metric regresses more than 5pp.
 
+#### What the system tracks
+
+All learning data lives in a local SQLite database (`.flywheel/state.db`) on your machine. There are no network calls, no telemetry, no analytics — [enforced by CI](SECURITY.md). The system records which auto-links you keep or remove (feedback), which entities appear together across notes (co-occurrence), how link weights evolve over time (edge weights), and which entities get auto-suppressed after repeated removal (suppression). This is how scoring improves: real usage, measured locally.
+
+None of this data leaves your machine unless you choose to share it. The `flywheel_calibration_export` tool produces a fully anonymized aggregate snapshot — vault size buckets (not exact counts), entity distribution by category (not names), survival rates, layer contributions, score distributions. No entity names, no note paths, no content. If you want to help tune scoring defaults across different vault sizes and styles, you can paste your export in the [Calibration Data](https://github.com/velvetmonkey/flywheel-memory/discussions/categories/calibration-data) discussion category. See [docs/SHARING.md](docs/SHARING.md) for what's safe to share and what isn't.
+
 ### 4. Agentic Memory & Policies
 
 Your AI knows what you were working on yesterday without re-explaining it. `brief` delivers startup context, `recall` retrieves across notes, entities (people, projects, concepts), and memories in one call, and `memory` stores observations that persist across sessions with automatic decay.
@@ -324,6 +330,7 @@ Flywheel controls retrieval; the model controls comprehension. Evidence recall i
 | [ARCHITECTURE.md](docs/ARCHITECTURE.md) | Index strategy, graph, auto-wikilinks |
 | [TESTING.md](docs/TESTING.md) | Test methodology and benchmarks |
 | [TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) | Error recovery and diagnostics |
+| [SHARING.md](docs/SHARING.md) | What's tracked, privacy guarantees, sharing stats |
 | [VISION.md](docs/VISION.md) | Where this is going |
 
 ---

--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -1,0 +1,95 @@
+# Sharing Calibration Data
+
+Flywheel learns from how you use your vault. Every accepted link, every removal, every edit that survives — it all feeds back into scoring. This page explains what's tracked, what's safe to share, and how sharing helps everyone.
+
+## What's tracked and why
+
+All data lives in `.flywheel/state.db` on your machine. Zero network calls (enforced by [CI test](../SECURITY.md)).
+
+| Data | Purpose | Contains vault-specific info? |
+|------|---------|-------------------------------|
+| **Wikilink feedback** | Tracks accepted/removed auto-links to learn suppression thresholds | Yes — note paths, entity names, context snippets |
+| **Suggestion events** | Audit log of every scoring decision (13-layer breakdown) | Yes — note paths, entity names |
+| **Vault metrics** | Aggregate counts (notes, links, entities, accuracy) over time | No — just numbers |
+| **Performance benchmarks** | Search latency, index timing, watcher pipeline | No — just timing data |
+| **Co-occurrence index** | Which entities appear together across notes | Yes — entity names |
+| **Edge weights** | Link strength based on survival and feedback | Yes — note paths |
+
+The first two groups are where the learning happens. The last two are aggregate statistics that contain no identifying information.
+
+## What's safe to share
+
+### `flywheel_calibration_export` (recommended)
+
+Purpose-built for cross-vault sharing. The export contains:
+
+- **Vault profile** — size bucket (e.g. "500-999"), not exact count. Link density, strictness mode, flywheel age
+- **Entity distribution** — counts per category (person: 45, project: 12), no names
+- **Suggestion funnel** — evaluations → applications → survivals, with rates
+- **Layer contributions** — average score per scoring layer, which layers contribute most
+- **Score distribution** — histogram in 5-point bins, mean and median
+- **Survival by category** — which entity types stick and which get removed
+- **Feedback stats** — explicit vs. implicit counts, accuracy rates
+- **Suppression stats** — how many entities are auto-suppressed
+- **Threshold analysis** — pass rates at different score thresholds
+
+What it **does not** contain: entity names, note paths, note content, file names, tag names, or anything that identifies your vault's subject matter. An optional `vault_id` (SHA-256 hash of your vault path, truncated) lets you track your own exports over time without revealing the path.
+
+### Also safe
+
+- **`vault_growth`** — aggregate metrics (note count, link density, connected ratio). Numbers only.
+- **`flywheel_benchmark`** — search latency, index timing. Performance data only.
+
+### Review before sharing
+
+- **`flywheel_learning_report`** — includes entity names in the "top rejected" section. Entity names could be people, clients, or other sensitive identifiers. Safe if your vault is non-sensitive; review the output first if it is.
+
+### Never share
+
+- **Raw `.flywheel/state.db`** — contains note paths, content snippets, entity names, and the full audit trail. Treat it like your vault itself.
+
+## How to export
+
+Ask your AI client:
+
+> Run `flywheel_calibration_export` with `days_back` set to 30.
+
+Or for a longer analysis window:
+
+> Run `flywheel_calibration_export` with `days_back` 90 and `include_vault_id` true.
+
+The output is a JSON object. Copy it.
+
+## How to share
+
+Post your calibration export in the [**Calibration Data** discussion category](https://github.com/velvetmonkey/flywheel-memory/discussions/categories/calibration-data) on GitHub.
+
+**Suggested title format:**
+
+```
+[calibration] <size_bucket> / <days> days / v<version>
+```
+
+Example: `[calibration] 1000-2499 / 30 days / v2.0.145`
+
+Paste the JSON in the body. Add any observations you have — what's working, what's surprising, what entity categories your vault focuses on. Context helps us interpret the numbers.
+
+## Why share
+
+Every vault is different. A personal journal, a software project, a research corpus — they have different entity distributions, different link densities, different feedback patterns. Calibration exports help us:
+
+- **Tune default thresholds** — is the default strictness right for vaults your size?
+- **Balance layer weights** — which scoring layers matter most across different vault types?
+- **Spot category-specific issues** — do certain entity types (people, projects, technologies) have systematically different survival rates?
+- **Track improvement** — are newer versions actually better across real vaults?
+
+Your data is anonymous. Your vault stays local. The aggregate patterns help everyone.
+
+## Privacy architecture
+
+For the full security model, see [SECURITY.md](../SECURITY.md). The key guarantees:
+
+- **Local-only storage** — all data in `.flywheel/state.db` on your machine
+- **Zero telemetry** — no phone-home, no analytics, no tracking. Enforced by CI
+- **One network exception** — `@huggingface/transformers` model download (~23MB, one-time, for semantic search). No vault data is sent
+- **Calibration export is opt-in** — you choose what to share, when, and where


### PR DESCRIPTION
New docs/SHARING.md explains what the system tracks, privacy guarantees, and how to share anonymized calibration exports. README and CONTRIBUTING updated with links.