### PR TITLE
fix: extraction retry, error logging, and artifact diagnostics (P39)

### DIFF
--- a/demos/lib/answer_layer.py
+++ b/demos/lib/answer_layer.py
@@ -196,11 +196,11 @@ def parse_contracted_answer(text):
 # Extraction / compression
 # ---------------------------------------------------------------------------
 
-def extract_concise(raw_answer, question, model='haiku'):
+def extract_concise(raw_answer, question, model='haiku', retries=1):
     """Compress a verbose answer into a concise factual statement.
 
     Only runs LLM extraction when the answer exceeds BREVITY_THRESHOLD tokens.
-    Returns (final_answer, extraction_mode).
+    Returns (final_answer, extraction_mode, extract_error).
     """
     # First try contract parsing
     parsed, mode = parse_contracted_answer(raw_answer)
@@ -208,7 +208,7 @@ def extract_concise(raw_answer, question, model='haiku'):
     # Check if already concise
     token_count = len(normalize_answer(parsed).split())
     if token_count <= BREVITY_THRESHOLD:
-        return parsed, mode
+        return parsed, mode, None
 
     # LLM extraction for verbose answers
     prompt = f"""Extract ONLY the factual answer from this response. Reply with just the fact, nothing else.
@@ -218,19 +218,30 @@ Response: {parsed[:500]}
 
 Factual answer:"""
 
-    try:
-        result = subprocess.run(
-            ['claude', '-p', prompt, '--model', model, '--no-session-persistence'],
-            capture_output=True, text=True, timeout=15
-        )
-        extracted = result.stdout.strip()
-        if extracted:
-            return extracted, 'llm_extract'
-    except Exception:
-        pass
+    last_error = None
+    for attempt in range(1 + retries):
+        try:
+            result = subprocess.run(
+                ['claude', '-p', prompt, '--model', model, '--no-session-persistence'],
+                capture_output=True, text=True, timeout=30
+            )
+            extracted = result.stdout.strip()
+            if extracted:
+                return extracted, 'llm_extract', None
+            last_error = f'empty response (exit {result.returncode})'
+            if result.stderr.strip():
+                last_error += f': {result.stderr.strip()[:200]}'
+        except subprocess.TimeoutExpired:
+            last_error = f'timeout on attempt {attempt + 1}'
+        except Exception as e:
+            last_error = f'{type(e).__name__}: {e}'
 
-    # Extraction failed — return parsed as-is
-    return parsed, mode
+        if attempt < retries:
+            print(f'  extract retry {attempt + 1}/{retries}: {last_error}', file=sys.stderr)
+
+    # Extraction failed — return parsed as-is with error detail
+    print(f'  extract failed ({token_count} tokens kept): {last_error}', file=sys.stderr)
+    return parsed, mode, last_error
 
 
 # ---------------------------------------------------------------------------
