### PR TITLE
docs: revert README to pre-redesign version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,70 @@
 <div align="center">
   <img src="header.png" alt="Flywheel" width="256"/>
   <h1>Flywheel</h1>
-  <p><strong>Persistent, learning AI memory for your Obsidian vault.</strong><br/>
-  All local. 60 seconds to install.</p>
-
-[![npm version](https://img.shields.io/npm/v/@velvetmonkey/flywheel-memory.svg)](https://www.npmjs.com/package/@velvetmonkey/flywheel-memory)
-[![CI](https://github.com/velvetmonkey/flywheel-memory/actions/workflows/ci.yml/badge.svg)](https://github.com/velvetmonkey/flywheel-memory/actions/workflows/ci.yml)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Tests](https://img.shields.io/badge/tests-2,712%20passed-brightgreen.svg)](docs/TESTING.md)
-[![MCP](https://img.shields.io/badge/MCP-Model%20Context%20Protocol-blueviolet.svg)](https://modelcontextprotocol.io/)
-[![Clients](https://img.shields.io/badge/clients-Claude%20Code%20%7C%20Cursor%20%7C%20Windsurf%20%7C%20VS%20Code%20%7C%20OpenClaw-blue.svg)](docs/SETUP.md)
-[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-blue.svg)](https://github.com/velvetmonkey/flywheel-memory)
+  <p><strong>MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.</strong><br/>
+  All local. All yours. A few lines of config.</p>
 </div>
 
-**[Get started](#try-it)** · **[See it work](#see-it-work)** · **[What's different](#what-makes-flywheel-different)** · **[Benchmarked](#benchmarked)** · **[Docs](#documentation)** · **[Story](#the-story-behind-this)**
+**Search** — Ask a question, get a decision surface. One call returns section provenance, full section content, extracted dates, entity bridges, and confidence scores — U-shaped interleaved so the best results land where attention peaks. Your AI reasons across results without opening any files. [$0.06-0.10/query](#benchmarked), measured.
 
-**Search** — Ask a question, get a decision surface — not a list of files to open. One call returns structured results with metadata, graph context, and section content. Your AI reasons across your vault without reading files one by one. [$0.06-0.10/query](#benchmarked), measured.
+**Write** — Every mutation auto-links entities across your vault. Voice dump a meeting debrief, Flywheel recognises names, projects, and relationships and wikilinks them in real time. [13 scoring layers](docs/ALGORITHM.md), zero manual curation.
 
-**Write** — Every mutation auto-links entities across your vault. Voice dump a meeting debrief — Flywheel recognizes names, projects, and relationships and wikilinks them automatically. Zero manual curation.
-
-**Remember** — Your AI knows what you were working on yesterday without re-explaining it. Links you keep get stronger. Links you remove get suppressed. After a week, suggestions reflect how *you* think, not defaults. The graph compounds with use.
+**Remember** — The system learns from your edits. Links you keep get stronger. Links you remove get suppressed. After a week, suggestions reflect how *you* think, not how the algorithm was configured. The graph compounds with use.
 
 All local. No cloud. No account. No sync.
+
+[![npm version](https://img.shields.io/npm/v/@velvetmonkey/flywheel-memory.svg)](https://www.npmjs.com/package/@velvetmonkey/flywheel-memory)
+[![MCP](https://img.shields.io/badge/MCP-Model%20Context%20Protocol-blueviolet.svg)](https://modelcontextprotocol.io/)
+[![CI](https://github.com/velvetmonkey/flywheel-memory/actions/workflows/ci.yml/badge.svg)](https://github.com/velvetmonkey/flywheel-memory/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![Clients](https://img.shields.io/badge/clients-Claude%20Code%20%7C%20Desktop%20%7C%20Cursor%20%7C%20Windsurf%20%7C%20VS%20Code%20%7C%20OpenClaw-blue.svg)](docs/SETUP.md)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-blue.svg)](https://github.com/velvetmonkey/flywheel-memory)
+[![HotpotQA](https://img.shields.io/badge/HotpotQA-91.7%25%20recall%20(500q)-brightgreen.svg)](docs/TESTING.md#retrieval-benchmark-hotpotqa)
+[![LoCoMo](https://img.shields.io/badge/LoCoMo-79%25%20recall%20(695q)-blue.svg)](docs/TESTING.md#retrieval-benchmark-locomo)
+[![Cost](https://img.shields.io/badge/cost-%240.06--0.10%2Fquery-green.svg)](docs/TESTING.md#how-the-e2e-benchmark-works)
+[![Tests](https://img.shields.io/badge/tests-2,712%20passed-brightgreen.svg)](docs/TESTING.md)
+
+**[See It Work](#see-it-work)** · **[Try It](#try-it)** · **[What Makes It Different](#what-makes-flywheel-different)** · **[Benchmarked](#benchmarked)** · **[Tested](#tested)** · **[Docs](#documentation)** · **[Story](#the-story-behind-this)** · **[License](#license)**
+
+> **Cognitive sovereignty** = your knowledge graph stays on your machine. No platform builds a profile from it. No subscription locks you in. You choose the model. You own the memory.
+
+<details>
+<summary><strong>How this compares to not using Flywheel</strong></summary>
+
+| | Without | With Flywheel |
+|---|---|---|
+| Your data | Leaves your machine | Stays local. No sync, no upload, no account |
+| Model choice | Locked to one provider | Model-agnostic via MCP. Swap anytime |
+| As models improve | Migration or vendor upgrade | Same tools, better reasoning. Your graph improves the model, not the other way around |
+| Tokens per question | Read 10-50 files to find context (~50-200k tokens) | One search returns a decision surface — metadata, graph context, and section content (~2-5k tokens). [$0.06-0.09/query](#benchmarked) measured |
+| "What's overdue?" | Read every file | Structured task queries with due dates, tags, and path filters |
+| "What links here?" | Grep the vault, flat list | Weighted backlinks + outlinks, ranked by edge strength and recency |
+| "Add a meeting note" | Raw write, no linking | Structured mutations that auto-link entities and densify the graph |
+| "What should I link?" | Not possible | 13-layer scoring engine + semantic search |
+| Your graph | Owned by the platform | Yours to [export](https://en.wikipedia.org/wiki/GraphML), analyse, or delete |
+| Tool calls | Hidden behind abstractions | Traceable, auditable, opt-in git commits |
+
+</details>
+
+### Who this is for
+
+**For** people who want control over their knowledge: developers, researchers, solo operators, and anyone who treats their notes as infrastructure, not disposable input. Every conversation you have with a cloud AI builds a cognitive profile of you that you don't own, can't export, and can't delete. Flywheel keeps that profile local. The people who use AI the most [want more control, not less](https://x.com/AnthropicAI/status/2036499691571953848). Also works as persistent memory for bots and agents — memory tools are included in the default preset, including [OpenClaw](https://github.com/openclaw/openclaw), where it replaces default amnesiac file access with graph-aware, learning memory.
+
+**Not for** people who want a hosted service. Flywheel runs on your machine, on your files. If you want cloud-managed knowledge, this isn't it.
 
 ---
 
 ## See It Work
 
-### "How much have I billed Acme Corp?"
+### Read: "How much have I billed Acme Corp?"
 
 From the [carter-strategy](demos/carter-strategy/) demo: a solo consultant with 3 clients, 5 projects, and $27K in invoices.
 
 <video src="https://github.com/user-attachments/assets/ec1b51a7-cb30-4c49-a35f-aa82c31ec976" autoplay loop muted playsinline width="100%"></video>
 
-*One search call answered a multi-file question — metadata, graph context, and section content. No file reads needed. The graph did the joining, not the AI reading files one by one.*
+One search call returned a decision surface: metadata (frontmatter) with amounts and status, backlink lists, outlink lists, and full section content around each match. Zero follow-up reads needed. The graph did the joining, not the AI reading files one by one.
 
-### Auto-wikilinks on every mutation
+### Write: Auto-wikilinks on every mutation
 
 ```
 ❯ Log that Stacy reviewed the security checklist before the Beta Corp kickoff
@@ -51,9 +80,9 @@ From the [carter-strategy](demos/carter-strategy/) demo: a solo consultant with 
             → 2 suggested links: entities co-occurring with Stacy + security across past notes
 ```
 
-You typed a plain sentence. Flywheel recognized three entities and linked them — names, aliases, and fuzzy matches, scored and [explainable](docs/ALGORITHM.md). Links you keep strengthen future scoring; links you edit out get suppressed. The system learns.
+You typed a plain sentence. Flywheel recognized three entities and linked them: entity names, aliases, and fuzzy matches scored across [13 dimensions](docs/ALGORITHM.md). Links you keep strengthen future scoring; links you edit out get suppressed. The system learns.
 
-`→` suggestions are off by default. Enable with `suggestOutgoingLinks: true` for daily notes, meeting logs, and voice capture. [Configuration guide →](docs/CONFIGURATION.md)
+`→` suggestions are off by default. Enable with `suggestOutgoingLinks: true` for daily notes, meeting logs, and voice capture. Anywhere you want the graph to grow organically. [Configuration guide →](docs/CONFIGURATION.md)
 
 ### Boundaries in action
 
@@ -78,7 +107,21 @@ What happened                         What didn't
 
 ## Try It
 
-> Nothing leaves your machine. Nothing writes unless you ask. Every change is a reversible git commit.
+### Quick start (60 seconds)
+
+```bash
+git clone https://github.com/velvetmonkey/flywheel-memory.git
+cd flywheel-memory/demos/carter-strategy && claude
+```
+
+Then ask: *"How much have I billed Acme Corp?"*
+
+| Demo | You are | Ask this |
+|------|---------|----------|
+| [carter-strategy](demos/carter-strategy/) | Solo consultant | "How much have I billed Acme Corp?" |
+| [artemis-rocket](demos/artemis-rocket/) | Rocket engineer | "What's blocking propulsion?" |
+| [nexus-lab](demos/nexus-lab/) | PhD researcher | "How does AlphaFold connect to my experiment?" |
+| [zettelkasten](demos/zettelkasten/) | Zettelkasten student | "How does spaced repetition connect to active recall?" |
 
 ### Install on your own vault
 
@@ -95,35 +138,26 @@ Add `.mcp.json` to your vault root:
 }
 ```
 
-Requires Node.js 22+ and an MCP client: [Claude Code](https://claude.ai/code), [Cursor](https://cursor.sh), [Windsurf](https://windsurf.com), [OpenClaw](https://github.com/openclaw/openclaw), or [others](docs/SETUP.md).
-
-Flywheel runs alongside Obsidian as a background index. No proprietary format, no cloud sync, no account. Delete `.flywheel/state.db` and it rebuilds from scratch.
-
-### Try a demo vault
-
 ```bash
-git clone https://github.com/velvetmonkey/flywheel-memory.git
-cd flywheel-memory/demos/carter-strategy && claude
+cd /path/to/your/vault && claude
 ```
 
-Then ask: *"How much have I billed Acme Corp?"*
-
-| Demo | You are | Ask this |
-|------|---------|----------|
-| [carter-strategy](demos/carter-strategy/) | Solo consultant | "How much have I billed Acme Corp?" |
-| [artemis-rocket](demos/artemis-rocket/) | Rocket engineer | "What's blocking propulsion?" |
-| [nexus-lab](demos/nexus-lab/) | PhD researcher | "How does AlphaFold connect to my experiment?" |
-| [zettelkasten](demos/zettelkasten/) | Zettelkasten student | "How does spaced repetition connect to active recall?" |
-
-[See all 7 demos →](demos/)
+Flywheel does not replace Obsidian. It runs alongside as a background index. Watches for changes, indexes in real-time, and makes the full graph available to any AI client. No proprietary format, no cloud sync, no account. Delete `.flywheel/state.db` and it rebuilds from scratch.
 
 ### Configure your tools
 
-18 tools by default. Add bundles as you need them: `graph`, `schema`, `wikilinks`, `temporal`, `diagnostics`. [Browse all 75 tools →](docs/TOOLS.md)
+| Preset | Tools | What you get |
+|--------|-------|--------------|
+| `default` | 18 | search, read, write, tasks, memory |
+| `full` | 75 | Everything (all 12 categories) |
+
+Start with `default` — it includes search, read, write, tasks, and memory. Add bundles as you need them: `graph` (includes GraphML export for Gephi/Cytoscape), `schema`, `wikilinks`, `temporal`, `diagnostics`.
 
 ```json
 { "env": { "FLYWHEEL_TOOLS": "default,graph" } }
 ```
+
+[Browse all 75 tools →](docs/TOOLS.md) | [Preset recipes →](docs/CONFIGURATION.md)
 
 <details>
 <summary><strong>Windows users - read this before you start</strong></summary>
@@ -136,31 +170,62 @@ Three things differ from macOS/Linux:
 See [docs/CONFIGURATION.md#windows](docs/CONFIGURATION.md#windows) for the full config example.
 </details>
 
+**Using Cursor, Windsurf, VS Code, OpenClaw, or another client?** See [docs/SETUP.md](docs/SETUP.md) for your client's config.
+
 ---
 
 ## What Makes Flywheel Different
 
-### Every link has a reason
+### 1. Enriched Search
 
-Suggestions aren't random. Every suggestion is scored across multiple dimensions — match quality, co-occurrence, recency, context, and more. Ask why any link was suggested and get a traceable breakdown. [How scoring works →](docs/ALGORITHM.md)
+Most search tools return a list of matches and leave the AI to figure out which ones matter. Flywheel returns a **decision surface**: every result includes section provenance (where in the note), pre-extracted dates (when it happened), entity bridges (what it connects to), and confidence scores (whether it's worth reading). One search call replaces what would otherwise be 5–10 follow-up reads.
 
-### The flywheel effect
+Results are multi-hop: a search for "Acme Corp" returns the client note *and* its connected invoices, projects, and people, each ranked by graph relevance. Frontmatter, scored backlinks, scored outlinks, content snippets — all from an in-memory index, zero file reads.
+
+With semantic embeddings enabled, "login security" finds notes about authentication without that exact keyword. Everything runs locally. SQLite full-text search (BM25), in-memory embeddings for semantic similarity, fused together for best-of-both results.
+
+### 2. Every Link Has a Reason
+
+Those `→` suggestions aren't random. Ask why Flywheel suggested `Marcus Johnson`:
+
+```
+Entity              Score  Match  Co-oc  Type  Context  Recency  Cross  Hub  Feedback  Semantic  Edge
+---------------------------------------------------------------------------------------------------
+Marcus Johnson        34    +10     +3    +5     +5       +5      +3    +1     +2         0       0
+```
+
+13 scoring layers, every number traceable to vault usage. Recency from what you last wrote. Co-occurrence from notes you've written before. Hub score from eigenvector centrality (not just how many notes link there, but how important those linking notes are). The score learns as you use it.
+
+See [docs/ALGORITHM.md](docs/ALGORITHM.md) for how scoring works.
+
+### 3. Use It and It Gets Smarter
 
 Every sentence you write through Flywheel makes your graph denser. A denser graph gives better search results, richer backlinks, and sharper suggestions. That's the flywheel.
 
-- **Proactive linking:** edit a note in Obsidian and Flywheel links it in the background. Tune thresholds or disable entirely.
-- **Co-occurrence** builds over time. Edge weights accumulate. Links that survive edits gain influence.
-- **Suppression** learns. Delete a wikilink Flywheel inserted and it notices. Remove the same link enough times and Flywheel stops suggesting it — no manual configuration needed.
+- **Proactive linking:** edit a note in Obsidian and Flywheel links it in the background. The file watcher scores every unlinked entity mention and inserts wikilinks that clear the threshold (score ≥ 20, max 5 per file, max 10 per day). Your graph grows while you write. Tune the thresholds via the `flywheel_config` tool, or disable it entirely.
+- **Co-occurrence** builds over time. Two entities appearing in 20 notes form a statistical bond
+- **Edge weights** accumulate. Links that survive edits gain influence
+- **Suppression** learns. When you delete a wikilink Flywheel inserted, it notices. Remove the same link enough times and Flywheel stops suggesting it - no manual configuration needed
 
-Static tools give you the same results on day 1 and day 100. Flywheel's suggestions on day 100 are informed by everything you've written and edited since day 1. This is [measured](docs/TESTING.md#graph-quality-266-tests-31-files), not a claim — CI fails if any metric regresses.
+Static tools give you the same results on day 1 and day 100. Flywheel's suggestions on day 100 are informed by everything you've written and edited since day 1. No retraining, no configuration, no manual curation. This isn't a claim - it's [measured](docs/TESTING.md#graph-quality-266-tests-31-files): 266 graph quality tests track F1 across 6 vault archetypes, a [50-generation stress test](docs/TESTING.md#multi-generation-stress-test) proves F1 doesn't collapse under 15% hostile feedback, and CI fails if any metric regresses more than 5pp.
 
-All learning data is local SQLite. No telemetry. [What's tracked →](docs/SHARING.md)
+#### What the system tracks
 
-### Agentic policies
+All learning data lives in a local SQLite database (`.flywheel/state.db`) on your machine. There are no network calls, no telemetry, no analytics — [enforced by CI](SECURITY.md). The system records which auto-links you keep or remove (feedback), which entities appear together across notes (co-occurrence), how link weights evolve over time (edge weights), and which entities get auto-suppressed after repeated removal (suppression). This is how scoring improves: real usage, measured locally.
 
-Complex vault workflows become deterministic YAML policies. All steps succeed or all roll back. Commit with one flag — a single git commit covering every step. Every write uses structured parsing that understands your document's headings, frontmatter, and code blocks. [Architecture →](docs/ARCHITECTURE.md)
+None of this data leaves your machine unless you choose to share it. The `flywheel_calibration_export` tool produces a fully anonymized aggregate snapshot — vault size buckets (not exact counts), entity distribution by category (not names), survival rates, layer contributions, score distributions. No entity names, no note paths, no content. If you want to help tune scoring defaults across different vault sizes and styles, you can paste your export in the [Calibration Data](https://github.com/velvetmonkey/flywheel-memory/discussions/categories/calibration-data) discussion category. See [docs/SHARING.md](docs/SHARING.md) for what's safe to share and what isn't.
 
-### Portable knowledge graph
+### 4. Agentic Memory & Policies
+
+Your AI knows what you were working on yesterday without re-explaining it. `brief` delivers startup context, `search` retrieves across notes, entities (people, projects, concepts), and memories in one call, and `memory` stores observations that persist across sessions with automatic decay. Every result is structured for machine consumption — a decision surface, not a text dump.
+
+Complex vault workflows become deterministic policies. Describe what you want, the AI authors the YAML, and you can execute it on demand. All steps succeed or all roll back. Commit with one flag - a single git commit covering every step.
+
+Most agent frameworks solve the trust problem through containment: sandboxing arbitrary code in isolates or containers. Flywheel solves it through constraint: policies can only express vault operations, every step is auditable, and the entire execution can be committed as a single reversible git commit. No sandbox needed when the language itself can't do anything dangerous.
+
+Under the hood, every write operation uses structured parsing - AST for protected-zone detection, gray-matter for frontmatter, heading-aware section targeting - not blind string replacement. Flywheel understands headings, frontmatter, lists, and code blocks as structure. Mutations target specific sections without corrupting surrounding content, even in complex documents. Safe writes aren't a promise. They're a property of the parser.
+
+### 5. Portable Knowledge Graph
 
 One call to `export_graph` and your entire vault (or any entity's neighborhood) becomes a [GraphML](https://en.wikipedia.org/wiki/GraphML) file. Open it in any graph tool, run community detection, find bottlenecks, or just see what's connected to what.
 
@@ -168,14 +233,14 @@ One call to `export_graph` and your entire vault (or any entity's neighborhood) 
 
 *"Show me everything connected to Acme Corp." One call: `export_graph({ center_entity: "Acme Corp" })`. Sarah Mitchell is the single contact linking 3 projects to the client. The Data Migration Playbook bridges two engagements. Seven invoices, two team members, one proposal. All from plain markdown. [Try it yourself →](demos/carter-strategy/carter-strategy-acme.graphml)*
 
-### System guarantees
+### 6. System Guarantees
 
 These are rules, not preferences:
 
-- **No surprise writes.** Tool-initiated mutations require explicit calls. Proactive linking (the only background write) is auditable and can be disabled entirely.
+- **No surprise writes.** Tool-initiated mutations require explicit calls. Proactive linking (the only background write) is auditable (score-thresholded, configurable, tracked in state.db) and can be disabled entirely.
 - **No hidden tool execution.** Every tool call is visible, scoped, and logged.
 - **No required cloud dependency.** Core indexing, search, and graph run locally. No account, no sync, no phone-home.
-- **All actions are auditable.** Every write can be a git commit — one parameter. Every change is reversible.
+- **All actions are auditable.** Every write can be a git commit - one parameter. Every change is reversible. Every change has a reason.
 - **No silent data exfiltration.** Your vault content is never sent anywhere except the AI model you chose to connect.
 
 ### How Flywheel compares
@@ -192,43 +257,70 @@ These are rules, not preferences:
 
 ## Benchmarked
 
-**91.7% retrieval recall** on [HotpotQA](https://hotpotqa.github.io/) — 500 hard multi-hop questions across 4,960 documents. Zero training data. $0.06/question. 2-8ms search.
+Two standard academic benchmarks. Reproducible: clone the repo, run the scripts, get the same numbers.
 
-Flywheel controls retrieval — did we find the right documents? The model controls comprehension. Every number is reproducible: clone the repo, run the scripts, get the same numbers.
+**How it works:** The benchmark builds a vault from the dataset, pre-warms it (index + auto-link + embeddings - same as production), then runs each question as an independent Claude session with Flywheel MCP tools. No cherry-picking, no prompt engineering. [Full methodology →](docs/TESTING.md#how-the-e2e-benchmark-works) | [`demos/hotpotqa/`](demos/hotpotqa/) | [`demos/locomo/`](demos/locomo/)
 
-**Retrieval vs. academic baselines** (HotpotQA, 500 questions):
+### Compared to other systems
 
-| System | Type | Recall | Training data |
+> **⚠️ These comparisons are not controlled experiments.** Different systems use different document representations, different LLM judges, different prompts, and different vault structures. We run the same benchmark datasets and report honestly, but treat these as directional indicators - not head-to-head results. The numbers reproduce if you clone the repo and run them yourself.
+
+**Conversational memory** ([LoCoMo](https://snap-research.github.io/locomo/), 695 questions):
+
+| System | Evidence Recall | Single-hop Recall | Multi-hop Recall | Questions | Cost/question | Infrastructure |
+|---|---|---|---|---|---|---|
+| **Flywheel** | **79.1%** | **95.5%** | **65.3%** | 695 | **$0.095** | Local SQLite + markdown |
+| [Mem0](https://mem0.ai/) | — | — | — | 695 | ~$0.30-0.50* | Redis + Qdrant |
+| [Zep](https://getzep.com/) | — | — | — | 695 | ~$0.30-0.50* | Cloud service |
+| [LangMem](https://github.com/langchain-ai/langmem) | — | — | — | 695 | ~$0.30-0.50* | Varies |
+| [Letta](https://memgpt.ai/) | — | — | — | 695 | ~$0.30-0.50* | Cloud/local |
+
+\* Competitor costs are estimates based on GPT-4o pricing ($2.50/1M input, $10/1M output) for answer generation + judging. Actual costs not disclosed. Competitors do not report evidence recall, only answer accuracy via GPT-4o judge — a different metric. Flywheel uses Claude Sonnet for answers with token F1 scoring. Infrastructure costs (Redis, Qdrant, cloud hosting) are additional.
+
+**Document retrieval** ([HotpotQA](https://hotpotqa.github.io/), 500 questions):
+
+| System | Type | Recall@5 | Docs | Cost/question | Training |
+|---|---|---|---|---|---|
+| **Flywheel** | General-purpose MCP tool | **91.7%** | 4,960 | **$0.058** | None |
+| [MDR](https://arxiv.org/abs/2009.12756) | Trained retriever | ~88% | 5M+ Wikipedia | N/A (inference only) | Trained on HotpotQA |
+| [Baleen](https://arxiv.org/abs/2101.00436) | Trained retriever | ~85% | 5M+ Wikipedia | N/A (inference only) | Trained on HotpotQA |
+| BM25 baseline | Industry-standard IR | ~70-75% | Varies | Negligible | None |
+
+**What's comparable and what isn't:**
+
+- **LoCoMo sample size matches.** Flywheel and competitors both use 695 questions — stratified samples from the same 1,986-question dataset. Competitor numbers from the [Mem0 paper](https://arxiv.org/abs/2504.19413).
+- **LoCoMo metrics differ.** Flywheel reports evidence recall (did the system find the right source notes) and token F1 (answer quality). Competitors report answer accuracy via GPT-4o judge — a different metric. These are not directly comparable.
+- **LoCoMo document pool differs.** Flywheel searches 272 markdown session notes. Competitors may chunk, summarise, or embed conversations differently - their document representations aren't published.
+- **LoCoMo prompt differs.** Our agent uses a minimal system prompt with the `default` tool preset (18 tools). Competitor prompt strategies aren't published.
+- **HotpotQA is not a fair comparison.** MDR and Baleen were trained on HotpotQA specifically and search 5M+ Wikipedia articles. Flywheel is a general-purpose tool with zero training, searching a 4,960-document vault. The comparison shows where untrained retrieval sits relative to specialised systems - not that we "beat" them.
+
+### Full LoCoMo results (695 questions)
+
+| Category | Evidence Recall | Answer Score | Questions |
 |---|---|---|---|
-| BM25 baseline | IR | ~75% | None |
-| [TF-IDF + Entity](https://arxiv.org/abs/1809.09600) | IR | ~80% | None |
-| [Baleen](https://arxiv.org/abs/2101.00436) (Stanford) | Trained retriever | ~85% | HotpotQA |
-| [MDR](https://arxiv.org/abs/2009.12756) (Facebook) | Trained retriever | ~88% | HotpotQA |
-| **Flywheel** | **MCP vault tool** | **91.7%** | **None** |
-| [Beam Retrieval](https://arxiv.org/abs/2308.08973) | Trained retriever | ~93% | End-to-end |
+| Adversarial | 97.3% | 0.478 (accuracy) | 182 |
+| Commonsense | 96.4% | 0.171 (F1) | 139 |
+| Single-hop | 95.5% | 0.131 (F1) | 139 |
+| Multi-hop | 65.3% | 0.139 (F1) | 139 |
+| Temporal | 59.6% | 0.092 (F1) | 96 |
+| **Overall** | **79.1%** | **0.226** | **695** |
 
-Not apples-to-apples — different test settings, sample sizes, and retrieval pools. [Full caveats →](docs/TESTING.md#retrieval-benchmark-hotpotqa)
+Evidence recall = did the system find the right source notes. Answer score = token F1 (categories 1-4) or adversarial detection accuracy (category 5). The vault is pre-warmed with auto-linking and embeddings before questions run - [how it works →](docs/TESTING.md#how-the-e2e-benchmark-works) · Reproduce: `demos/locomo/run-benchmark.sh`
 
-**Conversational memory** ([LoCoMo](https://snap-research.github.io/locomo/), 695 questions): **95.5%** single-hop recall, **65.3%** multi-hop, **79.1%** evidence recall overall. $0.095/question. No other MCP memory tool publishes retrieval benchmarks on a standard academic dataset. [LoCoMo details →](docs/TESTING.md#retrieval-benchmark-locomo) | [`demos/hotpotqa/`](demos/hotpotqa/) | [`demos/locomo/`](demos/locomo/)
-
-| Metric | Measured |
-|---|---|
-| Tests | 2,712 across 129 files |
-| Search latency | 2-8ms (FTS5), 10-30ms (hybrid) |
-| Wikilink precision | 100% on ground truth vault, 50 generations |
-| Write safety | 100 parallel writes, zero corruption |
-| Security | SQL injection, path traversal, Unicode normalization |
-| CI | 12 jobs, Ubuntu + Windows, Node 22 + 24 |
-
-[Full methodology →](docs/TESTING.md) · [Graph quality report →](docs/QUALITY_REPORT.md)
+Flywheel controls retrieval; the model controls comprehension. Evidence recall is ours — did we find the right documents? Answer score is the model's — did it understand what it found? These are deliberately separate metrics. When models improve, answer scores go up without changing a line of Flywheel code.
 
 ---
 
-## Who this is for
+## Tested
 
-**For** developers building AI agents and assistants that need persistent memory. Works as the memory backend for [OpenClaw](https://github.com/openclaw/openclaw) and any MCP client. Also for anyone who treats their Obsidian vault as infrastructure, not disposable notes.
+2,712 tests across read, write, security, concurrency, and graph quality. CI-gated on Ubuntu + Windows, Node 22 + 24.
 
-**Not for** people who want a hosted service. Flywheel runs on your machine, on your files.
+- **Graph quality:** 100% wikilink precision on ground truth vault, stress-tested over 50 generations with realistic noise. [Report →](docs/QUALITY_REPORT.md)
+- **Live AI testing:** real `claude -p` sessions verify tool adoption end-to-end, not just handler logic
+- **Write safety:** git-backed conflict detection, atomic rollback, 100 parallel writes with zero corruption
+- **Security:** SQL injection, path traversal, Unicode normalization, permission bypass
+
+[Full methodology and results →](docs/TESTING.md)
 
 ---
 
@@ -246,24 +338,29 @@ Not apples-to-apples — different test settings, sample sizes, and retrieval po
 | [TESTING.md](docs/TESTING.md) | Test methodology and benchmarks |
 | [TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) | Error recovery and diagnostics |
 | [SHARING.md](docs/SHARING.md) | What's tracked, privacy guarantees, sharing stats |
-| [BENCHMARKS.md](docs/BENCHMARKS.md) | Performance characteristics and scaling |
-| [POLICY_EXAMPLES.md](docs/POLICY_EXAMPLES.md) | Ready-to-run policy YAML examples |
-| [QUALITY_REPORT.md](docs/QUALITY_REPORT.md) | Graph quality metrics and regression tracking |
 | [VISION.md](docs/VISION.md) | Where this is going |
-
-Common questions — data privacy, scale, safety, cost: [FAQ →](docs/README.md#faq)
 
 ---
 
 ## The Story Behind This
 
-Flywheel started because I'm fundamentally lazy. I wanted to talk at my vault through a Telegram bot and have it not be rubbish — no typing, no manual linking, no curation. The lazy path needed to be the correct path, so I built a system where they're the same path.
+Flywheel started because I'm fundamentally lazy. I wanted to talk at my vault through a Telegram bot and have it not be rubbish - no typing, no manual linking, no curation. The lazy path needed to be the correct path, so I built a system where they're the same path.
 
-This is my third attempt at wiring AI into a knowledge vault. The first two failed because writes were non-deterministic and context didn't flow between sessions. This version unifies everything: one server with deterministic mutations, hybrid search, and a graph that compounds with use.
+I've been writing code for over 30 years and tried every PKM tool going before landing on Obsidian. Flywheel is my third attempt at wiring AI into my knowledge vault. The first two failed because writes were non-deterministic and context didn't flow between sessions. This version unifies everything: one server with deterministic mutations, hybrid search, and a graph that compounds with use. The Architecture exists because I kept hitting the same walls and refusing to stop.
 
-Built through Claude Code — I designed the architecture and made every decision. 2,712 tests across 2 platforms verify it works. As always, check what matters to you.
+Your attention, memory, and even the way you reason are increasingly shaped by systems you didn't choose. Platforms that optimise for engagement, models trained on someone else's priorities, defaults that quietly steer how you organise what you know. I wanted a knowledge layer that works for the person using it. A system that only gets smarter from your own honest engagement is fundamentally different from one that optimises for someone else's metrics.
 
-I dogfood it daily through a Telegram bot using voice input. Even quiet days produce 20–30 links where they used to be 3–5. All suggestions are welcome — I'm looking for people who care about this space. The full story and vision: [VISION.md](docs/VISION.md)
+The entire codebase was built through Claude Code with Opus 4.5 and 4.6. I designed the architecture and made every decision, but I haven't read every line 🫠 I've got bills to pay. It's been through extensive code reviews and testing, but verify what matters to you.
+
+I dogfood it daily through a Telegram bot using voice input. The volume of knowledge you can accumulate at speed through voice is staggering - even quiet days produce 20–30 links where they used to be 3–5. Flywheel exists partly because I needed something that could keep up. All suggestions are welcome! I'm looking for people who care about this space.
+
+### The Cognitive Pipeline
+
+What emerged from daily use is a workflow pattern: cheap models generate ideas at volume (Grok, ChatGPT — whatever's free), the Telegram bot filters for truth and persists to the vault, then a separate Claude Code session reads the stored context and executes from filtered material. Generate broadly, filter honestly, execute precisely.
+
+It works because Flywheel makes every stage persistent. The bot's conversation is logged and auto-wikilinked. The filter's judgements become searchable memories. The executor reads yesterday's daily notes and picks up where the last session left off — no re-explaining, no context dump, no starting from scratch.
+
+Because Flywheel is an MCP server, any client can be any stage. An OpenClaw bot, a Cursor session, Claude Desktop — they all get the same persistent, learning memory. The graph compounds across sessions. Your filing cabinet stops being passive storage and starts thinking with you.
 
 To contribute back to Obsidian I'm also building [Flywheel Crank](https://github.com/velvetmonkey/flywheel-crank) (early days), an Obsidian plugin that surfaces suggestions, graph visibility, and management tools directly in the editor.
 
@@ -274,5 +371,5 @@ To contribute back to Obsidian I'm also building [Flywheel Crank](https://github
 Apache-2.0. See [LICENSE](./LICENSE) for details.
 
 > Your knowledge. Your graph. Your terms.
-
-**[Get started in 60 seconds.](#try-it)**
+>
+> *If you can keep your head when all about you are losing theirs...* -- Kipling


### PR DESCRIPTION
## Summary
- Reverts README to the 375-line version from before the product page redesign (#71)
- Restores decision surface framing, detailed LoCoMo benchmark tables, cognitive sovereignty, numbered feature sections, cognitive pipeline section, and Kipling quote

## Why
The redesign trimmed too much — the original voice and detail level was better.

## Test plan
- [ ] Visual review of rendered README
- [ ] Confirm all anchor links in nav resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)