### PR TITLE
chore: release v2.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,7 +5945,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5971,13 +5971,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@velvetmonkey/vault-core": "^2.1.2",
+        "@velvetmonkey/vault-core": "^2.1.3",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.1.2",
-  "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
+  "version": "2.1.3",
+  "description": "MCP tools that search, write, and auto-link your Obsidian vault \u2014 and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -54,7 +54,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.1.2",
+    "@velvetmonkey/vault-core": "^2.1.3",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary

Bump vault-core + flywheel-memory to 2.1.3.

### Changes since 2.1.2

- fix: use normalizeTarget(note.path) for backlinks map lookups (#119) — 7 call sites were looking up `index.backlinks` by title instead of normalized path, causing broken orphan counts, health scores, maturity detection, and similarity filtering for notes in subdirectories

## Test plan

- [x] `npm run build` passes
- [ ] Publish both packages to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)