### PR TITLE
fix: add SIGTERM/SIGINT handlers for graceful MCP server shutdown

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1163,7 +1163,22 @@ if (process.argv.includes('--init-semantic')) {
   });
 }
 
-// Cleanup on exit
+// Graceful shutdown on signals (beforeExit does NOT fire on SIGTERM/SIGINT)
+function gracefulShutdown(signal: string) {
+  console.error(`[Memory] Received ${signal}, shutting down...`);
+  try { watcherInstance?.stop(); } catch {}
+  stopSweepTimer();
+  flushLogs()
+    .catch(() => {})
+    .finally(() => process.exit(0));
+  // Force exit after 2s if flushLogs hangs
+  setTimeout(() => process.exit(0), 2000).unref();
+}
+
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+
+// Cleanup on natural event-loop drain
 process.on('beforeExit', async () => {
   stopSweepTimer();
   await flushLogs();


### PR DESCRIPTION
## Summary

- Add `SIGTERM`/`SIGINT` signal handlers to the MCP server entry point so it shuts down cleanly when killed by flywheel-engine or systemd
- The `gracefulShutdown()` function stops the file watcher, sweep timer, and flushes logs before exiting (2s force-exit timeout as safety net)
- Fixes orphan flywheel-memory processes surviving engine restarts, which caused ToolSearch failures in the Claude session

Previously, the server only had a `beforeExit` handler (which doesn't fire on SIGTERM). When the engine kills its child processes on shutdown, the npx-spawned flywheel-memory node process would die without cleanup — leaving SQLite WAL locks, file watchers, and sweep timers dangling.

## Test plan

- [ ] Start flywheel-memory directly (`node bin/flywheel-memory.js`), send `kill <pid>`, verify it logs "Received SIGTERM" and exits 0
- [ ] Verify `npm run lint` and `npm run build` pass (confirmed)
- [ ] Verify existing tests still pass (2428/2430 pass; 2 pre-existing package-startup failures unrelated)

**Companion engine changes**: process tree killing + systemd ExecStartPre cleanup (separate flywheel-engine commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)