### PR TITLE
T8: HTTP security guide with nginx/Caddy reverse proxy recipes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,69 +54,7 @@ Flywheel runs locally on your machine. The default transport is **stdio** (no ne
 
 When `FLYWHEEL_TRANSPORT=http`, the server listens on `127.0.0.1:3111` by default. **There is no authentication** — any process on localhost can call tools. Do not expose to network without your own auth layer.
 
-### HTTP reverse proxy recipes
-
-If you need to expose the HTTP transport beyond localhost (e.g., for remote agents or multi-machine setups), always put a reverse proxy in front. **Never change `FLYWHEEL_HTTP_HOST` from `127.0.0.1`.**
-
-<details>
-<summary><strong>nginx</strong></summary>
-
-```nginx
-# /etc/nginx/sites-available/flywheel
-limit_req_zone $binary_remote_addr zone=flywheel:10m rate=30r/m;
-
-server {
-    listen 443 ssl;
-    server_name flywheel.example.com;
-
-    ssl_certificate     /etc/ssl/certs/flywheel.pem;
-    ssl_certificate_key /etc/ssl/private/flywheel.key;
-
-    location /mcp {
-        limit_req zone=flywheel burst=10 nodelay;
-
-        proxy_pass http://127.0.0.1:3111;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
-        # Disable buffering for streaming MCP responses
-        proxy_buffering off;
-
-        # Add your auth layer here (e.g., auth_basic, auth_request, or mTLS)
-    }
-
-    location /health {
-        proxy_pass http://127.0.0.1:3111;
-    }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Caddy</strong></summary>
-
-```caddyfile
-flywheel.example.com {
-    # Caddy handles TLS automatically
-
-    @mcp path /mcp
-    handle @mcp {
-        reverse_proxy localhost:3111 {
-            flush_interval -1  # Stream responses immediately
-        }
-        # Add your auth layer here (e.g., basicauth, forward_auth)
-    }
-
-    handle /health {
-        reverse_proxy localhost:3111
-    }
-}
-```
-
-</details>
+If you need to expose the HTTP transport beyond localhost (e.g., for remote agents or multi-machine setups), always put a reverse proxy in front. **Never change `FLYWHEEL_HTTP_HOST` from `127.0.0.1`.** See [docs/SECURITY.md](docs/SECURITY.md) for nginx and Caddy recipes with TLS termination, rate limiting, and auth placeholders.
 
 ### Network access
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Index strategy, FTS5 search, graph model, auto-wikilinks | "How does Flywheel work under the hood?" |
 | [CONFIGURATION.md](CONFIGURATION.md) | Environment variables, tool presets, platform setup | "How do I customize my setup?" |
 | [TESTING.md](TESTING.md) | Test philosophy, performance benchmarks, security testing | "How is this tested and can I trust it?" |
+| [SECURITY.md](SECURITY.md) | HTTP reverse proxy recipes — nginx, Caddy, TLS, auth | "How do I safely expose Flywheel over the network?" |
 | [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Error recovery, diagnostics, common issues | "Something went wrong — how do I fix it?" |
 | [VISION.md](VISION.md) | The flywheel effect, design principles, ecosystem | "Where is this project going?" |
 | [ALGORITHM.md](ALGORITHM.md) | The 13-layer scoring system — how every suggestion is computed | "How does auto-wikilinks decide what to link?" |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,98 @@
+# HTTP Security
+
+[← Back to docs](README.md) · [Security Policy](../SECURITY.md)
+
+Flywheel's HTTP transport (`FLYWHEEL_TRANSPORT=http`) has **no built-in authentication or TLS**. By default, it binds to `127.0.0.1:3111` — only processes on the same machine can reach it. This is safe for local development, but if you need remote access (multi-machine setups, remote agents), you must put a reverse proxy in front.
+
+> **Do not expose the HTTP transport to the network without a reverse proxy providing TLS and authentication.** Any client that can reach the port can call every tool — including write operations.
+
+---
+
+## nginx
+
+```nginx
+# /etc/nginx/sites-available/flywheel
+limit_req_zone $binary_remote_addr zone=flywheel:10m rate=30r/m;
+
+server {
+    listen 443 ssl;
+    server_name flywheel.example.com;
+
+    # --- TLS termination ---
+    ssl_certificate     /etc/ssl/certs/flywheel.pem;
+    ssl_certificate_key /etc/ssl/private/flywheel.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    # --- MCP endpoint ---
+    location /mcp {
+        limit_req zone=flywheel burst=10 nodelay;
+
+        # Flywheel stays on localhost — never change this
+        proxy_pass http://127.0.0.1:3111;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Disable buffering for streaming MCP responses
+        proxy_buffering off;
+
+        # Add your auth layer here (e.g., auth_basic, auth_request, or mTLS)
+    }
+
+    # --- Health check (no rate limit) ---
+    location /health {
+        proxy_pass http://127.0.0.1:3111;
+    }
+}
+```
+
+Enable with:
+
+```bash
+ln -s /etc/nginx/sites-available/flywheel /etc/nginx/sites-enabled/
+nginx -t && systemctl reload nginx
+```
+
+---
+
+## Caddy
+
+```caddyfile
+flywheel.example.com {
+    # Caddy provisions TLS automatically via Let's Encrypt
+
+    @mcp path /mcp
+    handle @mcp {
+        reverse_proxy localhost:3111 {
+            flush_interval -1   # Stream responses immediately
+        }
+        # Add your auth layer here (e.g., basicauth, forward_auth)
+    }
+
+    handle /health {
+        reverse_proxy localhost:3111
+    }
+}
+```
+
+Start with:
+
+```bash
+caddy run --config /etc/caddy/Caddyfile
+```
+
+Caddy handles TLS certificate provisioning, renewal, and OCSP stapling automatically. No certificate paths needed unless you supply your own.
+
+---
+
+## Before you deploy
+
+- [ ] `FLYWHEEL_HTTP_HOST` is `127.0.0.1` (the default — never change it)
+- [ ] Reverse proxy terminates TLS (self-signed is fine for internal use)
+- [ ] Auth layer is in place (basic auth, mTLS, OAuth proxy, etc.)
+- [ ] Rate limiting is configured to prevent abuse
+- [ ] Test: `curl -s https://flywheel.example.com/health` returns version info
+- [ ] Test: unauthenticated requests are rejected by your proxy

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -178,7 +178,7 @@ curl http://localhost:3111/health
 |----------|---------|-------------|
 | `FLYWHEEL_TRANSPORT` | `stdio` | Set to `http` for HTTP-only, or `both` to run stdio + HTTP simultaneously |
 | `FLYWHEEL_HTTP_PORT` | `3111` | Port the HTTP server listens on |
-| `FLYWHEEL_HTTP_HOST` | `127.0.0.1` | Bind address. Use `0.0.0.0` to accept connections from other machines |
+| `FLYWHEEL_HTTP_HOST` | `127.0.0.1` | Bind address. Keep as `127.0.0.1` — for remote access, use a [reverse proxy](SECURITY.md) instead |
 
 Example with custom port:
 


### PR DESCRIPTION
## Summary
- Create `docs/SECURITY.md` with nginx and Caddy reverse proxy recipes — both with TLS termination, localhost-only proxy_pass, rate limiting, streaming support, and auth placeholders
- Move inline recipes out of root `SECURITY.md` into the new doc (root now links to it)
- Fix unsafe `0.0.0.0` suggestion in `docs/SETUP.md` — now says to use a reverse proxy instead
- Add `SECURITY.md` to the `docs/README.md` document guide table

## Test plan
- [ ] All internal links resolve (root SECURITY.md → docs/SECURITY.md, SETUP.md → SECURITY.md, README.md table)
- [ ] Root SECURITY.md no longer contains inline nginx/Caddy configs
- [ ] `docs/SETUP.md` no longer suggests `0.0.0.0`
- [ ] nginx config is valid (`nginx -t` with the snippet)
- [ ] Caddy config is valid (`caddy validate` with the snippet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)