### PR TITLE
chore: bump vault-core + flywheel-memory to 2.0.152

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,7 +5945,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.0.151",
+      "version": "2.0.152",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5971,13 +5971,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.0.151",
+      "version": "2.0.152",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@velvetmonkey/vault-core": "^2.0.151",
+        "@velvetmonkey/vault-core": "^2.0.152",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.0.151",
+  "version": "2.0.152",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.0.151",
+  "version": "2.0.152",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -54,7 +54,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.0.151",
+    "@velvetmonkey/vault-core": "^2.0.152",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary

Release 2.0.152 — version bump for both packages.

### Changes since 2.0.151

- fix: daily note template fallback + list sanitization (#63)
- fix: broken wikilinks in daily notes (#58)
- fix: close feedback loop for external wikilink edits (#60)
- fix: watcher performance (#57)
- feat: P38 context engineering — three retrieval quality levers (#59)
- docs: README three-jobs restructure (#56), HotpotQA scores (#61), formatting (#62)

🤖 Generated with [Claude Code](https://claude.com/claude-code)