### PR TITLE
[codex] Documentation truth pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,19 @@
 <div align="center">
   <img src="header.png" alt="Flywheel" width="256"/>
   <h1>Flywheel</h1>
-  <p><strong>MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.</strong><br/>
-  All local. All yours. A few lines of config.</p>
+  <p><strong>Local-first memory for Obsidian that helps AI search, write, and reuse what your vault already knows.</strong><br/>
+  75 MCP tools. Local indexes. Markdown in, markdown out.</p>
 </div>
 
 [![npm version](https://img.shields.io/npm/v/@velvetmonkey/flywheel-memory.svg)](https://www.npmjs.com/package/@velvetmonkey/flywheel-memory)
-[![MCP](https://img.shields.io/badge/MCP-Model%20Context%20Protocol-blueviolet.svg)](https://modelcontextprotocol.io/)
 [![CI](https://github.com/velvetmonkey/flywheel-memory/actions/workflows/ci.yml/badge.svg)](https://github.com/velvetmonkey/flywheel-memory/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Clients](https://img.shields.io/badge/clients-Claude%20Code%20%7C%20Desktop%20%7C%20Cursor%20%7C%20Windsurf%20%7C%20VS%20Code%20%7C%20OpenClaw-blue.svg)](docs/SETUP.md)
-[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-blue.svg)](https://github.com/velvetmonkey/flywheel-memory)
 [![HotpotQA](https://img.shields.io/badge/HotpotQA-92.4%25%20recall%20(500q)-brightgreen.svg)](docs/TESTING.md#retrieval-benchmark-hotpotqa)
-[![LoCoMo](https://img.shields.io/badge/LoCoMo-84%25%20recall%20(695q)-blue.svg)](docs/TESTING.md#retrieval-benchmark-locomo)
-[![Cost](https://img.shields.io/badge/cost-%240.06--0.12%2Fquery-green.svg)](docs/TESTING.md#how-the-e2e-benchmark-works)
-[![Tests](https://img.shields.io/badge/tests-2,712%20passed-brightgreen.svg)](docs/TESTING.md)
+[![LoCoMo](https://img.shields.io/badge/LoCoMo-84.3%25%20evidence%20recall%20(695q)-blue.svg)](docs/TESTING.md#retrieval-benchmark-locomo)
 
-**[See It Work](#see-it-work)** · **[Try It](#try-it)** · **[What Makes It Different](#what-makes-flywheel-different)** · **[Benchmarked](#benchmarked)** · **[Tested](#tested)** · **[Docs](#documentation)** · **[Story](#the-story-behind-this)** · **[License](#license)**
+**[See It Work](#see-it-work)** · **[Try It](#try-it)** · **[What Makes It Different](#what-makes-flywheel-different)** · **[Benchmarked](#benchmarked)** · **[Tested](#tested)** · **[Docs](#documentation)** · **[License](#license)**
 
-> **Cognitive sovereignty** = your knowledge graph stays on your machine. No platform builds a profile from it. No subscription locks you in. You choose the model. You own the memory.
+Flywheel gives AI clients structured access to your vault: search results come back with frontmatter, backlinks, outlinks, snippets, and section context; writes can auto-link entities; memory and graph tools stay local to your files and SQLite state.
 
 <details>
 <summary><strong>How this compares to not using Flywheel</strong></summary>
@@ -28,7 +23,7 @@
 | Your data | Leaves your machine | Stays local. No sync, no upload, no account |
 | Model choice | Locked to one provider | Model-agnostic via MCP. Swap anytime |
 | As models improve | Migration or vendor upgrade | Same tools, better reasoning. Your graph improves the model, not the other way around |
-| Tokens per question | Read 10-50 files to find context (~50-200k tokens) | One search returns a decision surface — metadata, graph context, and section content (~2-5k tokens). [$0.06-0.09/query](#benchmarked) measured |
+| Tokens per question | Read files until the answer emerges | One search returns a decision surface — metadata, graph context, and section content |
 | "What's overdue?" | Read every file | Structured task queries with due dates, tags, and path filters |
 | "What links here?" | Grep the vault, flat list | Weighted backlinks + outlinks, ranked by edge strength and recency |
 | "Add a meeting note" | Raw write, no linking | Structured mutations that auto-link entities and densify the graph |
@@ -42,11 +37,11 @@
 
 ### Read: "How much have I billed Acme Corp?"
 
-From the [carter-strategy](demos/carter-strategy/) demo: a solo consultant with 3 clients, 5 projects, and $27K in invoices.
+From the [carter-strategy](demos/carter-strategy/) demo: a consultant vault with clients, invoices, projects, notes, and graph structure the model can query directly.
 
 <video src="https://github.com/user-attachments/assets/ec1b51a7-cb30-4c49-a35f-aa82c31ec976" autoplay loop muted playsinline width="100%"></video>
 
-One search call returned a decision surface: metadata (frontmatter) with amounts and status, backlink lists, outlink lists, and full section content around each match. Zero follow-up reads needed. The graph did the joining, not the AI reading files one by one.
+One search call returned a decision surface: frontmatter with amounts and status, backlink lists, outlink lists, and full section content around each match. Zero follow-up reads needed. The graph did the joining, not the AI reading files one by one.
 
 ### Write: Auto-wikilinks on every mutation
 
@@ -64,7 +59,7 @@ One search call returned a decision surface: metadata (frontmatter) with amounts
             → 2 suggested links: entities co-occurring with Stacy + security across past notes
 ```
 
-You typed a plain sentence. Flywheel recognized three entities and linked them: entity names, aliases, and fuzzy matches scored across [13 dimensions](docs/ALGORITHM.md). Links you keep strengthen future scoring; links you edit out get suppressed. The system learns.
+You typed a plain sentence. Flywheel recognized three entities and linked them: entity names, aliases, and fuzzy matches scored across [13 dimensions](docs/ALGORITHM.md). Links you keep strengthen future scoring; links you edit out get suppressed.
 
 `→` suggestions are off by default. Enable with `suggestOutgoingLinks: true` for daily notes, meeting logs, and voice capture. Anywhere you want the graph to grow organically. [Configuration guide →](docs/CONFIGURATION.md)
 
@@ -126,7 +121,7 @@ Add `.mcp.json` to your vault root:
 cd /path/to/your/vault && claude
 ```
 
-Flywheel does not replace Obsidian. It runs alongside as a background index. Watches for changes, indexes in real-time, and makes the full graph available to any AI client. No proprietary format, no cloud sync, no account. Delete `.flywheel/state.db` and it rebuilds from scratch.
+Flywheel does not replace Obsidian. It runs alongside as a background index, watches for changes, and makes the graph available to MCP clients. No proprietary format. Delete `.flywheel/state.db` and it rebuilds from scratch.
 
 ### Configure your tools
 
@@ -160,7 +155,7 @@ See [docs/CONFIGURATION.md#windows](docs/CONFIGURATION.md#windows) for the full 
 
 ### Who this is for
 
-**For** people who want control over their knowledge: developers, researchers, solo operators, and anyone who treats their notes as infrastructure, not disposable input. Every conversation you have with a cloud AI builds a cognitive profile of you that you don't own, can't export, and can't delete. Flywheel keeps that profile local. The people who use AI the most [want more control, not less](https://x.com/AnthropicAI/status/2036499691571953848). Also works as persistent memory for bots and agents — memory tools are included in the default preset, including [OpenClaw](https://github.com/openclaw/openclaw), where it replaces default amnesiac file access with graph-aware, learning memory.
+**For** people who want their vault to be usable by AI without turning it into a hosted product: developers, researchers, solo operators, and anyone who treats notes as working infrastructure. It also works as persistent memory for bots and agents through MCP.
 
 **Not for** people who want a hosted service. Flywheel runs on your machine, on your files. If you want cloud-managed knowledge, this isn't it.
 
@@ -168,9 +163,9 @@ See [docs/CONFIGURATION.md#windows](docs/CONFIGURATION.md#windows) for the full 
 
 ## What Makes Flywheel Different
 
-- **Search** — One call returns a decision surface: section provenance, extracted dates, entity bridges, confidence scores, and full section content. Multi-hop: "Acme Corp" returns the client note *and* its invoices, projects, and people. [$0.06-0.10/query](#benchmarked), measured.
+- **Search** — One call returns a decision surface: section provenance, extracted dates, entity bridges, confidence scores, and full section content. Multi-hop queries can surface the client note and the related invoices, projects, and people in one pass.
 - **Write** — Every mutation auto-links entities across your vault. Voice dump a meeting debrief and Flywheel wikilinks names, projects, and relationships automatically. [13 scoring layers](docs/ALGORITHM.md), zero manual curation.
-- **Remember** — `brief` delivers startup context, `memory` persists observations across sessions, and `search` retrieves across all three in one call. The system learns from your edits — links you keep get stronger, links you remove get suppressed.
+- **Remember** — `brief` delivers startup context, `memory` persists observations across sessions, and `search` retrieves across all three in one call.
 
 All local. No cloud. No account. No sync.
 
@@ -182,7 +177,7 @@ Entity              Score  Match  Co-oc  Type  Context  Recency  Cross  Hub  Fee
 Marcus Johnson        34    +10     +3    +5     +5       +5      +3    +1     +2         0       0
 ```
 
-13 scoring layers, every number traceable to vault usage. The score learns as you use it. [How scoring works →](docs/ALGORITHM.md)
+13 scoring layers, every number traceable to vault usage. [How scoring works →](docs/ALGORITHM.md)
 
 ### The flywheel effect
 
@@ -192,11 +187,11 @@ Every sentence you write makes your graph denser — better search results, rich
 - **Co-occurrence** builds over time. Links that survive edits gain influence.
 - **Suppression** learns. Remove a wikilink enough times and Flywheel stops suggesting it.
 
-Day 100 suggestions are informed by everything you've written since day 1. This is [measured](docs/TESTING.md#graph-quality-266-tests-31-files), not a claim — CI fails if any metric regresses. All learning data is local SQLite. [What's tracked →](docs/SHARING.md)
+Day 100 suggestions are informed by everything you've written since day 1. This is [measured](docs/TESTING.md#graph-quality-266-tests-31-files), not hand-waved. All learning data is local SQLite. [What's tracked →](docs/SHARING.md)
 
 ### Agentic policies
 
-Complex vault workflows become deterministic YAML policies. All steps succeed or all roll back. Commit with one flag. Every write uses structured parsing that understands headings, frontmatter, and code blocks as structure — not blind string replacement. [Architecture →](docs/ARCHITECTURE.md)
+Complex vault workflows become deterministic YAML policies. All steps succeed or all roll back. Commit with one flag. Every write uses structured parsing that understands headings, frontmatter, and code blocks as structure. [Architecture →](docs/ARCHITECTURE.md)
 
 ### Portable knowledge graph
 
@@ -230,9 +225,13 @@ These are rules, not preferences:
 
 ## Benchmarked
 
-**92.4% retrieval recall** on [HotpotQA](https://hotpotqa.github.io/). **84.8% recall@5** on [LoCoMo](https://snap-research.github.io/locomo/) conversational memory. Zero training data. Fully local. $0.07/question.
+Latest checked-in benchmark artifacts:
 
-Every number is reproducible: clone the repo, run the scripts, get the same results. No other MCP memory tool publishes retrieval benchmarks on standard academic datasets.
+- **HotpotQA full end-to-end**: **92.4% document recall** on **500 questions / 4,960 docs**. Latest artifact: **March 28, 2026**. Cost in that run: **$0.074/question**.
+- **LoCoMo full end-to-end**: **84.3% evidence recall** and **58.7% answer accuracy** on **695 scored questions / 272 sessions**. Latest artifact: **March 28, 2026**. Final token F1: **0.483**.
+- **LoCoMo unit retrieval**: **84.8% Recall@5** and **90.4% Recall@10** on the full non-adversarial retrieval set.
+
+Every number below is tied to a checked-in report or reproducible harness in the repo.
 
 **Multi-hop retrieval vs. academic baselines** (HotpotQA, 500 questions, 4,960 documents):
 
@@ -245,7 +244,7 @@ Every number is reproducible: clone the repo, run the scripts, get the same resu
 | **Flywheel** | **92.4%** | **None** |
 | [Beam Retrieval](https://arxiv.org/abs/2308.08973) | ~93% | End-to-end |
 
-**Conversational memory** ([LoCoMo](https://snap-research.github.io/locomo/), 1,531 questions, 272 session notes):
+**Conversational memory retrieval** ([LoCoMo](https://snap-research.github.io/locomo/), 1,531 scored retrieval queries, 272 session notes):
 
 | Category | Recall@5 | Recall@10 |
 |---|---|---|
@@ -255,7 +254,7 @@ Every number is reproducible: clone the repo, run the scripts, get the same resu
 | Multi-hop | 58.1% | 72.7% |
 | Temporal | 56.9% | 67.4% |
 
-E2E with Claude Sonnet (695 questions): 97.4% single-hop evidence recall, 73.7% multi-hop, 84.3% overall. 58.7% answer accuracy (LLM-as-judge). Competitors (Mem0, Zep, LangMem) report answer accuracy via GPT-4o judge but not evidence recall — metrics differ. [Full comparison →](docs/TESTING.md#retrieval-benchmark-locomo)
+E2E with Claude Sonnet (latest checked-in 695-question run): **97.4%** single-hop evidence recall, **73.7%** multi-hop evidence recall, **84.3%** overall evidence recall, and **58.7%** answer accuracy (Claude Haiku judge). [Full methodology and caveats →](docs/TESTING.md#retrieval-benchmark-locomo)
 
 > **Directional, not apples-to-apples.** Different test settings, sample sizes, retrieval pools, and metrics. Flywheel searches 4,960 pooled docs (harder than HotpotQA distractor setting of 10, easier than fullwiki 5M+). Academic retrievers train on the benchmark; Flywheel has zero training data. Run-to-run variance of ~1pp is expected due to LLM non-determinism. [Full caveats →](docs/TESTING.md#retrieval-benchmark-hotpotqa)
 
@@ -265,9 +264,9 @@ E2E with Claude Sonnet (695 questions): 97.4% single-hop evidence recall, 73.7% 
 
 ## Tested
 
-2,712 tests across read, write, security, concurrency, and graph quality. CI-gated on Ubuntu + Windows, Node 22 + 24.
+2,760 defined tests across 142 test files and ~54.7k lines of test code. CI runs focused jobs on Ubuntu, plus a full matrix on Ubuntu and Windows across Node 22 and 24.
 
-- **Graph quality:** 100% wikilink precision on ground truth vault, stress-tested over 50 generations with realistic noise. [Report →](docs/QUALITY_REPORT.md)
+- **Graph quality:** latest generated report shows balanced-mode **40.2% precision / 71.7% recall / 51.5% F1** on the primary synthetic vault, plus multi-generation, archetype, chaos, and regression tests. [Report →](docs/QUALITY_REPORT.md)
 - **Live AI testing:** real `claude -p` sessions verify tool adoption end-to-end, not just handler logic
 - **Write safety:** git-backed conflict detection, atomic rollback, 100 parallel writes with zero corruption
 - **Security:** SQL injection, path traversal, Unicode normalization, permission bypass
@@ -294,32 +293,6 @@ E2E with Claude Sonnet (695 questions): 97.4% single-hop evidence recall, 73.7% 
 
 ---
 
-## The Story Behind This
-
-Flywheel started because I'm fundamentally lazy. I wanted to talk at my vault through a Telegram bot and have it not be rubbish - no typing, no manual linking, no curation. The lazy path needed to be the correct path, so I built a system where they're the same path.
-
-I've been writing code for over 30 years and tried every PKM tool going before landing on Obsidian. Flywheel is my third attempt at wiring AI into my knowledge vault. The first two failed because writes were non-deterministic and context didn't flow between sessions. This version unifies everything: one server with deterministic mutations, hybrid search, and a graph that compounds with use. The Architecture exists because I kept hitting the same walls and refusing to stop.
-
-Your attention, memory, and even the way you reason are increasingly shaped by systems you didn't choose. Platforms that optimise for engagement, models trained on someone else's priorities, defaults that quietly steer how you organise what you know. I wanted a knowledge layer that works for the person using it. A system that only gets smarter from your own honest engagement is fundamentally different from one that optimises for someone else's metrics.
-
-The entire codebase was built through Claude Code with Opus 4.5 and 4.6. I designed the architecture and made every decision and it's been through extensive code reviews and testing, but verify what matters to you.
-
-I dogfood it daily through a Telegram bot using voice input. The volume of knowledge you can accumulate at speed through voice is staggering - even quiet days produce 20–30 links where they used to be 3–5. Flywheel exists partly because I needed something that could keep up. All suggestions are welcome! I'm looking for people who care about this space.
-
-### The Cognitive Pipeline
-
-What emerged from daily use is a workflow pattern: cheap models generate ideas at volume (Grok, ChatGPT — whatever's free), the Telegram bot filters for truth and persists to the vault, then a separate Claude Code session reads the stored context and executes from filtered material. Generate broadly, filter honestly, execute precisely.
-
-It works because Flywheel makes every stage persistent. The bot's conversation is logged and auto-wikilinked. The filter's judgements become searchable memories. The executor reads yesterday's daily notes and picks up where the last session left off — no re-explaining, no context dump, no starting from scratch.
-
-Because Flywheel is an MCP server, any client can be any stage. An OpenClaw bot, a Cursor session, Claude Desktop — they all get the same persistent, learning memory. The graph compounds across sessions. Your filing cabinet stops being passive storage and starts thinking with you.
-
-To contribute back to Obsidian I'm also building [Flywheel Crank](https://github.com/velvetmonkey/flywheel-crank) (early days), an Obsidian plugin that surfaces suggestions, graph visibility, and management tools directly in the editor.
-
----
-
 ## License
 
 Apache-2.0. See [LICENSE](./LICENSE) for details.
-
-> Your knowledge. Your graph. Your terms.

--- a/docs/PROVE-IT.md
+++ b/docs/PROVE-IT.md
@@ -14,9 +14,9 @@ No screenshots. No demos on someone else's machine. Clone the repo, run the test
 - [Phase 5: Try a Different Domain](#phase-5-try-a-different-domain)
 - [Phase 6: Your Own Vault](#phase-6-your-own-vault)
 - [Reproduce Our Numbers](#reproduce-our-numbers)
-  - [1. Unit Tests (2,712 passed)](#1-unit-tests-2712-passed)
-  - [2. HotpotQA Retrieval Benchmark (92.4% recall, 500 questions)](#2-hotpotqa-retrieval-benchmark-917-recall-500-questions)
-  - [3. LoCoMo E2E Benchmark (79% recall, 695 questions)](#3-locomo-e2e-benchmark-79-recall-695-questions)
+  - [1. Unit Tests](#1-unit-tests)
+  - [2. HotpotQA Retrieval Benchmark (92.4% recall, 500 questions)](#2-hotpotqa-retrieval-benchmark-924-recall-500-questions)
+  - [3. LoCoMo E2E Benchmark (84.3% evidence recall, 695 questions)](#3-locomo-e2e-benchmark-843-evidence-recall-695-questions)
 - [What You Just Proved](#what-you-just-proved)
 - [Why It's Efficient](#why-its-efficient)
 - [Next Steps](#next-steps)
@@ -25,7 +25,7 @@ No screenshots. No demos on someone else's machine. Clone the repo, run the test
 
 ## Prerequisites
 
-- **Node.js 22–24** -- check with `node --version`.
+- **Node.js 22+** -- check with `node --version`.
 - **Claude Code** -- authenticated and working (`claude --version`)
 - **git** -- to clone the repo
 
@@ -40,16 +40,9 @@ npm install
 npm test
 ```
 
-Wait for it:
+Your output will reflect the current Vitest totals in this checkout. As of **March 28, 2026**, the repo defines **2,760 tests across 142 test files**.
 
-```
-Test Suites: 129 passed, 129 total
-Tests:       2,712 passed, 2,712 total
-Snapshots:   0 total
-Time:        ~18s
-```
-
-2,712 tests. All passing. No mocks of external services -- these are real SQLite queries, real file parsing, real graph traversals against real vaults. If something is broken, you know in 18 seconds.
+No mocks of external services -- these are real SQLite queries, real file parsing, real graph traversals against real vaults.
 
 ---
 
@@ -194,7 +187,7 @@ See [SETUP.md](SETUP.md) for the complete walkthrough.
 
 Three headline benchmarks, three sets of instructions. Each is self-contained and copy-pasteable.
 
-### 1. Unit Tests (2,712 passed)
+### 1. Unit Tests
 
 **What it proves:** Every tool handler, search index, graph traversal, mutation engine, security boundary, and concurrency path works correctly against real vaults and real SQLite databases. No external service mocks.
 
@@ -213,16 +206,13 @@ npm test
 
 **Expected output:**
 
-```
-Test Suites: 129 passed, 129 total
-Tests:       2,712 passed, 2,712 total
-Snapshots:   0 total
-Time:        ~18s
-```
+- A successful `vitest` run across all three workspace packages
+- Totals that match the current checkout
+- As of **March 28, 2026**: **2,760 defined tests across 142 test files**
 
-`npm test` runs `vitest run` across all three workspace packages (vault-core, flywheel-memory, flywheel-bench). The mcp-server package contains the vast majority of tests. No network access, no API keys, no Docker -- just Node and SQLite.
+`npm test` runs `vitest run` across all three workspace packages (`vault-core`, `flywheel-memory`, `flywheel-bench`). The mcp-server package contains the vast majority of tests. No network access, no API keys, no Docker -- just Node and SQLite.
 
-**Estimated time:** ~1 minute (install) + ~18 seconds (tests).
+**Estimated time:** roughly 1 minute for install, then a short local test run.
 
 ---
 
@@ -235,7 +225,7 @@ Time:        ~18s
 - MCP server built: `npm run build`
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI authenticated (`claude --version`)
 - Python 3 (for analysis script)
-- Anthropic API credits (~$0.058/question)
+- Anthropic API credits (latest checked-in 500-question run averaged **$0.074/question**)
 
 **Step 1: Build the benchmark vault**
 
@@ -268,18 +258,19 @@ Results land in `demos/hotpotqa/results/run-<timestamp>/`.
 cat demos/hotpotqa/results/run-*/report.md
 ```
 
-**Expected results:**
+**Latest checked-in artifact:** `demos/hotpotqa/results/run-20260328T044033/report.md` (**March 28, 2026**)
 
-| Metric | Expected |
+| Metric | Latest checked-in run |
 |---|---|
-| Document Recall | ~92% (917/1000 supporting docs found) |
-| Full Recall (both docs) | ~84% (418/500) |
-| Partial Recall (at least 1 doc) | ~99.8% (499/500) |
+| Document Recall | **92.4%** (924/1000 supporting docs found) |
+| Full Recall (both docs) | **85.2%** (426/500) |
+| Partial Recall (at least 1 doc) | **99.6%** (498/500) |
+| Avg Cost / Question | **$0.074** |
 
-Exact numbers vary by a few percentage points between runs due to LLM non-determinism. The 92.4% headline is from seed 42 with Sonnet.
+Exact numbers vary between runs due to model non-determinism and pricing changes. Treat the table above as the latest committed run, not a permanent invariant.
 
 **Estimated time:** ~2-3 hours for 500 questions (each question is a separate Claude session).
-**Estimated cost:** ~$29 (500 questions x ~$0.058/question).
+**Estimated cost:** about **$37** at the pricing/model mix used in the latest checked-in run.
 
 **Smaller test run:** To verify the pipeline works before committing to the full 500:
 
@@ -291,7 +282,7 @@ This runs 20 questions in ~10 minutes for ~$1.25.
 
 ---
 
-### 3. LoCoMo E2E Benchmark (79% recall, 695 questions)
+### 3. LoCoMo E2E Benchmark (84.3% evidence recall, 695 questions)
 
 **What it proves:** Flywheel retrieves evidence from long-term conversational memory — measured on the same LoCoMo dataset from Snap Research (ACL 2024) used by Mem0, Zep, LangMem, and MemGPT.
 
@@ -300,7 +291,7 @@ This runs 20 questions in ~10 minutes for ~$1.25.
 - MCP server built: `npm run build`
 - Claude Code CLI authenticated
 - Python 3
-- Anthropic API credits (~$0.12/question)
+- Anthropic API credits (latest checked-in 695-question run averaged **$0.122/question**)
 
 **Step 1: Build the benchmark vault**
 
@@ -334,21 +325,21 @@ Results land in `demos/locomo/results/run-<timestamp>/`.
 cat demos/locomo/results/run-*/report.md
 ```
 
-**Expected results:**
+**Latest checked-in artifact:** `demos/locomo/results/run-20260328T043936/report.md` (**March 28, 2026**)
 
 | Category | Questions | Evidence Recall | Accuracy (Judge) |
 |---|---|---|---|
-| **Overall** | **695** | **~84%** | **~59%** |
-| Single-hop | 139 | ~97% | ~77% |
-| Commonsense | 139 | ~96% | ~78% |
-| Multi-hop | 139 | ~74% | ~39% |
-| Temporal | 96 | ~69% | ~53% |
-| Adversarial | 182 | ~99% | ~48% |
+| **Overall** | **695** | **84.3%** | **58.7%** |
+| Single-hop | 139 | 97.4% | 77.0% |
+| Commonsense | 139 | 96.4% | 78.4% |
+| Multi-hop | 139 | 73.7% | 38.9% |
+| Temporal | 96 | 69.2% | 53.1% |
+| Adversarial | 182 | 98.9% | 47.8% |
 
-Exact numbers vary by a few percentage points between runs due to LLM non-determinism. The 84.3% headline is from seed 42 with Sonnet. Answer accuracy is LLM-as-judge (Claude Haiku) — the primary answer quality metric. Token F1 (diagnostic) is also reported automatically on every run.
+Latest checked-in final token F1 is **0.483** and raw token F1 is **0.291**. Exact numbers vary between runs due to model non-determinism. Answer accuracy is LLM-as-judge (Claude Haiku in the latest committed report).
 
 **Estimated time:** ~8-12 hours for 695 questions.
-**Estimated cost:** ~$85 (695 x ~$0.12/question).
+**Estimated cost:** about **$85** at the pricing/model mix used in the latest checked-in run.
 
 **Smaller test run:** To verify the pipeline:
 
@@ -362,7 +353,7 @@ This runs 30 questions in ~15 minutes for ~$2.50.
 
 ## What You Just Proved
 
-1. **Tests pass** -- 2,712 of them, against real data
+1. **The test corpus is substantial** -- 2,760 defined tests in the current checkout, against real data
 2. **Graph queries work** -- backlinks + metadata, no file reads
 3. **Auto-wikilinks work** -- plain text in, linked text out
 4. **The algorithm is transparent** -- scores with explanations, not black boxes

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,15 +44,15 @@
 
 7 production-ready vaults representing real knowledge work. Each demo is a self-contained Obsidian vault with an `.mcp.json` already configured.
 
-| Demo | Persona | Try This | Notes |
-|------|---------|----------|-------|
-| [carter-strategy](../demos/carter-strategy/) | Solo consultant tracking clients and invoices | "How much have I billed Acme Corp?" | 32 |
-| [artemis-rocket](../demos/artemis-rocket/) | Rocket engineer managing milestones | "What's blocking the propulsion milestone?" | 63 |
-| [startup-ops](../demos/startup-ops/) | SaaS co-founder running operations | "What's our MRR?" | 31 |
-| [nexus-lab](../demos/nexus-lab/) | PhD researcher navigating literature | "How does AlphaFold connect to my experiment?" | 32 |
-| [solo-operator](../demos/solo-operator/) | Content creator managing revenue | "How's revenue this month?" | 16 |
-| [support-desk](../demos/support-desk/) | Support agent resolving tickets | "What's Sarah Chen's situation?" | 12 |
-| [zettelkasten](../demos/zettelkasten/) | Zettelkasten student studying learning science | "How does spaced repetition connect to active recall?" | 47 |
+| Demo | Persona | Try This |
+|------|---------|----------|
+| [carter-strategy](../demos/carter-strategy/) | Solo consultant tracking clients and invoices | "How much have I billed Acme Corp?" |
+| [artemis-rocket](../demos/artemis-rocket/) | Rocket engineer managing milestones | "What's blocking the propulsion milestone?" |
+| [startup-ops](../demos/startup-ops/) | SaaS co-founder running operations | "What's our MRR?" |
+| [nexus-lab](../demos/nexus-lab/) | PhD researcher navigating literature | "How does AlphaFold connect to my experiment?" |
+| [solo-operator](../demos/solo-operator/) | Content creator managing revenue | "How's revenue this month?" |
+| [support-desk](../demos/support-desk/) | Support agent resolving tickets | "What's Sarah Chen's situation?" |
+| [zettelkasten](../demos/zettelkasten/) | Zettelkasten student studying learning science | "How does spaced repetition connect to active recall?" |
 
 Every demo is a real test fixture. If it works in the README, it passes in CI.
 
@@ -67,7 +67,7 @@ cd flywheel-memory/demos/carter-strategy && claude
 
 ```bash
 npm run build    # Build both packages
-npm test         # Run full test suite (2,712 tests)
+npm test         # Run full test suite
 npm run dev      # Watch mode
 npm run lint     # Type check
 ```
@@ -82,13 +82,13 @@ For architecture details and code organization, see [ARCHITECTURE.md](ARCHITECTU
 No. Flywheel runs entirely on your machine. No cloud services, no API keys (beyond Claude itself), no data leaves your disk. The SQLite indexes live inside your vault directory.
 
 **How many notes can it handle?**
-CI benchmarks test 100,000-line file mutations and 2,500-entity indexes. The bench package can generate vaults up to 100k notes. The in-memory index builds at startup (a few seconds cold, ~100ms cached) and queries return in under 10ms.
+CI benchmarks test 100,000-line file mutations and 2,500-entity indexes. The bench package can generate very large synthetic vaults. See [BENCHMARKS.md](BENCHMARKS.md) and [TESTING.md](TESTING.md) for the scoped measurements that are actually checked in.
 
 **Will it corrupt my vault?**
-2,712 tests say no. The test suite includes 100 parallel write operations with zero corruption, property-based fuzzing with 50+ randomized scenarios per property, and dedicated security tests for injection attacks and path traversal. See [TESTING.md](TESTING.md).
+The repo currently defines 2,760 tests across 142 test files. The suite includes 100 parallel write operations with zero corruption in the stress tests, property-based fuzzing, and dedicated security tests for injection attacks and path traversal. See [TESTING.md](TESTING.md).
 
 **How much does it cost in tokens?**
-A typical query uses 50-200 tokens of context. Compare that to grep-and-read, which typically costs ~800-2,000 tokens for text-searchable questions. Measured across a 7-beat demo scenario: the `brief` tool delivers 44x token savings (71 tokens vs 3,164 baseline). The bigger win is structural queries (backlinks, hubs, paths) that grep can't answer at all.
+It depends on the dataset, model, and task. The checked-in benchmark artifacts currently show about **$0.074/question** for the latest HotpotQA 500-question run and **$0.122/question** for the latest 695-question LoCoMo E2E run. See [TESTING.md](TESTING.md) for the exact scope and dates.
 
 **Does it work with Claude Desktop?**
 Yes. See [CONFIGURATION.md](CONFIGURATION.md) for Claude Desktop setup instructions.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -19,7 +19,7 @@ After trying the [demo vaults](../demos/), point Flywheel at your own Obsidian v
 
 ## Prerequisites
 
-- **Node.js 22–24** -- check with `node --version`.
+- **Node.js 22+** -- check with `node --version`.
 - **An Obsidian vault** -- any folder with `.md` files works, but Flywheel detects Obsidian conventions (`.obsidian/` folder, periodic notes, templates)
 - **An MCP-compatible client** -- Claude Code, Claude Desktop, Cursor, Windsurf, VS Code + GitHub Copilot, Continue, [OpenClaw](https://github.com/openclaw/openclaw), or any Streamable HTTP client
 
@@ -309,7 +309,7 @@ Start with these to see Flywheel in action on your vault:
 
 > "Search for notes about [topic]"
 
-This uses full-text search. Results return in under 10ms with highlighted snippets.
+This uses full-text search with highlighted snippets from the local index.
 
 ### 2. Explore connections
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,7 +4,7 @@
 
 Your vault is your second brain. You don't hand it to software you can't trust.
 
-**2,712 tests | 129 test files | 47,000+ lines of test code**
+**2,760 defined tests | 142 test files | 54,700+ lines of test code**
 
 - [Test Philosophy](#test-philosophy)
 - [CI Pipeline](#ci-pipeline)
@@ -207,10 +207,6 @@ HotpotQA is primarily used as a QA benchmark (answer extraction, measured by EM/
 - **Sample size.** Flywheel: 500 questions. Academic baselines typically use the full dev set (7,405 questions). Our confidence intervals are tighter than our earlier 200-question run but still wider than the full set.
 - **What's real.** Flywheel's 92.4% beats the standard BM25 baseline (~75%) by +17pp, attributable to 2-hop backfill, query expansion, and FTS5 OR-mode with BM25 ranking. Flywheel exceeds MDR (~88%) and approaches Beam Retrieval (~93%) despite zero training data, purpose-built architectures, and a harder retrieval setting (5,000 docs vs 10). Run-to-run variance of ~1pp is expected due to LLM non-determinism.
 
-### Comparison with other MCP/vault tools
-
-As of March 2026, we are not aware of any other MCP memory tool that has published end-to-end retrieval benchmarks on a standard academic dataset. Most tools in this space report feature lists but not measured retrieval quality.
-
 Source: [`demos/hotpotqa/`](../demos/hotpotqa/) | [`packages/mcp-server/test/retrieval-bench/`](../packages/mcp-server/test/retrieval-bench/)
 
 ### CI Regression Gate
@@ -359,7 +355,7 @@ The graph quality suite validates that the wikilink suggestion engine works corr
 
 ### Baselines
 
-Locked in `baselines.json` (2026-02-26). CI fails if any metric regresses >5pp.
+Locked in `baselines.json` (**2026-02-26**). CI fails if any metric regresses >5pp. These are regression baselines, not the same thing as the latest generated proof report in [QUALITY_REPORT.md](QUALITY_REPORT.md).
 
 | Mode | Precision | Recall | F1 | MRR |
 |---|---|---|---|---|
@@ -368,6 +364,8 @@ Locked in `baselines.json` (2026-02-26). CI fails if any metric regresses >5pp.
 | Aggressive | 26.1% | 76.7% | 39.0% | 0.742 |
 
 Measured against a 96-note/61-entity ground truth vault. Links stripped, engine must rediscover them.
+
+The latest generated proof report checked into this repo is [QUALITY_REPORT.md](QUALITY_REPORT.md), generated on **March 27, 2026 21:45 UTC**. Its current balanced-mode headline is **40.2% precision / 71.7% recall / 51.5% F1**.
 
 ### Multi-Generation Stress Test
 
@@ -403,7 +401,7 @@ This is a fundamentally different claim than "the handler returns valid JSON." I
 
 Every test is a real `claude -p` session against a demo vault. Claude gets `--strict-mcp-config` (no filesystem, no web — vault tools only). The output is captured as `stream-json` JSONL, and Python analyzers extract every `tool_use` event to compute adoption rates, tool sequences, and category breakdowns. Clean state between runs: StateDb deleted, write operations git-restored. Nothing is mocked.
 
-We are not aware of any other MCP server that publishes live AI test results.
+This kind of test is valuable because it measures actual tool selection and composition, not just handler correctness.
 
 ### Test Suites
 
@@ -413,7 +411,7 @@ We are not aware of any other MCP server that publishes live AI test results.
 | **Bundle adoption** | Claude finds the right tools for each of 12 bundles | 36 (12 × 3 runs) | 11/12 at 100% | [`run-bundle-test.sh`](../demos/run-bundle-test.sh) |
 | **Sequential workflow** | 7-beat workflow where each beat builds on previous vault state | 7 beats | 7/7 passed | [`run-demo-test.sh`](../demos/run-demo-test.sh) |
 | **HotpotQA benchmark** | End-to-end retrieval quality on HotpotQA multi-hop questions | 500 questions | 92.4% recall | [`hotpotqa/run-benchmark.sh`](../demos/hotpotqa/run-benchmark.sh) |
-| **LoCoMo benchmark** | Retrieval + answer accuracy on long-term conversational memory (5 categories) | 759 questions | 84.9% recall, 58.8% accuracy | [`locomo/run-benchmark.sh`](../demos/locomo/run-benchmark.sh) |
+| **LoCoMo benchmark** | Retrieval + answer accuracy on long-term conversational memory (5 categories) | 695 scored questions | 84.3% evidence recall, 58.7% accuracy | [`locomo/run-benchmark.sh`](../demos/locomo/run-benchmark.sh) |
 
 ### Why This Matters
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -35,7 +35,7 @@ Voice → Transcription → AI Agent → Flywheel → Queryable Knowledge
 
 Walking to lunch after a meeting. Pull out your phone and say: "Log that we agreed to push the launch to March. Sarah Mitchell owns the Acme Data Migration, and Stacy Thompson is starting the Beta Corp Dashboard." Your voice becomes a transcript. The AI agent sends it to Flywheel. Flywheel recognizes `[[Sarah Mitchell]]`, `[[Acme Data Migration]]`, `[[Stacy Thompson]]`, and `[[Beta Corp Dashboard]]` from your existing vault. It writes the note, links it to the right entities, and the knowledge graph grows -- all before you've sat down.
 
-The next time you ask "What's the latest on the Acme deal?", the answer is already indexed, linked, and ready in under 10ms.
+The next time you ask "What's the latest on the Acme deal?", the answer is already indexed, linked, and ready from the local graph.
 
 ---
 
@@ -57,7 +57,7 @@ The relationship between graph density and suggestion quality isn't linear — i
 
 The feedback loop is also temporal. Early suggestions may seem noisy — Flywheel links entities you don't think are relevant. But each one, kept or rejected, trains the next round. Kept links accumulate co-occurrence signal. Rejected links shift the Beta-Binomial posterior toward suppression. Six months in, the noisy suggestions have either proven their worth (they're now part of answer paths you traverse daily) or they've been suppressed (the system learned to stop suggesting them).
 
-This is why we measure F1 over 50 generations of simulated use: to prove the loop converges rather than degrades. It does. Precision holds at 100%. Recall climbs as density increases.
+This is why we measure F1 over 50 generations of simulated use: to prove the loop converges rather than degrades. It does. The latest checked-in reports show the system stays stable across noisy feedback loops while recall improves as the graph gets denser.
 
 See the main [README](../packages/mcp-server/README.md#the-flywheel-effect) for the flywheel cycle diagram.
 

--- a/packages/mcp-server/test/write/docs/claims-truth.test.ts
+++ b/packages/mcp-server/test/write/docs/claims-truth.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+
+const REPO_ROOT = path.join(__dirname, '../../../../../');
+const README_PATH = path.join(REPO_ROOT, 'README.md');
+const DOCS_TESTING_PATH = path.join(REPO_ROOT, 'docs', 'TESTING.md');
+const DOCS_PROVE_IT_PATH = path.join(REPO_ROOT, 'docs', 'PROVE-IT.md');
+const DOCS_README_PATH = path.join(REPO_ROOT, 'docs', 'README.md');
+const DOCS_VISION_PATH = path.join(REPO_ROOT, 'docs', 'VISION.md');
+const DOCS_QUALITY_REPORT_PATH = path.join(REPO_ROOT, 'docs', 'QUALITY_REPORT.md');
+const DEMOS_DIR = path.join(REPO_ROOT, 'demos');
+
+async function read(filePath: string): Promise<string> {
+  return fs.readFile(filePath, 'utf-8');
+}
+
+async function findLatestRunDir(dataset: 'hotpotqa' | 'locomo'): Promise<string> {
+  const resultsDir = path.join(REPO_ROOT, 'demos', dataset, 'results');
+  const entries = await fs.readdir(resultsDir, { withFileTypes: true });
+  const runs = entries
+    .filter(entry => entry.isDirectory() && entry.name.startsWith('run-'))
+    .map(entry => entry.name)
+    .sort();
+
+  if (runs.length === 0) {
+    throw new Error(`No run directories found in ${resultsDir}`);
+  }
+
+  return path.join(resultsDir, runs[runs.length - 1]);
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+describe('documentation claims truth', () => {
+  it('README and benchmark docs match the latest checked-in HotpotQA and LoCoMo artifacts', async () => {
+    const [readme, testingDoc, proveItDoc] = await Promise.all([
+      read(README_PATH),
+      read(DOCS_TESTING_PATH),
+      read(DOCS_PROVE_IT_PATH),
+    ]);
+
+    const hotpotRunDir = await findLatestRunDir('hotpotqa');
+    const hotpotAnalysis = JSON.parse(await read(path.join(hotpotRunDir, 'analysis.json')));
+
+    const locomoRunDir = await findLatestRunDir('locomo');
+    const locomoAnalysis = JSON.parse(await read(path.join(locomoRunDir, 'analysis.json')));
+    const locomoReport = await read(path.join(locomoRunDir, 'report.md'));
+
+    const hotpotDocRecall = `${(hotpotAnalysis.overall_recall * 100).toFixed(1)}%`;
+    const hotpotFullRecall = `${((hotpotAnalysis.full_recall_count / hotpotAnalysis.total_questions) * 100).toFixed(1)}%`;
+    const hotpotPartialRecall = `${((hotpotAnalysis.partial_recall_count / hotpotAnalysis.total_questions) * 100).toFixed(1)}%`;
+    const hotpotCost = `$${(hotpotAnalysis.total_cost_usd / hotpotAnalysis.total_questions).toFixed(3)}`;
+
+    const locomoEvidenceRecall = `${(locomoAnalysis.overall_evidence_recall * 100).toFixed(1)}%`;
+    const locomoFinalF1 = locomoAnalysis.overall_final_token_f1.toFixed(3);
+    const locomoRawF1 = locomoAnalysis.overall_raw_token_f1.toFixed(3);
+    const locomoCost = `$${(locomoAnalysis.total_cost_usd / locomoAnalysis.scored_questions).toFixed(3)}`;
+    const judgeMatch = locomoReport.match(/Answer Accuracy \| \*\*([0-9.]+%)\*\*/);
+    expect(judgeMatch, 'LoCoMo report should include Answer Accuracy').toBeTruthy();
+    const locomoAccuracy = judgeMatch![1];
+
+    for (const doc of [readme, testingDoc, proveItDoc]) {
+      expect(doc).toContain(hotpotDocRecall);
+      expect(doc).toContain(locomoEvidenceRecall);
+    }
+
+    expect(testingDoc).toContain(hotpotCost);
+    expect(proveItDoc).toContain(hotpotCost);
+    expect(readme).toContain(locomoAccuracy);
+    expect(testingDoc).toContain(locomoAccuracy);
+    expect(proveItDoc).toContain(locomoAccuracy);
+    expect(testingDoc).toContain(locomoFinalF1);
+    expect(proveItDoc).toContain(locomoFinalF1);
+    expect(proveItDoc).toContain(locomoRawF1);
+    expect(proveItDoc).toContain(locomoCost);
+    expect(proveItDoc).toContain(hotpotFullRecall);
+    expect(proveItDoc).toContain(hotpotPartialRecall);
+  });
+
+  it('README and docs do not contain known stale benchmark or quality phrases', async () => {
+    const docs = await Promise.all([
+      read(README_PATH),
+      read(DOCS_TESTING_PATH),
+      read(DOCS_PROVE_IT_PATH),
+      read(DOCS_VISION_PATH),
+    ]);
+
+    const bannedPhrases = [
+      '2,712',
+      '129 test files',
+      '47,000+ lines of test code',
+      '100% wikilink precision',
+      'Precision holds at 100%',
+      '84.9% recall, 58.8% accuracy',
+      '759 questions',
+      'As of March 2026, we are not aware',
+      'We are not aware of any other MCP server',
+    ];
+
+    for (const doc of docs) {
+      for (const phrase of bannedPhrases) {
+        expect(doc.includes(phrase), `Unexpected stale phrase: ${phrase}`).toBe(false);
+      }
+    }
+  });
+
+  it('README graph-quality headline matches the latest generated quality report', async () => {
+    const [readme, qualityReport] = await Promise.all([
+      read(README_PATH),
+      read(DOCS_QUALITY_REPORT_PATH),
+    ]);
+
+    const balancedMatch = qualityReport.match(/\| balanced \| ([0-9.]+%) \| ([0-9.]+%) \| ([0-9.]+%) \|/i);
+    expect(balancedMatch, 'QUALITY_REPORT should include balanced-mode metrics').toBeTruthy();
+
+    const [, precision, recall, f1] = balancedMatch!;
+    expect(readme).toContain(precision);
+    expect(readme).toContain(recall);
+    expect(readme).toContain(f1);
+  });
+
+  it('docs index lists the shipped demos with .mcp.json files', async () => {
+    const docsIndex = await read(DOCS_README_PATH);
+    const entries = await fs.readdir(DEMOS_DIR, { withFileTypes: true });
+    const shippedDemos = entries
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name);
+
+    const configuredDemos: string[] = [];
+    for (const demo of shippedDemos) {
+      try {
+        await fs.access(path.join(DEMOS_DIR, demo, '.mcp.json'));
+        configuredDemos.push(demo);
+      } catch {
+        // Not a shipped demo vault, ignore.
+      }
+    }
+
+    expect(configuredDemos.length).toBe(7);
+    for (const demo of configuredDemos) {
+      expect(docsIndex).toMatch(new RegExp(`\\[${escapeRegex(demo)}\\]`));
+    }
+  });
+});


### PR DESCRIPTION
## What changed

This PR rewrites the public documentation as a strict truth pass.

It updates the homepage and supporting docs to match the latest checked-in benchmark artifacts, current suite-size facts, and current graph-quality reporting, while removing weaker or stale claims.

It also adds a docs-truth test so benchmark numbers and known stale phrases fail in CI if they drift again.

## Why

The README and docs had accumulated time-sensitive claims and stale counts that no longer matched the current repo state.

That is especially risky for benchmark, test, graph-quality, and setup/runtime copy because those are the first things a new reader uses to judge credibility.

## Scope

Included:
- README proof-first rewrite and badge cleanup
- benchmark/test/runtime claim updates in docs
- removal of unsupported exact latency and comparison claims
- new docs-truth coverage for benchmark/date consistency and stale phrase bans

Not included:
- regenerated benchmark/report JSON artifacts
- code or behavior changes outside documentation/test guardrails

## Validation

- `npx vitest run test/write/docs/tool-counts.test.ts test/write/docs/claims-truth.test.ts test/read/docs/readme-examples.test.ts test/read/docs/demo-vault-assertions.test.ts`
- `npx vitest run test/write/core/git.test.ts test/write/stress/git-concurrency.test.ts`

## Impact

First-time readers get a tighter product page with current proof points.

Maintainers get CI protection against stale benchmark numbers, test counts, and previously removed marketing claims.
