### PR TITLE
chore: bump flywheel-memory to 2.0.153

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5971,13 +5971,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.0.152",
+      "version": "2.0.153",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@velvetmonkey/vault-core": "^2.0.152",
+        "@velvetmonkey/vault-core": "^2.0.153",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.0.152",
+  "version": "2.0.153",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -54,7 +54,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.0.152",
+    "@velvetmonkey/vault-core": "^2.0.153",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary
- Version bump for flywheel-memory release 2.0.153
- Updates vault-core dependency to ^2.0.153

## Test plan
- [ ] Build passes
- [ ] npm publish succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)