@@ -285,12 +296,14 @@ def process_question(jsonl_path, question, index, category, model='haiku'):
     Returns the answer artifact dict.
     """
     raw_answer = parse_raw_answer(jsonl_path)
-    final_answer, extraction_mode = extract_concise(raw_answer, question, model=model)
+    final_answer, extraction_mode, extract_error = extract_concise(
+        raw_answer, question, model=model
+    )
 
     raw_tokens = normalize_answer(raw_answer).split()
     final_tokens = normalize_answer(final_answer).split()
 
-    return {
+    artifact = {
         'index': index,
         'category': category,
         'question': question,
@@ -301,6 +314,9 @@ def process_question(jsonl_path, question, index, category, model='haiku'):
         'final_token_count': len(final_tokens),
         'normalized': raw_answer != final_answer,
     }
+    if extract_error:
+        artifact['extract_error'] = extract_error
+    return artifact
 
 
 # ---------------------------------------------------------------------------

--- a/demos/lib/test_answer_layer.py
+++ b/demos/lib/test_answer_layer.py
@@ -242,33 +242,57 @@ class TestParseRawAnswer:
 class TestExtractConcise:
     def test_short_answer_no_extraction(self):
         """Answers within threshold are returned as-is."""
-        final, mode = extract_concise('ANSWER: 2022', 'What year?')
+        final, mode, err = extract_concise('ANSWER: 2022', 'What year?')
         assert final == '2022'
         assert mode == 'prompt_contract'
+        assert err is None
 
     def test_short_fallback_no_extraction(self):
-        final, mode = extract_concise('2022', 'What year?')
+        final, mode, err = extract_concise('2022', 'What year?')
         assert final == '2022'
         assert mode == 'parser_fallback'
+        assert err is None
 
     @patch('answer_layer.subprocess.run')
     def test_verbose_triggers_extraction(self, mock_run):
         """Verbose answers should trigger LLM extraction."""
         mock_run.return_value = MagicMock(stdout='2022', returncode=0)
         verbose = 'Based on my thorough search of the vault I found that the relevant information indicates the year was 2022'
-        final, mode = extract_concise(verbose, 'What year?')
+        final, mode, err = extract_concise(verbose, 'What year?')
         assert final == '2022'
         assert mode == 'llm_extract'
+        assert err is None
         mock_run.assert_called_once()
 
     @patch('answer_layer.subprocess.run')
-    def test_extraction_failure_returns_parsed(self, mock_run):
-        """If LLM extraction fails, return the parsed answer."""
-        mock_run.side_effect = Exception('timeout')
+    def test_extraction_failure_returns_parsed_with_error(self, mock_run):
+        """If LLM extraction fails, return the parsed answer with error detail."""
+        mock_run.side_effect = Exception('connection refused')
         verbose = 'Based on my thorough search of the vault I found that the relevant information indicates the year was 2022'
-        final, mode = extract_concise(verbose, 'What year?')
+        final, mode, err = extract_concise(verbose, 'What year?', retries=0)
         assert final == verbose.strip()
         assert mode == 'parser_fallback'
+        assert 'connection refused' in err
+
+    @patch('answer_layer.subprocess.run')
+    def test_extraction_retries_on_failure(self, mock_run):
+        """Should retry once on failure then succeed."""
+        mock_run.side_effect = [Exception('timeout'), MagicMock(stdout='2022', returncode=0)]
+        verbose = 'Based on my thorough search of the vault I found that the relevant information indicates the year was 2022'
+        final, mode, err = extract_concise(verbose, 'What year?', retries=1)
+        assert final == '2022'
+        assert mode == 'llm_extract'
+        assert err is None
+        assert mock_run.call_count == 2
+
+    @patch('answer_layer.subprocess.run')
+    def test_extraction_empty_response_has_error(self, mock_run):
+        """Empty extraction response should report error."""
+        mock_run.return_value = MagicMock(stdout='', stderr='', returncode=0)
+        verbose = 'Based on my thorough search of the vault I found that the relevant information indicates the year was 2022'
+        final, mode, err = extract_concise(verbose, 'What year?', retries=0)
+        assert final == verbose.strip()
+        assert 'empty response' in err
 
 
 # ---------------------------------------------------------------------------
@@ -355,4 +379,19 @@ class TestProcessQuestion:
         assert artifact['normalized'] is True
         assert artifact['raw_token_count'] > BREVITY_THRESHOLD
         assert artifact['final_token_count'] == 1
+        assert 'extract_error' not in artifact
+        Path(path).unlink()
+
+    @patch('answer_layer.subprocess.run')
+    def test_failed_extraction_has_error_in_artifact(self, mock_run):
+        mock_run.side_effect = Exception('connection refused')
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.jsonl', delete=False) as f:
+            verbose = 'Based on my thorough search of the vault I found that the relevant information indicates the year was 2022'
+            f.write(json.dumps({'type': 'result', 'result': verbose}) + '\n')
+            path = f.name
+
+        artifact = process_question(path, 'What year?', 42, 'multi_hop')
+        assert artifact['extraction_mode'] == 'parser_fallback'
+        assert 'extract_error' in artifact
+        assert 'connection refused' in artifact['extract_error']
         Path(path).unlink()


### PR DESCRIPTION
## Summary

- **`extract_concise()` returns 3-tuple** `(answer, mode, error)` — callers now see why extraction failed
- **Retry on failure** — one retry by default (configurable via `retries` param), with stderr logging between attempts
- **Timeout raised** from 15s to 30s — smoke test showed the original was too tight
- **`extract_error` field** in per-question artifacts — makes failures visible in the audit trail instead of silently falling back
- **53 unit tests** (3 new: retry succeeds on 2nd attempt, empty response error, error propagation to artifact)

## Why

Smoke test showed q1355 (multi_hop, 100 tokens) silently stayed uncompressed — `prompt_contract` mode with 99 tokens when extraction should have fired. The `except Exception: pass` swallowed the failure with no trace. At 695 questions, ~10-15% of verbose answers would stay uncompressed invisibly.

## Test plan

- [x] `python3 -m pytest demos/lib/test_answer_layer.py -v` — 53/53 passed
- [ ] Re-run `COUNT=10` smoke test to confirm extraction errors are now logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)