### PR TITLE
chore: bump vault-core to 2.0.153

### DIFF
--- a/demos/locomo/run-benchmark.sh
+++ b/demos/locomo/run-benchmark.sh
@@ -21,7 +21,7 @@ COUNT="${COUNT:-695}"  # Default: 695 balanced questions (matches Mem0 competiti
 MODE="${MODE:-dialog}"
 SEED="${SEED:-42}"
 TIMESTAMP=$(date +%Y%m%dT%H%M%S)
-RESULTS_DIR="$SCRIPT_DIR/results/run-$TIMESTAMP"
+RESULTS_DIR="${RESUME:-$SCRIPT_DIR/results/run-$TIMESTAMP}"
 
 # Pre-flight
 if [[ ! -f "$MCP_SERVER" ]]; then
@@ -45,6 +45,20 @@ INDICES_FILE="$RESULTS_DIR/indices.json"
 mkdir -p "$RESULTS_DIR/raw"
 
 # Stratified sampling: equal per category, spread across conversations
+if [[ -n "${RESUME:-}" ]] && [[ -f "$INDICES_FILE" ]]; then
+  echo "Resuming — reusing existing indices"
+  python3 -c "
+import json
+from collections import Counter
+gt = json.load(open('$GROUND_TRUTH'))
+questions = gt['questions']
+indices = json.load(open('$INDICES_FILE'))
+print(f'Sampled {len(indices)} questions across {len(set(questions[i][\"category\"] for i in indices))} categories')
+dist = Counter(questions[i]['category'] for i in indices)
+for cat, n in sorted(dist.items()):
+    print(f'  {cat}: {n}')
+"
+else
 python3 -c "
 import json, random
 random.seed(${SEED})
@@ -89,6 +103,7 @@ dist = Counter(questions[i]['category'] for i in indices)
 for cat, n in sorted(dist.items()):
     print(f'  {cat}: {n}')
 "
+fi
 
 echo ""
 echo "=== LoCoMo End-to-End Benchmark ==="
@@ -111,6 +126,9 @@ warmup_config=$(cat <<EOF
 EOF
 )
 
+if [[ -n "${RESUME:-}" ]] && [[ -f "$RESULTS_DIR/warmup.jsonl" ]]; then
+  echo "Resuming — skipping warmup (already done)"
+else
 echo "Pre-warming vault: index + auto-link + embeddings..."
 if claude -p "Bootstrap this vault for benchmarking. Run these steps in order:
 1. Call health_check — report entity_count and note_count.
@@ -130,6 +148,7 @@ Report final status with entity_count, note_count, and embeddings_ready." \
 else
   echo "WARNING: Pre-warm failed (exit $?) — continuing anyway"
 fi
+fi
 echo ""
 
 # Read indices
@@ -142,6 +161,13 @@ for i in $INDICES; do
   category=$(python3 -c "import json; print(json.load(open('$GROUND_TRUTH'))['questions'][$i]['category'])")
 
   echo -n "  q${padded} [${category}]: "
+
+  # Resume support: skip questions with >1 line in JSONL (i.e., already answered)
+  existing="$RESULTS_DIR/raw/q${padded}.jsonl"
+  if [[ -f "$existing" ]] && [[ $(wc -l < "$existing") -gt 1 ]]; then
+    echo "skip (exists)"
+    continue
+  fi
 
   if claude -p "You are answering questions about conversations stored in this vault.
 Each note is one session of a multi-session conversation between two people.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,7 +5945,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.0.152",
+      "version": "2.0.153",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.0.152",
+  "version": "2.0.153",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Version bump for vault-core release 2.0.153
- Includes: incremental auto_vacuum for DB, hub scores fix with degree centrality fallback, hourly maintenance vacuum in pipeline

## Test plan
- [ ] Build passes
- [ ] npm publish succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)