### PR TITLE
chore: release v2.1.0 (flywheel-memory)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5971,13 +5971,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.0.158",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@velvetmonkey/vault-core": "^2.0.158",
+        "@velvetmonkey/vault-core": "^2.1.0",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.0.158",
-  "description": "MCP tools that search, write, and auto-link your Obsidian vault \u2014 and learn from your edits.",
+  "version": "2.1.0",
+  "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -54,7 +54,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.0.158",
+    "@velvetmonkey/vault-core": "^2.1.0",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary
- Bump flywheel-memory to 2.1.0
- Update vault-core dependency to ^2.1.0

Part 2 of minor release 2.1.0.