### PR TITLE
feat: multi-threshold brevity + answer layer diagnostics (P39)

### DIFF
--- a/demos/lib/answer_layer.py
+++ b/demos/lib/answer_layer.py
@@ -33,6 +33,9 @@ UNAVAILABLE_SENTINEL = 'Not stated in the vault.'
 ANSWER_PREFIX = 'ANSWER:'
 
 BREVITY_THRESHOLD = 10  # normalized token count above which extraction runs
+ANSWER_MAX_TOKENS = 10
+ANSWER_MAX_CHARS = 100
+ANSWER_MAX_SENTENCES = 1
 
 ARTICLES = {'a', 'an', 'the'}
 
@@ -133,6 +136,39 @@ def adversarial_score(prediction):
 
 
 # ---------------------------------------------------------------------------
+# Brevity checks
+# ---------------------------------------------------------------------------
+
+def count_sentences(text):
+    """Count sentences via regex split on sentence-ending punctuation."""
+    if not text.strip():
+        return 0
+    parts = re.split(r'[.!?]+(?:\s|$)', text.strip())
+    return len([p for p in parts if p.strip()])
+
+
+def brevity_check(answer, max_tokens=ANSWER_MAX_TOKENS, max_chars=ANSWER_MAX_CHARS,
+                  max_sentences=ANSWER_MAX_SENTENCES):
+    """Check if answer exceeds any brevity threshold.
+
+    Returns (needs_compression, reason_string).
+    """
+    tc = len(normalize_answer(answer).split()) if answer.strip() else 0
+    if tc > max_tokens:
+        return (True, f'over_max_tokens:{tc}>{max_tokens}')
+
+    cc = len(answer)
+    if cc > max_chars:
+        return (True, f'over_max_chars:{cc}>{max_chars}')
+
+    sc = count_sentences(answer)
+    if sc > max_sentences:
+        return (True, f'over_max_sentences:{sc}>{max_sentences}')
+
+    return (False, '')
+
+
+# ---------------------------------------------------------------------------
 # Raw answer parser
 # ---------------------------------------------------------------------------
 
@@ -196,19 +232,27 @@ def parse_contracted_answer(text):
 # Extraction / compression
 # ---------------------------------------------------------------------------
 
-def extract_concise(raw_answer, question, model='haiku', retries=1):
+def extract_concise(raw_answer, question, model='haiku', retries=1,
+                    max_tokens=ANSWER_MAX_TOKENS, max_chars=ANSWER_MAX_CHARS,
+                    max_sentences=ANSWER_MAX_SENTENCES):
     """Compress a verbose answer into a concise factual statement.
 
-    Only runs LLM extraction when the answer exceeds BREVITY_THRESHOLD tokens.
-    Returns (final_answer, extraction_mode, extract_error).
+    Runs LLM extraction when any brevity threshold is exceeded or parser fell back.
+    Returns (final_answer, extraction_mode, extract_error, compression_reason).
     """
     # First try contract parsing
     parsed, mode = parse_contracted_answer(raw_answer)
 
-    # Check if already concise
+    # Check brevity thresholds
+    needs_compress, compress_reason = brevity_check(parsed, max_tokens, max_chars, max_sentences)
+    if mode == 'parser_fallback' and not needs_compress:
+        needs_compress = True
+        compress_reason = 'fallback_parse'
+
+    if not needs_compress:
+        return parsed, mode, None, ''
+
     token_count = len(normalize_answer(parsed).split())
-    if token_count <= BREVITY_THRESHOLD:
-        return parsed, mode, None
 
     # LLM extraction for verbose answers
     prompt = f"""Extract ONLY the factual answer from this response. Reply with just the fact, nothing else.
@@ -227,7 +271,7 @@ Factual answer:"""
             )
             extracted = result.stdout.strip()
             if extracted:
-                return extracted, 'llm_extract', None
+                return extracted, 'compressed', None, compress_reason
             last_error = f'empty response (exit {result.returncode})'
             if result.stderr.strip():
                 last_error += f': {result.stderr.strip()[:200]}'
