### PR TITLE
chore: bump vault-core + flywheel-memory to 2.0.155

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flywheel-memory-monorepo",
-  "version": "2.0.114",
+  "version": "2.0.154",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flywheel-memory-monorepo",
-      "version": "2.0.114",
+      "version": "2.0.154",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5945,7 +5945,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.0.154",
+      "version": "2.0.155",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5971,13 +5971,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.0.154",
+      "version": "2.0.155",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@velvetmonkey/vault-core": "^2.0.154",
+        "@velvetmonkey/vault-core": "^2.0.155",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.0.154",
+  "version": "2.0.155",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.0.154",
+  "version": "2.0.155",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -54,7 +54,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.0.154",
+    "@velvetmonkey/vault-core": "^2.0.155",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
Version bump for release.

## Changes in 2.0.155
- Delete 1100+ hardcoded word arrays, use google-10k + feedback
- Consolidate 5 stopword sets → 1
- Consolidate 6 excluded-folder copies → 1
- Unify 4 exclude config fields → 1 `exclude` field
- Remove tech keyword matching (frontmatter handles it)