### PR TITLE
fix: use normalizeTarget(note.path) for backlinks map lookups

### DIFF
--- a/packages/mcp-server/src/core/read/similarity.ts
+++ b/packages/mcp-server/src/core/read/similarity.ts
@@ -10,6 +10,7 @@ import type Database from 'better-sqlite3';
 import type { VaultIndex } from './types.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { normalizeTarget } from './graph.js';
 import {
   findSemanticallySimilar,
   buildEmbeddingsIndex,
@@ -122,8 +123,8 @@ export function findSimilarNotes(
         }
 
         // Backlinks
-        const normalizedTitle = note.title.toLowerCase();
-        const backlinks = index.backlinks.get(normalizedTitle) || [];
+        const normalizedPath = normalizeTarget(note.path);
+        const backlinks = index.backlinks.get(normalizedPath) || [];
         for (const bl of backlinks) {
           linkedPaths.add(bl.source);
         }
@@ -159,8 +160,8 @@ function getLinkedPaths(index: VaultIndex, sourcePath: string): Set<string> {
   }
 
   // Backlinks
-  const normalizedTitle = note.title.toLowerCase();
-  const backlinks = index.backlinks.get(normalizedTitle) || [];
+  const normalizedPath = normalizeTarget(note.path);
+  const backlinks = index.backlinks.get(normalizedPath) || [];
   for (const bl of backlinks) {
     linkedPaths.add(bl.source);
   }

--- a/packages/mcp-server/src/resources/vault.ts
+++ b/packages/mcp-server/src/resources/vault.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { VaultIndex } from '../core/read/types.js';
 import { getFrontmatterSchema } from '../tools/read/frontmatter.js';
+import { normalizeTarget } from '../core/read/graph.js';
 
 /**
  * Register vault resources with the MCP server
@@ -52,8 +53,8 @@ export function registerVaultResources(
       // Count orphans (notes with no backlinks)
       let orphanCount = 0;
       for (const note of index.notes.values()) {
-        const normalizedTitle = note.title.toLowerCase();
-        const backlinks = index.backlinks.get(normalizedTitle);
+        const normalizedPath = normalizeTarget(note.path);
+        const backlinks = index.backlinks.get(normalizedPath);
         if (!backlinks || backlinks.length === 0) {
           orphanCount++;
         }

--- a/packages/mcp-server/src/tools/read/computed.ts
+++ b/packages/mcp-server/src/tools/read/computed.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import matter from 'gray-matter';
 import type { VaultIndex } from '../../core/read/types.js';
+import { normalizeTarget } from '../../core/read/graph.js';
 
 // =============================================================================
 // TYPES
@@ -182,7 +183,7 @@ export async function computeFrontmatter(
       }
 
       case 'backlink_count': {
-        const backlinks = index.backlinks.get(note?.title.toLowerCase() ?? '');
+        const backlinks = index.backlinks.get(normalizeTarget(note?.path ?? ''));
         value = backlinks?.length ?? 0;
         method = 'backlink_index';
         break;

--- a/packages/mcp-server/src/tools/read/graphAnalysis.ts
+++ b/packages/mcp-server/src/tools/read/graphAnalysis.ts
@@ -13,7 +13,7 @@ import type { StateDb } from '@velvetmonkey/vault-core';
 import { getExcludeTags, getExcludeEntities, type FlywheelConfig } from '../../core/read/config.js';
 import { MAX_LIMIT } from '../../core/read/constants.js';
 import { requireIndex } from '../../core/read/indexGuard.js';
-import { findOrphanNotes, findHubNotes } from '../../core/read/graph.js';
+import { findOrphanNotes, findHubNotes, normalizeTarget } from '../../core/read/graph.js';
 import { computeCentralityMetrics, detectCycles } from './graphAdvanced.js';
 
 /** Check if a note path looks like a periodic note (daily, weekly, monthly, quarterly, yearly). */
@@ -262,8 +262,8 @@ export function registerGraphAnalysisTools(
             }
 
             // 4. Backlink count score
-            const normalizedTitle = note.title.toLowerCase();
-            const backlinks = index.backlinks.get(normalizedTitle) || [];
+            const normalizedPath = normalizeTarget(note.path);
+            const backlinks = index.backlinks.get(normalizedPath) || [];
             const backlinkCount = backlinks.length;
             const backlinkScore = backlinkCount === 0 ? 0 : backlinkCount <= 2 ? 0.5 : 1.0;
 

--- a/packages/mcp-server/src/tools/read/health.ts
+++ b/packages/mcp-server/src/tools/read/health.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { VaultIndex } from '../../core/read/types.js';
-import { resolveTarget, getBacklinksForNote, findSimilarEntity, getIndexState, getIndexProgress, getIndexError, type IndexState } from '../../core/read/graph.js';
+import { resolveTarget, getBacklinksForNote, findSimilarEntity, getIndexState, getIndexProgress, getIndexError, normalizeTarget, type IndexState } from '../../core/read/graph.js';
 import { detectPeriodicNotes } from './periodic.js';
 import { getActivitySummary } from './temporal.js';
 import type { FlywheelConfig } from '../../core/read/config.js';
@@ -431,7 +431,7 @@ export function registerHealthTools(
         // Orphan ratio: notes with 0 backlinks (excluding periodic notes)
         let orphanCount = 0;
         for (const note of index.notes.values()) {
-          const bl = index.backlinks.get(note.title.toLowerCase());
+          const bl = index.backlinks.get(normalizeTarget(note.path));
           if (!bl || bl.length === 0) orphanCount++;
         }
         const orphanRatio = 1 - (orphanCount / noteCount);

--- a/packages/mcp-server/src/tools/read/noteIntelligence.ts
+++ b/packages/mcp-server/src/tools/read/noteIntelligence.ts
@@ -134,8 +134,8 @@ export function registerNoteIntelligenceTools(
                 if (m.similarity < 0.3) return false;
                 // Filter out entities whose backing notes have excluded tags
                 if (excludeTags.size > 0) {
-                  const entityNote = index.notes.get(m.entityName.toLowerCase() + '.md')
-                    ?? [...index.notes.values()].find(n => n.title.toLowerCase() === m.entityName.toLowerCase());
+                  const entityPath = index.entities.get(m.entityName.toLowerCase());
+                  const entityNote = entityPath ? index.notes.get(entityPath) : [...index.notes.values()].find(n => n.title.toLowerCase() === m.entityName.toLowerCase());
                   if (entityNote) {
                     const noteTags = Object.keys(entityNote.frontmatter)
                       .filter(k => k === 'tags')

--- a/packages/mcp-server/src/tools/read/schema.ts
+++ b/packages/mcp-server/src/tools/read/schema.ts
@@ -6,6 +6,7 @@
  */
 
 import type { VaultIndex, VaultNote, Backlink } from '../../core/read/types.js';
+import { normalizeTarget } from '../../core/read/graph.js';
 
 // =============================================================================
 // TYPES
@@ -555,9 +556,9 @@ export function findContradictions(
     }
   }
 
-  for (const [entityName, _entityPath] of entitiesToCheck) {
+  for (const [entityName, entityPath] of entitiesToCheck) {
     // Find all notes that link to this entity
-    const backlinks = index.backlinks.get(entityName);
+    const backlinks = index.backlinks.get(normalizeTarget(entityPath));
     if (!backlinks || backlinks.length < 2) continue;
 
     // Get unique source note paths


### PR DESCRIPTION
## Summary

- **7 call sites** were looking up `index.backlinks` by `note.title.toLowerCase()` (filename only, e.g. `p38`) instead of the canonical normalized path key (e.g. `tech/flywheel/roadmap/p38`). This silently returned `undefined` for any note in a subdirectory.
- Vault stats resource reported 1,617/1,629 notes as orphans (99.3%)
- `health_check` vault health score had wrong orphan ratio
- `graph_analysis` immature note detection, `find_similar` exclude-linked filtering, `schema_validate` contradiction detection, and computed `backlink_count` were all broken for nested notes
- Fixed `noteIntelligence.ts` to resolve entities through `index.entities` instead of guessing root-level paths

## Files changed

| File | Fix |
|---|---|
| `resources/vault.ts` | `note.title.toLowerCase()` → `normalizeTarget(note.path)` |
| `tools/read/health.ts` | Same |
| `tools/read/computed.ts` | Same |
| `tools/read/graphAnalysis.ts` | Same |
| `core/read/similarity.ts` | Same (2 locations) |
| `tools/read/schema.ts` | `entityName` → `normalizeTarget(entityPath)` |
| `tools/read/noteIntelligence.ts` | Resolve through `index.entities` instead of guessing path |

## Test plan

- [x] `npm run build` passes
- [x] 2455/2457 tests pass (2 pre-existing failures in package-startup tests)
- [ ] After deploy: read `vault://stats` resource and confirm orphan count drops from 1,617 to a reasonable number

🤖 Generated with [Claude Code](https://claude.com/claude-code)