### PR TITLE
fix: replace dynamic require('crypto') with static ESM import

### DIFF
--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -50,6 +50,8 @@ What it **does not** contain: entity names, note paths, note content, file names
 
 ## How to export
 
+The calibration export tool is in the **`diagnostics`** bundle, available in the `full` preset. If you're using `default` or `agent`, add diagnostics to your config: `FLYWHEEL_TOOLS=default,diagnostics` (see [CONFIGURATION.md](CONFIGURATION.md) for details).
+
 Ask your AI client:
 
 > Run `flywheel_calibration_export` with `days_back` set to 30.

--- a/packages/mcp-server/src/core/read/calibrationExport.ts
+++ b/packages/mcp-server/src/core/read/calibrationExport.ts
@@ -13,6 +13,7 @@ import {
   getSuppressedCount,
 } from '../write/wikilinkFeedback.js';
 import { hasEmbeddingsIndex } from './embeddings.js';
+import { createHash } from 'node:crypto';
 
 // =============================================================================
 // TYPES
@@ -383,8 +384,7 @@ export function getCalibrationExport(
   let vaultId: string | undefined;
   if (includeVaultId) {
     // Generate a stable anonymous ID from vault path hash
-    const crypto = require('crypto');
-    vaultId = crypto.createHash('sha256').update(stateDb.vaultPath).digest('hex').slice(0, 16);
+    vaultId = createHash('sha256').update(stateDb.vaultPath).digest('hex').slice(0, 16);
   }
 
   return {


### PR DESCRIPTION
## Summary
- Replace `require('crypto')` with `import { createHash } from 'node:crypto'` in calibration export
- Add preset/bundle info to SHARING.md (diagnostics bundle required)

Fixes `Dynamic require of "crypto" is not supported` error when running `flywheel_calibration_export`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)