### PR TITLE
fix: close feedback loop for external wikilink edits (Cat 1)

### DIFF
--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -18,6 +18,7 @@ import {
   detectImplicitEntities,
   checkDbIntegrity,
   safeBackupAsync,
+  recordEntityMention,
   type EntitySearchResult,
 } from '@velvetmonkey/vault-core';
 
@@ -64,6 +65,7 @@ import {
   updateStoredNoteTags,
   isSuppressed,
   getAllSuppressionPenalties,
+  trackWikilinkApplications,
 } from '../../write/wikilinkFeedback.js';
 import { processPendingCorrections } from '../../write/corrections.js';
 import { recomputeEdgeWeights } from '../../write/edgeWeights.js';
@@ -175,6 +177,7 @@ export class PipelineRunner {
       await runStep('forward_links', tracker, { files: p.events.length }, () => this.forwardLinks());
       await this.wikilinkCheck();
       await this.implicitFeedback();
+      await runStep('incremental_recency', tracker, { files: p.events.length }, () => this.incrementalRecency());
       await runStep('corrections', tracker, {}, () => this.corrections());
       await runStep('prospect_scan', tracker, { files: p.events.length }, () => this.prospectScan());
       await this.suggestionScoring();
@@ -348,12 +351,12 @@ export class PipelineRunner {
 
   private async recency(): Promise<Record<string, unknown>> {
     const { p } = this;
-    const cachedRecency = loadRecencyFromStateDb();
+    const cachedRecency = loadRecencyFromStateDb(p.sd ?? undefined);
     const cacheAgeMs = cachedRecency ? Date.now() - (cachedRecency.lastUpdated ?? 0) : Infinity;
     if (cacheAgeMs >= 60 * 60 * 1000) {
       const entities = this.entitiesAfter.map(e => ({ name: e.name, path: e.path, aliases: e.aliases }));
       const recencyIndex = await buildRecencyIndex(p.vp, entities);
-      saveRecencyToStateDb(recencyIndex);
+      saveRecencyToStateDb(recencyIndex, p.sd ?? undefined);
       serverLog('watcher', `Recency: rebuilt ${recencyIndex.lastMentioned.size} entities`);
       return { rebuilt: true, entities: recencyIndex.lastMentioned.size };
     }
@@ -770,6 +773,7 @@ export class PipelineRunner {
       );
       for (const diff of this.linkDiffs) {
         if (deletedFiles.has(diff.file)) continue;
+        const newlyTracked: Array<{ entity: string; matchedTerm?: string }> = [];
         for (const target of diff.added) {
           if (checkApplication.get(target, diff.file)) continue;
           const entity = this.entitiesAfter.find(
@@ -779,7 +783,15 @@ export class PipelineRunner {
           if (entity) {
             recordFeedback(p.sd, entity.name, 'implicit:manual_added', diff.file, true);
             additionResults.push({ entity: entity.name, file: diff.file });
+            newlyTracked.push({
+              entity: entity.name,
+              matchedTerm: entity.nameLower === target ? undefined : target,
+            });
           }
+        }
+        // Track applications so removal detection works on subsequent edits
+        if (newlyTracked.length > 0) {
+          trackWikilinkApplications(p.sd, diff.file, newlyTracked);
         }
       }
     }
@@ -802,6 +814,23 @@ export class PipelineRunner {
     if (newlySuppressed.length > 0) {
       serverLog('watcher', `Suppression: ${newlySuppressed.length} entities newly suppressed: ${newlySuppressed.join(', ')}`);
     }
+  }
+
+  // ── Step 10.1: Incremental recency ──────────────────────────────
+
+  private async incrementalRecency(): Promise<Record<string, unknown>> {
+    const { p } = this;
+    if (!p.sd) return { skipped: true };
+
+    let updated = 0;
+    const now = new Date();
+    for (const entry of this.forwardLinkResults) {
+      for (const target of entry.resolved) {
+        recordEntityMention(p.sd, target, now);
+        updated++;
+      }
+    }
+    return { entities_updated: updated };
   }
 
   // ── Step 10.5: Corrections ────────────────────────────────────────

--- a/packages/mcp-server/src/core/shared/recency.ts
+++ b/packages/mcp-server/src/core/shared/recency.ts
@@ -203,8 +203,8 @@ export function getRecencyBoost(entityName: string, index: RecencyIndex): number
  *
  * @returns RecencyIndex or null if StateDb unavailable or empty
  */
-export function loadRecencyFromStateDb(): RecencyIndex | null {
-  const stateDb = getStateDb();
+export function loadRecencyFromStateDb(explicitStateDb?: StateDb): RecencyIndex | null {
+  const stateDb = explicitStateDb ?? getStateDb();
   if (!stateDb) return null;
 
   try {
@@ -237,8 +237,8 @@ export function loadRecencyFromStateDb(): RecencyIndex | null {
  *
  * @param index - RecencyIndex to save
  */
-export function saveRecencyToStateDb(index: RecencyIndex): void {
-  const stateDb = getStateDb();
+export function saveRecencyToStateDb(index: RecencyIndex, explicitStateDb?: StateDb): void {
+  const stateDb = explicitStateDb ?? getStateDb();
   if (!stateDb) {
     console.error('[Flywheel] saveRecencyToStateDb: No StateDb available');
     return;

--- a/packages/mcp-server/src/tools/write/wikilinkFeedback.ts
+++ b/packages/mcp-server/src/tools/write/wikilinkFeedback.ts
@@ -70,6 +70,8 @@ export function registerWikilinkFeedbackTools(
             };
           }
 
+          console.error(`[Flywheel] wikilink_feedback: stateDb path=${stateDb.db.name}`);
+
           try {
             recordFeedback(stateDb, entity, context || '', note_path || '', correct);
           } catch (e) {
@@ -80,6 +82,10 @@ export function registerWikilinkFeedbackTools(
               isError: true,
             };
           }
+
+          // Verify the row persisted
+          const rowCount = (stateDb.db.prepare('SELECT COUNT(*) as cnt FROM wikilink_feedback').get() as { cnt: number }).cnt;
+          console.error(`[Flywheel] wikilink_feedback: after insert, total rows=${rowCount}, db=${stateDb.db.name}`);
 
           if (!correct && note_path && !skip_status_update) {
             stateDb.db.prepare(
@@ -102,6 +108,7 @@ export function registerWikilinkFeedbackTools(
               suppression_updated: suppressionUpdated,
             },
             total_suppressed: getSuppressedCount(stateDb),
+            total_feedback_rows: rowCount,
           };
           break;
         }


### PR DESCRIPTION
## Summary

Fixes the four Category 1 "Feedback Loop — Structurally Broken" issues from the Feb 20 issues audit.

- **1.1 wikilink_applications empty** — External tools (engine/crank) bypass MCP, so `trackWikilinkApplications()` was never called. The watcher pipeline now seeds applications when it detects added wikilinks via `linkDiffs`, enabling removal detection on subsequent edits.
- **1.3 recency table empty, Layer 7 dormant** — `saveRecencyToStateDb()` used a module-level singleton that was null in the watcher context. Now accepts an explicit `stateDb` parameter; pipeline passes `p.sd` directly. Adds incremental recency step (10.1) that calls `recordEntityMention()` for entities in changed files.
- **1.2 wikilink_feedback 0 rows** — Adds DB path logging, row-count verification after insert, and `total_feedback_rows` in the response to diagnose/surface persistence failures.
- **1.4 entities_fts schema error** — Already fixed by migration v34, no changes needed.

## Files changed

- `packages/mcp-server/src/core/read/watch/pipeline.ts` — retroactive application tracking, incremental recency step, `recordEntityMention` import
- `packages/mcp-server/src/core/shared/recency.ts` — optional `explicitStateDb` param on save/load
- `packages/mcp-server/src/tools/write/wikilinkFeedback.ts` — diagnostic logging + verification

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 2379 tests pass (4 pre-existing failures unrelated)
- [ ] Deploy and verify wikilink_applications populates after external engine edit
- [ ] Verify recency table has rows after watcher pipeline runs
- [ ] Call `wikilink_feedback` report mode, confirm `total_feedback_rows > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)