### PR TITLE
fix: harden watcher pipeline + doctor diagnosis correctness

### DIFF
--- a/packages/mcp-server/src/core/read/embeddings.ts
+++ b/packages/mcp-server/src/core/read/embeddings.ts
@@ -877,7 +877,7 @@ export function diagnoseEmbeddings(vaultPath: string): EmbeddingDiagnosis {
       checks.push({ name: 'entity_orphans', status: 'ok', detail: '0 orphaned' });
     }
   } catch {
-    checks.push({ name: 'entity_orphans', status: 'ok', detail: 'No entity embeddings table' });
+    checks.push({ name: 'entity_orphans', status: 'warning', detail: 'Could not check entity embeddings' });
   }
 
   // Check 6: Integrity (NaN/Inf sample)

--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -466,7 +466,12 @@ export class PipelineRunner {
           // Don't let embedding errors affect watcher
         }
       }
-      const orphansRemoved = removeOrphanedNoteEmbeddings();
+      let orphansRemoved = 0;
+      try {
+        orphansRemoved = removeOrphanedNoteEmbeddings();
+      } catch {
+        // Don't let orphan cleanup errors affect watcher
+      }
       tracker.end({ updated: embUpdated, removed: embRemoved, orphans_removed: orphansRemoved });
       serverLog('watcher', `Note embeddings: ${embUpdated} updated, ${embRemoved} removed, ${orphansRemoved} orphans cleaned`);
     } else {
@@ -1149,9 +1154,15 @@ export class PipelineRunner {
     }
 
     p.sd.db.pragma('incremental_vacuum');
-    p.sd.db.pragma('wal_checkpoint(TRUNCATE)');
-    p.sd.setMetadataValue.run('last_incremental_vacuum', String(Date.now()));
-    serverLog('watcher', 'Incremental vacuum + WAL checkpoint completed');
-    return { vacuumed: true, wal_checkpointed: true };
+    const walResult = p.sd.db.pragma('wal_checkpoint(TRUNCATE)') as Array<{ busy: number; log: number; checkpointed: number }>;
+    const checkpointed = walResult?.[0]?.busy === 0;
+
+    if (checkpointed) {
+      p.sd.setMetadataValue.run('last_incremental_vacuum', String(Date.now()));
+      serverLog('watcher', 'Incremental vacuum + WAL checkpoint completed');
+    } else {
+      serverLog('watcher', 'Incremental vacuum done, WAL checkpoint skipped (busy readers)');
+    }
+    return { vacuumed: true, wal_checkpointed: checkpointed };
   }
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -510,7 +510,7 @@ async function main() {
   const startTime = Date.now();
 
   // Parse multi-vault config
-  const vaultConfigs = _earlyVaultConfigs;
+  const vaultConfigs = parseVaultConfig();
 
   // ── Phase 1: Initialize primary vault (StateDb only — fast) ──
   if (vaultConfigs) {


### PR DESCRIPTION
## Summary

Fixes 4 correctness/regression issues found in code review of recent commits (4f96602, 22afd8e):

- **Guard `removeOrphanedNoteEmbeddings()`** — the call sat outside the per-event try/catch, so a corrupt/missing `notes_fts` table could kill the entire watcher batch. Now wrapped in its own try/catch matching the existing best-effort pattern.
- **Check WAL checkpoint return status** — `PRAGMA wal_checkpoint(TRUNCATE)` can silently no-op under active readers. Now checks the `busy` field; only records success and suppresses the hourly retry when the checkpoint actually completed.
- **Re-parse `FLYWHEEL_VAULTS` in `main()`** — the import-time `_earlyVaultConfigs` cache is still used for module-level `vaultPath` (the CLI fix), but `main()` now calls `parseVaultConfig()` fresh so test harnesses that set env after import still work.
- **Entity-orphan diagnosis honesty** — the catch block was reporting `status: 'ok'` for any error (including real corruption); now uses `status: 'warning'` matching the note-orphan check pattern at the same level.

## Test plan

- [x] `npm run build` — clean, no type errors
- [x] `npm test` — 2,735 tests pass (2 pre-existing `package-startup` failures on main, unrelated)
- [x] Manual diff review confirms each fix is scoped to the reported issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)