### PR TITLE
feat: pass custom_categories to entity scanning

### DIFF
--- a/packages/mcp-server/src/core/write/wikilinks.ts
+++ b/packages/mcp-server/src/core/write/wikilinks.ts
@@ -243,6 +243,7 @@ async function rebuildIndex(vaultPath: string): Promise<void> {
 
   entityIndex = await scanVaultEntities(vaultPath, {
     excludeFolders: DEFAULT_EXCLUDE_FOLDERS,
+    customCategories: getConfig()?.custom_categories,
   });
 
   indexReady = true;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -617,6 +617,7 @@ async function updateEntitiesInStateDb(vp?: string, sd?: StateDb | null): Promis
 
     const entityIndex = await scanVaultEntities(vault, {
       excludeFolders,
+      customCategories: config.custom_categories,
     });
     db.replaceAllEntities(entityIndex);
     serverLog('index', `Updated ${entityIndex._metadata.total_entities} entities in StateDb`);

--- a/packages/mcp-server/src/tools/read/system.ts
+++ b/packages/mcp-server/src/tools/read/system.ts
@@ -77,6 +77,7 @@ export function registerSystemTools(
         const stateDb = getStateDb?.();
         if (stateDb) {
           try {
+            const config = loadConfig(stateDb);
             const entityIndex = await scanVaultEntities(vaultPath, {
               excludeFolders: [
                 'daily-notes', 'daily', 'weekly', 'weekly-notes', 'monthly',
@@ -84,6 +85,7 @@ export function registerSystemTools(
                 'inbox', 'templates', 'attachments', 'tmp',
                 'clippings', 'readwise', 'articles', 'bookmarks', 'web-clips',
               ],
+              customCategories: config.custom_categories,
             });
             stateDb.replaceAllEntities(entityIndex);
             console.error(`[Flywheel] Updated ${entityIndex._metadata.total_entities} entities in StateDb`);

--- a/packages/mcp-server/src/tools/write/enrich.ts
+++ b/packages/mcp-server/src/tools/write/enrich.ts
@@ -21,6 +21,7 @@ import {
 import { trackWikilinkApplications, updateStoredNoteLinks } from '../../core/write/wikilinkFeedback.js';
 import { scanVaultEntities, SCHEMA_VERSION, type StateDb } from '@velvetmonkey/vault-core';
 import { buildFTS5Index, getFTS5State } from '../../core/read/fts5.js';
+import { loadConfig } from '../../core/read/config.js';
 import { hasEmbeddingsIndex } from '../../core/read/embeddings.js';
 
 interface InitPreviewItem {
@@ -204,7 +205,8 @@ async function executeRun(stateDb: StateDb | null, vaultPath: string): Promise<R
   if (entityCount === 0) {
     const start = Date.now();
     try {
-      const entityIndex = await scanVaultEntities(vaultPath, { excludeFolders: EXCLUDE_FOLDERS });
+      const config = loadConfig(stateDb);
+      const entityIndex = await scanVaultEntities(vaultPath, { excludeFolders: EXCLUDE_FOLDERS, customCategories: config.custom_categories });
       stateDb.replaceAllEntities(entityIndex);
       const newCount = entityIndex._metadata.total_entities;
       steps.push({


### PR DESCRIPTION
## Summary
Completes the custom_categories wiring started in #37. All 4 `scanVaultEntities()` call sites now pass `customCategories` from config:

- `index.ts` — startup entity scan
- `enrich.ts` — vault_init entity scan
- `wikilinks.ts` — rebuildIndex()
- `system.ts` — refresh_index

Without this, entities with custom frontmatter types (e.g. `type: work`) were categorized as "other" at scan time, so the scoring-side fix from #37 could never fire.

## Test plan
- [x] 2,390 tests passing
- [x] Type check and build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)