### PR TITLE
fix: WAL checkpoint + embedding orphan cleanup in watcher pipeline

### DIFF
--- a/packages/mcp-server/src/core/read/embeddings.ts
+++ b/packages/mcp-server/src/core/read/embeddings.ts
@@ -759,6 +759,7 @@ export interface EmbeddingDiagnosis {
     embedded: number;
     vaultNotes: number;
     orphaned: number;
+    orphanedEntities: number;
     missing: number;
   };
 }
@@ -770,7 +771,7 @@ export interface EmbeddingDiagnosis {
 export function diagnoseEmbeddings(vaultPath: string): EmbeddingDiagnosis {
   const db = getDb();
   const checks: EmbeddingCheck[] = [];
-  const counts = { embedded: 0, vaultNotes: 0, orphaned: 0, missing: 0 };
+  const counts = { embedded: 0, vaultNotes: 0, orphaned: 0, orphanedEntities: 0, missing: 0 };
 
   if (!db) {
     checks.push({ name: 'database', status: 'stale', detail: 'No database available' });
@@ -856,6 +857,27 @@ export function diagnoseEmbeddings(vaultPath: string): EmbeddingDiagnosis {
     }
   } catch {
     checks.push({ name: 'orphans', status: 'warning', detail: 'Could not check' });
+  }
+
+  // Check 5b: Entity embedding orphans
+  try {
+    const embNames = new Set(
+      (db.prepare('SELECT entity_name FROM entity_embeddings').all() as Array<{ entity_name: string }>).map(r => r.entity_name)
+    );
+    const entityNames = new Set(
+      (db.prepare('SELECT name FROM entities').all() as Array<{ name: string }>).map(r => r.name)
+    );
+    counts.orphanedEntities = 0;
+    for (const n of embNames) {
+      if (!entityNames.has(n)) counts.orphanedEntities++;
+    }
+    if (counts.orphanedEntities > 0) {
+      checks.push({ name: 'entity_orphans', status: 'warning', detail: `${counts.orphanedEntities} orphaned entity embeddings` });
+    } else {
+      checks.push({ name: 'entity_orphans', status: 'ok', detail: '0 orphaned' });
+    }
+  } catch {
+    checks.push({ name: 'entity_orphans', status: 'ok', detail: 'No entity embeddings table' });
   }
 
   // Check 6: Integrity (NaN/Inf sample)
@@ -990,6 +1012,7 @@ export async function buildEntityEmbeddingsIndex(
   const total = entities.size;
   let done = 0;
   let updated = 0;
+  let skipped = 0;
 
   for (const [name, entity] of entities) {
     done++;
@@ -1008,8 +1031,11 @@ export async function buildEntityEmbeddingsIndex(
       const buf = Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength);
       upsert.run(name, buf, hash, activeModelConfig.id, Date.now());
       updated++;
-    } catch {
-      // Skip entities we can't process
+    } catch (err) {
+      skipped++;
+      if (skipped <= 3) {
+        console.error(`[Semantic] Failed to embed entity ${name}: ${err instanceof Error ? err.message : err}`);
+      }
     }
 
     if (onProgress) onProgress(done, total);
@@ -1023,7 +1049,7 @@ export async function buildEntityEmbeddingsIndex(
     }
   }
 
-  console.error(`[Semantic] Entity embeddings: ${updated} updated, ${total - updated} unchanged`);
+  console.error(`[Semantic] Entity embeddings: ${updated} updated, ${total - updated - skipped} unchanged, ${skipped} failed`);
   return updated;
 }
 
@@ -1056,9 +1082,46 @@ export async function updateEntityEmbedding(
 
     // Update in-memory map
     entityEmbeddingsMap.set(entityName, embedding);
-  } catch {
-    // Skip entities we can't process
+  } catch (err) {
+    console.error(`[Semantic] Failed to update entity embedding ${entityName}: ${err instanceof Error ? err.message : err}`);
   }
+}
+
+/**
+ * Remove note embeddings whose paths no longer exist in the FTS5 index.
+ * Safe to call after fts5Incremental has run.
+ */
+export function removeOrphanedNoteEmbeddings(): number {
+  const db = getDb();
+  if (!db) return 0;
+
+  const result = db.prepare(
+    'DELETE FROM note_embeddings WHERE path NOT IN (SELECT path FROM notes_fts)'
+  ).run();
+  return result.changes;
+}
+
+/**
+ * Remove entity embeddings for entities no longer in the provided set.
+ * Also cleans up the in-memory entity embeddings map.
+ */
+export function removeOrphanedEntityEmbeddings(currentEntityNames: Set<string>): number {
+  const db = getDb();
+  if (!db) return 0;
+
+  const rows = db.prepare('SELECT entity_name FROM entity_embeddings').all() as Array<{ entity_name: string }>;
+  const deleteStmt = db.prepare('DELETE FROM entity_embeddings WHERE entity_name = ?');
+  const embMap = getEmbMap();
+  let removed = 0;
+
+  for (const row of rows) {
+    if (!currentEntityNames.has(row.entity_name)) {
+      deleteStmt.run(row.entity_name);
+      embMap.delete(row.entity_name);
+      removed++;
+    }
+  }
+  return removed;
 }
 
 /**

--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -48,6 +48,8 @@ import {
   hasEmbeddingsIndex,
   updateEntityEmbedding,
   hasEntityEmbeddingsIndex,
+  removeOrphanedNoteEmbeddings,
+  removeOrphanedEntityEmbeddings,
 } from '../embeddings.js';
 import { updateTaskCacheForFile, removeTaskCacheForFile } from '../taskCache.js';
 import { saveVaultIndexToCache } from '../graph.js';
@@ -464,8 +466,9 @@ export class PipelineRunner {
           // Don't let embedding errors affect watcher
         }
       }
-      tracker.end({ updated: embUpdated, removed: embRemoved });
-      serverLog('watcher', `Note embeddings: ${embUpdated} updated, ${embRemoved} removed`);
+      const orphansRemoved = removeOrphanedNoteEmbeddings();
+      tracker.end({ updated: embUpdated, removed: embRemoved, orphans_removed: orphansRemoved });
+      serverLog('watcher', `Note embeddings: ${embUpdated} updated, ${embRemoved} removed, ${orphansRemoved} orphans cleaned`);
     } else {
       tracker.skip('note_embeddings', 'not built');
     }
@@ -478,6 +481,7 @@ export class PipelineRunner {
     if (hasEntityEmbeddingsIndex() && p.sd) {
       tracker.start('entity_embeddings', { files: p.events.length });
       let entEmbUpdated = 0;
+      let entEmbOrphansRemoved = 0;
       const entEmbNames: string[] = [];
       try {
         const allEntities = getAllEntitiesFromDb(p.sd);
@@ -495,11 +499,14 @@ export class PipelineRunner {
             entEmbNames.push(entity.name);
           }
         }
+        // Clean up embeddings for entities no longer in the database
+        const currentNames = new Set(allEntities.map(e => e.name));
+        entEmbOrphansRemoved = removeOrphanedEntityEmbeddings(currentNames);
       } catch {
         // Don't let entity embedding errors affect watcher
       }
-      tracker.end({ updated: entEmbUpdated, updated_entities: entEmbNames.slice(0, 10) });
-      serverLog('watcher', `Entity embeddings: ${entEmbUpdated} updated`);
+      tracker.end({ updated: entEmbUpdated, updated_entities: entEmbNames.slice(0, 10), orphans_removed: entEmbOrphansRemoved });
+      serverLog('watcher', `Entity embeddings: ${entEmbUpdated} updated, ${entEmbOrphansRemoved} orphans cleaned`);
     } else {
       tracker.skip('entity_embeddings', !p.sd ? 'no sd' : 'not built');
     }
@@ -1142,8 +1149,9 @@ export class PipelineRunner {
     }
 
     p.sd.db.pragma('incremental_vacuum');
+    p.sd.db.pragma('wal_checkpoint(TRUNCATE)');
     p.sd.setMetadataValue.run('last_incremental_vacuum', String(Date.now()));
-    serverLog('watcher', 'Incremental vacuum completed');
-    return { vacuumed: true };
+    serverLog('watcher', 'Incremental vacuum + WAL checkpoint completed');
+    return { vacuumed: true, wal_checkpointed: true };
   }
 }


### PR DESCRIPTION
## Summary
- Add `PRAGMA wal_checkpoint(TRUNCATE)` to the hourly maintenance step, fixing unbounded WAL growth (501MB observed in doctor)
- Add `removeOrphanedNoteEmbeddings()` and `removeOrphanedEntityEmbeddings()` to clean stale embeddings during watcher pipeline runs (1,154 note orphans + unknown entity orphans)
- Log entity embedding failures instead of silently swallowing them (mirrors existing note embedding pattern)
- Extend `diagnoseEmbeddings()` to detect and report entity embedding orphans

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 2,728 pass (2 pre-existing package-startup failures on main)
- [ ] Deploy and run `health_check` / `flywheel_doctor` — WAL warning should clear after next maintenance cycle, orphan counts should drop to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)