### PR TITLE
fix: watcher performance — throttle expensive pipeline steps + fix parse error logging

### DIFF
--- a/packages/mcp-server/src/core/read/graph.ts
+++ b/packages/mcp-server/src/core/read/graph.ts
@@ -19,6 +19,7 @@ import {
 } from '@velvetmonkey/vault-core';
 import { parseNote } from './parser.js';
 import { levenshteinDistance } from '../shared/levenshtein.js';
+import { serverLog } from '../shared/serverLog.js';
 import { embedTextCached, findSemanticallySimilarEntities, hasEntityEmbeddingsIndex } from './embeddings.js';
 import { getActiveScopeOrNull } from '../../vault-scope.js';
 
@@ -164,7 +165,7 @@ async function buildVaultIndexInternal(
 
   // Parse all notes with concurrency control
   const notes = new Map<string, VaultNote>();
-  const parseErrors: string[] = [];
+  const parseErrors: Array<{ path: string; reason: string }> = [];
   let parsedCount = 0;
 
   // Process files in batches for controlled concurrency
@@ -178,15 +179,15 @@ async function buildVaultIndexInternal(
       })
     );
 
-    for (const result of results) {
+    for (let j = 0; j < results.length; j++) {
+      const result = results[j];
       if (result.status === 'fulfilled') {
         notes.set(result.value.note.path, result.value.note);
       } else {
-        // Extract file path from the batch (best effort)
-        const batchIndex = results.indexOf(result);
-        if (batchIndex >= 0 && batch[batchIndex]) {
-          parseErrors.push(batch[batchIndex].path);
-        }
+        const filePath = batch[j]?.path ?? '<unknown>';
+        const reason = result.reason instanceof Error
+          ? result.reason.message : String(result.reason);
+        parseErrors.push({ path: filePath, reason });
       }
       parsedCount++;
     }
@@ -203,9 +204,13 @@ async function buildVaultIndexInternal(
   }
 
   if (parseErrors.length > 0) {
-    console.error(`Failed to parse ${parseErrors.length} files:`);
-    for (const errorPath of parseErrors) {
-      console.error(`  - ${errorPath}`);
+    const msg = `Failed to parse ${parseErrors.length} file(s):`;
+    console.error(msg);
+    serverLog('index', msg, 'error');
+    for (const err of parseErrors) {
+      const detail = `  - ${err.path}: ${err.reason}`;
+      console.error(detail);
+      serverLog('index', detail, 'error');
     }
   }
 

--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -285,9 +285,23 @@ export class PipelineRunner {
       for (const r of rows) this.hubBefore.set(r.name, r.hub_score);
     }
 
+    // Throttle: full entity scan is expensive (recursive directory walk).
+    // Skip if scanned within 5 minutes; downstream steps still get entities from DB.
+    const entityScanAgeMs = p.ctx.lastEntityScanAt > 0
+      ? Date.now() - p.ctx.lastEntityScanAt : Infinity;
+    if (entityScanAgeMs < 5 * 60 * 1000) {
+      tracker.start('entity_scan', {});
+      tracker.skip('entity_scan', `cache valid (${Math.round(entityScanAgeMs / 1000)}s old)`);
+      this.entitiesBefore = p.sd ? getAllEntitiesFromDb(p.sd) : [];
+      this.entitiesAfter = this.entitiesBefore;
+      serverLog('watcher', `Entity scan: throttled (${Math.round(entityScanAgeMs / 1000)}s old)`);
+      return;
+    }
+
     this.entitiesBefore = p.sd ? getAllEntitiesFromDb(p.sd) : [];
     tracker.start('entity_scan', { note_count: vaultIndex.notes.size });
     await p.updateEntitiesInStateDb(p.vp, p.sd);
+    p.ctx.lastEntityScanAt = Date.now();
     this.entitiesAfter = p.sd ? getAllEntitiesFromDb(p.sd) : [];
     const entityDiff = computeEntityDiff(this.entitiesBefore, this.entitiesAfter);
 
@@ -330,6 +344,16 @@ export class PipelineRunner {
 
   private async hubScores(): Promise<Record<string, unknown>> {
     const { p } = this;
+
+    // Throttle: hub score computation iterates all notes + power iteration.
+    // Skip if computed within 5 minutes.
+    const hubAgeMs = p.ctx.lastHubScoreRebuildAt > 0
+      ? Date.now() - p.ctx.lastHubScoreRebuildAt : Infinity;
+    if (hubAgeMs < 5 * 60 * 1000) {
+      serverLog('watcher', `Hub scores: throttled (${Math.round(hubAgeMs / 1000)}s old)`);
+      return { skipped: true, age_ms: hubAgeMs };
+    }
+
     const vaultIndex = p.getVaultIndex();
     const hubUpdated = await exportHubScores(vaultIndex, p.sd);
     const hubDiffs: Array<{ entity: string; before: number; after: number }> = [];
@@ -340,6 +364,7 @@ export class PipelineRunner {
         if (prev !== r.hub_score) hubDiffs.push({ entity: r.name, before: prev, after: r.hub_score });
       }
     }
+    p.ctx.lastHubScoreRebuildAt = Date.now();
     serverLog('watcher', `Hub scores: ${hubUpdated ?? 0} updated`);
     return { updated: hubUpdated ?? 0, diffs: hubDiffs.slice(0, 10) };
   }
@@ -479,9 +504,19 @@ export class PipelineRunner {
     const { p, tracker } = this;
     const vaultIndex = p.getVaultIndex();
     if (p.sd) {
+      // Throttle: full index serialization to SQLite is expensive for large vaults.
+      // Skip if saved within 30 seconds.
+      const cacheAgeMs = p.ctx.lastIndexCacheSaveAt > 0
+        ? Date.now() - p.ctx.lastIndexCacheSaveAt : Infinity;
+      if (cacheAgeMs < 30 * 1000) {
+        tracker.start('index_cache', {});
+        tracker.skip('index_cache', `saved recently (${Math.round(cacheAgeMs / 1000)}s ago)`);
+        return;
+      }
       tracker.start('index_cache', { note_count: vaultIndex.notes.size });
       try {
         saveVaultIndexToCache(p.sd, vaultIndex);
+        p.ctx.lastIndexCacheSaveAt = Date.now();
         tracker.end({ saved: true });
         serverLog('watcher', 'Index cache saved');
       } catch (err) {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -264,6 +264,9 @@ async function initializeVault(name: string, vaultPathArg: string): Promise<Vaul
     indexError: null,
     lastCooccurrenceRebuildAt: 0,
     lastEdgeWeightRebuildAt: 0,
+    lastEntityScanAt: 0,
+    lastHubScoreRebuildAt: 0,
+    lastIndexCacheSaveAt: 0,
   };
 
   try {

--- a/packages/mcp-server/src/vault-registry.ts
+++ b/packages/mcp-server/src/vault-registry.ts
@@ -33,6 +33,12 @@ export interface VaultContext {
   lastCooccurrenceRebuildAt: number;
   /** Per-vault timestamp: last edge weight rebuild */
   lastEdgeWeightRebuildAt: number;
+  /** Per-vault timestamp: last entity scan */
+  lastEntityScanAt: number;
+  /** Per-vault timestamp: last hub score rebuild */
+  lastHubScoreRebuildAt: number;
+  /** Per-vault timestamp: last index cache save */
+  lastIndexCacheSaveAt: number;
 }
 
 export class VaultRegistry {


### PR DESCRIPTION
## Summary

- **Throttle entityScan (Step 2)** — full recursive `scanVaultEntities()` directory walk now gated to 5-minute intervals; downstream steps still get entities from DB when throttled
- **Throttle hubScores (Step 3)** — full graph power-iteration now gated to 5-minute intervals
- **Throttle indexCache (Step 6)** — full vault index serialization to SQLite now gated to 30-second intervals
- **Fix parse error logging** — replace fragile `indexOf` correlation with indexed loop; log both file path and rejection reason; send errors to `serverLog` (not just `console.error`)

Addresses 3 root causes from watcher.md:
1. ~~Full vault rebuild on every file change~~ → Step 1 was already incremental; the real bottleneck was unthrottled Steps 2, 3, and 6
2. ~~Double-trigger under polling~~ → content hash gate already exists in `index.ts:938-962`, no change needed
3. ~~Unknown parse failure with no path logged~~ → fixed

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 2379 tests pass (2 pre-existing package-startup failures unrelated)
- [ ] Manual: edit a file rapidly, verify server logs show `entity_scan: throttled` and `Hub scores: throttled` on subsequent batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)