### PR TITLE
chore: bump vault-core + flywheel-memory to 2.0.151

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,7 +5945,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.0.150",
+      "version": "2.0.151",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5971,13 +5971,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.0.150",
+      "version": "2.0.151",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@velvetmonkey/vault-core": "^2.0.150",
+        "@velvetmonkey/vault-core": "^2.0.151",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.0.150",
+  "version": "2.0.151",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.0.150",
+  "version": "2.0.151",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -54,7 +54,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.0.150",
+    "@velvetmonkey/vault-core": "^2.0.151",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary
- Bump both `@velvetmonkey/vault-core` and `@velvetmonkey/flywheel-memory` to 2.0.151
- Update vault-core dependency pin in flywheel-memory

## Changes since 2.0.150
- Launch packaging (Phases A-F) (#47)
- Tool count 74 → 75 (#48)
- Include LICENSE in npm packages (#49)
- Freeze one-line positioning (#50)
- Changelog catch-up v2.0.108-150 (#51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)