@@ -241,7 +285,7 @@ Factual answer:"""
 
     # Extraction failed — return parsed as-is with error detail
     print(f'  extract failed ({token_count} tokens kept): {last_error}', file=sys.stderr)
-    return parsed, mode, last_error
+    return parsed, 'extraction_failed', last_error, compress_reason
 
 
 # ---------------------------------------------------------------------------
@@ -290,14 +334,17 @@ Reply with exactly one word: CORRECT or WRONG"""
 # Per-question artifact
 # ---------------------------------------------------------------------------
 
-def process_question(jsonl_path, question, index, category, model='haiku'):
+def process_question(jsonl_path, question, index, category, model='haiku',
+                     max_tokens=ANSWER_MAX_TOKENS, max_chars=ANSWER_MAX_CHARS,
+                     max_sentences=ANSWER_MAX_SENTENCES):
     """Parse and optionally extract a concise answer from a question's JSONL.
 
-    Returns the answer artifact dict.
+    Returns the answer artifact dict with compression diagnostics.
     """
     raw_answer = parse_raw_answer(jsonl_path)
-    final_answer, extraction_mode, extract_error = extract_concise(
-        raw_answer, question, model=model
+    final_answer, extraction_mode, extract_error, compression_reason = extract_concise(
+        raw_answer, question, model=model,
+        max_tokens=max_tokens, max_chars=max_chars, max_sentences=max_sentences,
     )
 
     raw_tokens = normalize_answer(raw_answer).split()
@@ -312,7 +359,8 @@ def process_question(jsonl_path, question, index, category, model='haiku'):
         'extraction_mode': extraction_mode,
         'raw_token_count': len(raw_tokens),
         'final_token_count': len(final_tokens),
-        'normalized': raw_answer != final_answer,
+        'compression_applied': extraction_mode == 'compressed',
+        'compression_reason': compression_reason,
     }
     if extract_error:
         artifact['extract_error'] = extract_error
@@ -333,13 +381,18 @@ def main():
     ext.add_argument('--index', required=True, type=int, help='Question index')
     ext.add_argument('--category', required=True, help='Question category')
     ext.add_argument('--model', default='haiku', help='Model for extraction')
+    ext.add_argument('--max-tokens', type=int, default=ANSWER_MAX_TOKENS)
+    ext.add_argument('--max-chars', type=int, default=ANSWER_MAX_CHARS)
+    ext.add_argument('--max-sentences', type=int, default=ANSWER_MAX_SENTENCES)
     ext.add_argument('--output', required=True, help='Output artifact path')
 
     args = parser.parse_args()
 
     if args.command == 'extract':
         artifact = process_question(
-            args.jsonl, args.question, args.index, args.category, model=args.model
+            args.jsonl, args.question, args.index, args.category, model=args.model,
+            max_tokens=args.max_tokens, max_chars=args.max_chars,
+            max_sentences=args.max_sentences,
         )
         output_path = Path(args.output)
         output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/demos/locomo/analyze-benchmark.py
