### PR TITLE
fix: flywheel_config get returns {} due to stale fallback scope

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -381,7 +381,11 @@ function updateFlywheelConfig(config: FlywheelConfig): void {
   flywheelConfig = config;
   setWikilinkConfig(config);
   const ctx = getActiveVaultContext();
-  if (ctx) ctx.flywheelConfig = config;
+  if (ctx) {
+    ctx.flywheelConfig = config;
+    // Rebuild fallback scope so scope-aware getters see the update
+    setActiveScope(buildVaultScope(ctx));
+  }
 }
 
 /**
@@ -569,6 +573,8 @@ async function main() {
   loadVaultCooccurrence(primaryCtx);
   activateVault(primaryCtx);
   await bootVault(primaryCtx, startTime);
+  // Re-activate after boot so fallback scope reflects post-boot state (config, index, etc.)
+  activateVault(primaryCtx);
 
   // ── Phase 4: Initialize + boot secondary vaults (background) ──
   if (vaultConfigs && vaultConfigs.length > 1) {


### PR DESCRIPTION
## Summary
- `flywheel_config({ mode: "get" })` returned `{}` because the scope-aware getter read from a stale `VaultScope` snapshot
- `updateFlywheelConfig()` now rebuilds the fallback scope after updates
- Post-boot re-activation ensures the fallback scope reflects loaded config

## Test plan
- [ ] `flywheel_config({ mode: "get" })` returns full config after server restart
- [ ] SET then GET returns the updated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)