### PR TITLE
docs: fix stale tool counts

### DIFF
--- a/demos/analyze-bundle-test.py
+++ b/demos/analyze-bundle-test.py
@@ -77,7 +77,7 @@ TOOL_CATEGORY = {
     "predict_stale_notes": "temporal",
     "track_concept_evolution": "temporal",
     "temporal_summary": "temporal",
-    # diagnostics (14 tools)
+    # diagnostics (20 tools)
     "health_check": "diagnostics",
     "get_vault_stats": "diagnostics",
     "get_folder_structure": "diagnostics",

--- a/demos/analyze-demo-test.py
+++ b/demos/analyze-demo-test.py
@@ -77,7 +77,7 @@ TOOL_CATEGORY = {
     "predict_stale_notes": "temporal",
     "track_concept_evolution": "temporal",
     "temporal_summary": "temporal",
-    # diagnostics (14 tools)
+    # diagnostics (20 tools)
     "health_check": "diagnostics",
     "get_vault_stats": "diagnostics",
     "get_folder_structure": "diagnostics",

--- a/demos/hotpotqa/run-benchmark.sh
+++ b/demos/hotpotqa/run-benchmark.sh
@@ -44,7 +44,7 @@ echo "Model:     $MODEL"
 echo "Results:   $RESULTS_DIR"
 echo ""
 
-# MCP config — default preset (16 tools: search, read, write, tasks)
+# MCP config — default preset (18 tools: search, read, write, tasks, memory)
 mcp_config=$(cat <<EOF
 {"mcpServers":{"flywheel":{"command":"node","args":["$MCP_SERVER"],"env":{"PROJECT_PATH":"$VAULT_DIR","FLYWHEEL_TOOLS":"default"}}}}
 EOF

--- a/demos/locomo/run-benchmark.sh
+++ b/demos/locomo/run-benchmark.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # End-to-end LoCoMo retrieval benchmark
 #
-# Runs LoCoMo questions through Claude with Flywheel MCP tools (agent preset),
+# Runs LoCoMo questions through Claude with Flywheel MCP tools (default preset),
 # then analyzes evidence recall and answer quality.
 #
 # Usage:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -161,6 +161,7 @@ Unknown names are ignored with a warning. If nothing valid is found, falls back 
 | `tasks` | 3 | tasks, vault_toggle_task, vault_add_task |
 | `memory` | 2 | memory, brief |
 | `note-ops` | 4 | vault_delete/move/rename_note, merge_entities |
+| `temporal` | 4 | get_context_around_date, predict_stale_notes, track_concept_evolution, temporal_summary |
 | `diagnostics` | 20 | health_check, get_vault_stats, get_folder_structure, refresh_index, get_all_entities, get_unlinked_mentions, vault_growth, vault_activity, flywheel_config, server_log, suggest/dismiss_merge, vault_init, flywheel_doctor, flywheel_trust_report, flywheel_benchmark, vault_session_history, vault_entity_history, flywheel_learning_report, flywheel_calibration_export |
 
 Deprecated aliases (`minimal`, `writer`, `researcher`, `backlinks`, `structure`, `append`, `frontmatter`, `notes`, `orphans`, `hubs`, `paths`, `health`, `analysis`, `git`, `ops`) still work with a warning — they resolve to current category names.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -462,7 +462,7 @@ Each of 12 tool bundles tested with a targeted prompt against carter-strategy va
 | 3 | vault_record_correction | builtin:1 | Yes | ToolSearch -> vault_record_correction |
 
 ### diagnostics
-> Category: `diagnostics` (14 tools)
+> Category: `diagnostics` (20 tools)
 
 | Run | Target Tools Used | Other Tools | Hit? | Sequence |
 |-----|-------------------|-------------|------|----------|

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -29,14 +29,14 @@
 | [Read a specific note](#read-deeper) | `get_note_structure` | 3 |
 | [Write or edit content](#write--edit) | `vault_add_to_section` | 5 |
 | [Work with tasks](#tasks) | `tasks` | 3 |
-| [Explore how notes connect](#explore-connections) | `get_backlinks`, `graph_analysis`, `semantic_analysis` | 10 |
+| [Explore how notes connect](#explore-connections) | `get_backlinks`, `graph_analysis`, `semantic_analysis` | 11 |
 | [Improve my wikilinks](#wikilinks--linking) | `suggest_wikilinks` | 7 |
 | [Clean up my schema](#schema--consistency) | `vault_schema`, `schema_conventions`, `schema_validate` | 7 |
 | [Record corrections](#corrections) | `vault_record_correction` | 4 |
 | [Move, rename, or merge notes](#organize-notes) | `vault_move_note` | 4 |
 | [Persistent memory](#session-memory) | `memory`, `brief` | 2 |
 | [Analyze temporal patterns](#temporal-analysis) | `get_context_around_date` | 4 |
-| [Check vault health](#vault-health) | `health_check` | 14 |
+| [Check vault health](#vault-health) | `health_check` | 20 |
 | [Automate workflows](#automation) | `policy` | 2 |
 
 ---

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -321,7 +321,7 @@ Add `.mcp.json` to your vault root:
 cd /path/to/your/vault && claude
 ```
 
-Defaults to the `default` preset (16 tools). Add bundles as needed. See [docs/CONFIGURATION.md](https://github.com/velvetmonkey/flywheel-memory/blob/main/docs/CONFIGURATION.md) for all options.
+Defaults to the `default` preset (18 tools). Add bundles as needed. See [docs/CONFIGURATION.md](https://github.com/velvetmonkey/flywheel-memory/blob/main/docs/CONFIGURATION.md) for all options.
 
 > **Works with any MCP client.** Primarily tested with [[CLAUDE]]. See [Transport Options](#transport-options) for HTTP setup (Cursor, Windsurf, Aider, LangGraph, Ollama, etc.).
 

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -14,9 +14,8 @@ import type { VaultRegistry } from './vault-registry.js';
 // FLYWHEEL_TOOLS / FLYWHEEL_PRESET env var controls which tools are loaded.
 //
 // Presets:
-//   default    - Note-taking essentials: search, read, write, tasks (16 tools)
-//   agent      - Autonomous AI agents: search, read, write, memory (16 tools)
-//   full       - All tools except agent memory (71 tools). Add ",memory" for all 74.
+//   default    - Note-taking essentials: search, read, write, tasks, memory (18 tools)
+//   full       - All tools, all categories (75 tools)
 //
 // Composable bundles (combine with presets or each other):
 //   graph       - Structural analysis + link detail + semantic + export (11 tools)
@@ -27,13 +26,12 @@ import type { VaultRegistry } from './vault-registry.js';
 //   memory      - Session memory + brief (2 tools)
 //   note-ops    - File management: delete, move, rename, merge (4 tools)
 //   temporal    - Time-based vault intelligence (4 tools)
-//   diagnostics - Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history (18 tools)
+//   diagnostics - Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export (20 tools)
 //
 // Examples:
-//   FLYWHEEL_TOOLS=default                    # 16 tools
-//   FLYWHEEL_TOOLS=agent                      # 16 tools
-//   FLYWHEEL_TOOLS=default,graph              # 27 tools
-//   FLYWHEEL_TOOLS=agent,tasks                # 16 tools
+//   FLYWHEEL_TOOLS=default                    # 18 tools
+//   FLYWHEEL_TOOLS=default,graph              # 29 tools
+//   FLYWHEEL_TOOLS=default,graph,wikilinks    # 36 tools
 //   FLYWHEEL_TOOLS=search,read,graph          # fine-grained categories
 //
 // Categories (12):
@@ -234,7 +232,7 @@ export const TOOL_CATEGORY: Record<string, ToolCategory> = {
   track_concept_evolution: 'temporal',
   temporal_summary: 'temporal',
 
-  // diagnostics (18 tools) -- vault health, stats, config, activity, merges, doctor, trust, benchmark, history
+  // diagnostics (20 tools) -- vault health, stats, config, activity, merges, doctor, trust, benchmark, history, learning report, calibration export
   health_check: 'diagnostics',
   get_vault_stats: 'diagnostics',
   get_folder_structure: 'diagnostics',


### PR DESCRIPTION
## Summary

- Fix stale tool counts in config.ts comments (default 16→18, full 71→75, diagnostics 18→20)
- Remove deprecated `agent` preset from config.ts examples
- Fix TOOLS.md At a Glance (graph 10→11, diagnostics 14→20)
- Add missing `temporal` row to CONFIGURATION.md Category Reference table
- Update benchmark scripts and README to reflect current state

All 75 tools correctly mapped to 12 categories — no code changes, comments/docs only.

## Test plan

- [x] `npm run build` passes
- [ ] Grep for stale counts (`16 tools`, `71 tools`, `14 tools`) returns clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)