+++ b/demos/locomo/analyze-benchmark.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'lib'))
 
 from answer_layer import (
     adversarial_score,
+    brevity_check,
     judge_answer as al_judge_answer,
     normalize_answer,
     parse_raw_answer,
@@ -162,12 +163,16 @@ def compute_metrics(results_dir, gt_path):
             extraction_mode = artifact.get('extraction_mode', 'unknown')
             raw_token_count = artifact.get('raw_token_count', 0)
             final_token_count = artifact.get('final_token_count', 0)
+            compression_applied = artifact.get('compression_applied', False)
+            compression_reason = artifact.get('compression_reason', '')
         else:
             # Legacy: no artifact, parse from JSONL
             raw_answer = parse_raw_answer(str(jsonl_path))
             final_answer, extraction_mode = parse_contracted_answer(raw_answer)
             raw_token_count = len(normalize_answer(raw_answer).split())
             final_token_count = len(normalize_answer(final_answer).split())
+            compression_applied = False
+            compression_reason = ''
 
         # Answer quality scoring (raw and final)
         ground_truth = q.get('answer', '')
@@ -196,6 +201,8 @@ def compute_metrics(results_dir, gt_path):
             'extraction_mode': extraction_mode,
             'raw_token_count': raw_token_count,
             'final_token_count': final_token_count,
+            'compression_applied': compression_applied,
+            'compression_reason': compression_reason,
             'evidence_recall': round(evidence_recall, 3),
             'raw_token_f1': round(raw_score, 3),
             'final_token_f1': round(final_score, 3),
@@ -378,17 +385,25 @@ def write_report(results_dir, metrics, judge_data=None):
             lines.append(f'| {cat} | {n} | {er_cat:.1%} ({ev["found"]}/{ev["relevant"]}) | {final_f1_cat:.3f} | {raw_f1_cat:.3f} |')
     lines.append('')
 
-    # --- Extraction summary ---
+    # --- Answer Layer Diagnostics ---
     modes = defaultdict(int)
     for q in per_question:
         modes[q.get('extraction_mode', 'unknown')] += 1
+    compression_count = sum(1 for q in per_question if q.get('compression_applied', False))
+    compression_rate = compression_count / scored_count if scored_count > 0 else 0
+    avg_raw_tokens = sum(q.get('raw_token_count', 0) for q in per_question) / scored_count if scored_count > 0 else 0
+    avg_final_tokens = sum(q.get('final_token_count', 0) for q in per_question) / scored_count if scored_count > 0 else 0
+
     if modes:
-        lines.append('## Answer Extraction')
+        lines.append('## Answer Layer Diagnostics')
         lines.append('')
-        lines.append('| Mode | Count |')
-        lines.append('|------|-------|')
-        for mode, count in sorted(modes.items(), key=lambda x: -x[1]):
-            lines.append(f'| {mode} | {count} |')
+        lines.append('| Metric | Value |')
+        lines.append('|--------|-------|')
+        mode_parts = ', '.join(f'{k}: {v}' for k, v in sorted(modes.items()))
+        lines.append(f'| Extraction Modes | {mode_parts} |')
+        lines.append(f'| Compression Rate | {compression_rate:.0%} ({compression_count}/{scored_count}) |')
+        lines.append(f'| Avg Raw Tokens | {avg_raw_tokens:.1f} |')
+        lines.append(f'| Avg Final Tokens | {avg_final_tokens:.1f} |')
         lines.append('')
 
     # --- Worst evidence recall ---
@@ -455,11 +470,32 @@ def write_report(results_dir, metrics, judge_data=None):
     # Backward compat: overall_token_f1 = raw token F1
     analysis['overall_token_f1'] = analysis['overall_raw_token_f1']
 
+    # Adversarial accuracy (separate metric)
+    adv_final = metrics['cat_final_f1'].get('adversarial', {'score_sum': 0, 'count': 0})
+    if adv_final['count'] > 0:
+        analysis['overall_adversarial_accuracy'] = round(adv_final['score_sum'] / adv_final['count'], 4)
+
+    # Answer layer diagnostics
+    analysis['answer_layer_diagnostics'] = {
+        'extraction_modes': dict(modes),
+        'compression_rate': round(compression_rate, 4),
+        'avg_raw_tokens': round(avg_raw_tokens, 1),
+        'avg_final_tokens': round(avg_final_tokens, 1),
+    }
+
     if judge_data:
         analysis['primary_answer_metric'] = 'judge_accuracy'
         analysis['judge_model'] = judge_data['judge_model']
         analysis['overall_judge_accuracy'] = judge_data['overall_accuracy']
         analysis['overall_judge_ci_95'] = judge_data['overall_ci_95']
+        analysis['judge_scored_count'] = judge_data['total_scored']
+        analysis['judge_failed_count'] = sum(
+            1 for jq in judge_data.get('per_question', [])
+            if jq.get('correct') == 0 and not any(
+                pq['index'] == jq['index'] and pq.get('category_num') == 5
+                for pq in per_question
+            )
+        ) if judge_data.get('per_question') else 0
         for cat, jcat in judge_data['by_category'].items():
             if cat in analysis['by_category_answer']:
                 analysis['by_category_answer'][cat]['judge_accuracy'] = jcat['accuracy']

--- a/demos/locomo/run-benchmark.sh
+++ b/demos/locomo/run-benchmark.sh
@@ -24,6 +24,9 @@ JUDGE="${JUDGE:-1}"
 JUDGE_MODEL="${JUDGE_MODEL:-haiku}"
 ANSWER_EXTRACT="${ANSWER_EXTRACT:-1}"
 EXTRACT_MODEL="${EXTRACT_MODEL:-haiku}"
+ANSWER_MAX_TOKENS="${ANSWER_MAX_TOKENS:-10}"
+ANSWER_MAX_CHARS="${ANSWER_MAX_CHARS:-100}"
+ANSWER_MAX_SENTENCES="${ANSWER_MAX_SENTENCES:-1}"
 TIMESTAMP=$(date +%Y%m%dT%H%M%S)
 RESULTS_DIR="${RESUME:-$SCRIPT_DIR/results/run-$TIMESTAMP}"
 
@@ -212,6 +215,9 @@ ANSWER: <your concise factual answer>
       --index "$i" \
       --category "$category" \
       --model "$EXTRACT_MODEL" \
+      --max-tokens "$ANSWER_MAX_TOKENS" \
+      --max-chars "$ANSWER_MAX_CHARS" \
+      --max-sentences "$ANSWER_MAX_SENTENCES" \
       --output "$answer_artifact" 2>&1 | tr '\n' ' '
   fi
   echo "done"


### PR DESCRIPTION
## Summary

Completes P39 Phase 2 spec coverage on top of the existing answer layer (#88, #89, #91). Adds the remaining features that were specified but not yet implemented.

- **Multi-threshold brevity checks** — `ANSWER_MAX_TOKENS=10`, `ANSWER_MAX_CHARS=100`, `ANSWER_MAX_SENTENCES=1` with any-of trigger (replaces token-only `BREVITY_THRESHOLD`)
- **`count_sentences()` and `brevity_check()` functions** — reusable, with reason strings
- **Compression diagnostics in artifacts** — `compression_applied` (bool), `compression_reason` (e.g. `over_max_tokens:15>10`, `fallback_parse`)
- **Answer Layer Diagnostics section** in report.md — extraction modes, compression rate, avg raw/final tokens
- **`answer_layer_diagnostics` in analysis.json** — extraction_modes dict, compression_rate, avg_raw_tokens, avg_final_tokens
- **`overall_adversarial_accuracy`** as separate metric in analysis.json
- **`judge_scored_count` / `judge_failed_count`** in analysis.json
- **Env var controls** in runner: `ANSWER_MAX_TOKENS`, `ANSWER_MAX_CHARS`, `ANSWER_MAX_SENTENCES`

### Files changed

| File | Changes |
|------|---------|
| `demos/lib/answer_layer.py` | `count_sentences()`, `brevity_check()`, multi-threshold `extract_concise()`, `compression_applied`/`compression_reason` in artifacts, CLI `--max-*` flags |
| `demos/locomo/run-benchmark.sh` | 3 new env vars, pass thresholds to `answer_layer.py extract` |
| `demos/locomo/analyze-benchmark.py` | Read compression fields from artifacts, diagnostics section in report, diagnostics + adversarial + judge counts in analysis.json |

## Test plan

- [x] Syntax checks (Python + Bash)
- [x] Unit tests: `count_sentences`, `brevity_check`, `extract_concise` 4-tuple return, `process_question` artifact fields
- [x] Analyzer module loads and imports cleanly
- [ ] `COUNT=10 JUDGE=1` smoke test
- [ ] Backward compat on old results dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)