### PR TITLE
fix: hub scores all-zero + add DB auto_vacuum

### DIFF
--- a/packages/core/src/migrations.ts
+++ b/packages/core/src/migrations.ts
@@ -56,6 +56,11 @@ export function initSchema(db: Database.Database): void {
   // Enable WAL mode for better concurrent read performance
   db.pragma('journal_mode = WAL');
 
+  // Incremental auto-vacuum — reclaims freed pages without full VACUUM blocking.
+  // Only takes effect on new DBs (before first table). Existing DBs need a one-time
+  // VACUUM in openStateDb() to activate.
+  db.pragma('auto_vacuum = INCREMENTAL');
+
   // Enable foreign keys
   db.pragma('foreign_keys = ON');
 

--- a/packages/core/src/sqlite.ts
+++ b/packages/core/src/sqlite.ts
@@ -199,6 +199,18 @@ export function openStateDb(vaultPath: string): StateDb {
     db = new Database(dbPath);
     initSchema(db);
 
+    // Enable incremental auto_vacuum on existing databases (one-time cost).
+    // New DBs get it from initSchema before tables are created, but existing
+    // DBs need a VACUUM to switch the file format.
+    if (!isNewDb) {
+      const autoVacuum = db.pragma('auto_vacuum', { simple: true });
+      if (autoVacuum === 0) {
+        console.error('[vault-core] Enabling incremental auto_vacuum (one-time VACUUM)');
+        db.pragma('auto_vacuum = INCREMENTAL');
+        db.exec('VACUUM');
+      }
+    }
+
     // If we just created a fresh DB but backup files exist, salvage from them
     if (isNewDb) {
       attemptSalvage(db, dbPath);

--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -182,6 +182,7 @@ export class PipelineRunner {
       await runStep('tag_scan', tracker, { files: p.events.length }, () => this.tagScan());
       await runStep('retrieval_cooccurrence', tracker, {}, () => this.retrievalCooccurrence());
       await runStep('integrity_check', tracker, {}, () => this.integrityCheck());
+      await runStep('maintenance', tracker, {}, () => this.maintenance());
 
       // Record success
       const duration = Date.now() - this.batchStart;
@@ -1057,5 +1058,25 @@ export class PipelineRunner {
       serverLog('watcher', `Integrity check FAILED: ${result.detail}`, 'error');
       return { integrity: 'failed', detail: result.detail };
     }
+  }
+
+  // ── Maintenance: periodic incremental vacuum ─────────────────────
+
+  private async maintenance(): Promise<Record<string, unknown>> {
+    const { p } = this;
+    if (!p.sd) return { skipped: true, reason: 'no statedb' };
+
+    const VACUUM_INTERVAL_MS = 60 * 60 * 1000; // hourly
+    const lastRow = p.sd.getMetadataValue.get('last_incremental_vacuum') as { value: string } | undefined;
+    const lastVacuum = lastRow ? parseInt(lastRow.value, 10) : 0;
+
+    if (Date.now() - lastVacuum < VACUUM_INTERVAL_MS) {
+      return { skipped: true, reason: 'vacuumed recently' };
+    }
+
+    p.sd.db.pragma('incremental_vacuum');
+    p.sd.setMetadataValue.run('last_incremental_vacuum', String(Date.now()));
+    serverLog('watcher', 'Incremental vacuum completed');
+    return { vacuumed: true };
   }
 }

--- a/packages/mcp-server/src/core/shared/hubExport.ts
+++ b/packages/mcp-server/src/core/shared/hubExport.ts
@@ -26,7 +26,7 @@ const EIGEN_ITERATIONS = 50;
  *
  * @returns Map of normalized entity name → score (0-100)
  */
-export function computeHubScores(index: VaultIndex): Map<string, number> {
+export function computeHubScores(index: VaultIndex): { scores: Map<string, number>; edgeCount: number } {
   // Build node list and adjacency
   const nodes: string[] = [];
   const nodeIdx = new Map<string, number>();
@@ -47,7 +47,7 @@ export function computeHubScores(index: VaultIndex): Map<string, number> {
   }
 
   const N = nodes.length;
-  if (N === 0) return new Map();
+  if (N === 0) return { scores: new Map(), edgeCount: 0 };
 
   // Build edges from outlinks (bidirectional for eigenvector)
   for (const note of index.notes.values()) {
@@ -65,6 +65,13 @@ export function computeHubScores(index: VaultIndex): Map<string, number> {
         adj[toIdx].push(fromIdx);
       }
     }
+  }
+
+  // Count edges for diagnostics
+  const edgeCount = adj.reduce((sum, a) => sum + a.length, 0);
+  if (edgeCount === 0) {
+    console.error(`[Flywheel] Hub scores: 0 edges in graph of ${N} nodes, skipping eigenvector`);
+    return { scores: new Map(), edgeCount: 0 };
   }
 
   // Power iteration for eigenvector centrality
@@ -99,7 +106,25 @@ export function computeHubScores(index: VaultIndex): Map<string, number> {
       result.set(nodes[i], scaled);
     }
   }
-  return result;
+
+  // Fallback to degree centrality when eigenvector is too sparse
+  // (disconnected components cause most nodes to get zero)
+  if (result.size < N * 0.1 && edgeCount > 0) {
+    console.error(`[Flywheel] Hub scores: eigenvector too sparse (${result.size}/${N}), falling back to degree centrality`);
+    result.clear();
+    let maxDegree = 0;
+    for (let i = 0; i < N; i++) {
+      if (adj[i].length > maxDegree) maxDegree = adj[i].length;
+    }
+    if (maxDegree > 0) {
+      for (let i = 0; i < N; i++) {
+        const scaled = Math.round((adj[i].length / maxDegree) * 100);
+        if (scaled > 0) result.set(nodes[i], scaled);
+      }
+    }
+  }
+
+  return { scores: result, edgeCount };
 }
 
 
@@ -150,8 +175,8 @@ export async function exportHubScores(
   }
 
   // Compute hub scores from vault index
-  const hubScores = computeHubScores(vaultIndex);
-  console.error(`[Flywheel] Computed hub scores for ${hubScores.size} notes`);
+  const { scores: hubScores, edgeCount } = computeHubScores(vaultIndex);
+  console.error(`[Flywheel] Computed hub scores for ${hubScores.size} notes (${edgeCount} edges in graph)`);
 
   // Update hub scores in SQLite
   try {


### PR DESCRIPTION
## Summary
- **Hub scores fix**: eigenvector centrality produced all zeros when graph had no resolved edges. Adds edge count diagnostic, early return on empty graph, and degree centrality fallback when eigenvector is too sparse (<10% of nodes scored)
- **DB vacuum**: mirrors vault-core auto_vacuum changes in workspace copy. Adds hourly `incremental_vacuum` maintenance step to watcher pipeline

## Test plan
- [ ] Restart MCP server and run `flywheel_doctor` — hub scores should show non-zero counts
- [ ] Check server logs for edge count diagnostic output
- [ ] Verify `PRAGMA auto_vacuum` returns `2` (INCREMENTAL) after restart
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)