### PR TITLE
chore: release v2.0.157

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.0.156",
+  "version": "2.0.157",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump vault-core and flywheel-memory to 2.0.157

🤖 Generated with [Claude Code](https://claude.com/claude-code)