### PR TITLE
Fix health telemetry timestamps and add pipeline activity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Controlled by `FLYWHEEL_TOOLS` / `FLYWHEEL_PRESET` env var. Per-tool category ga
 
 **Presets:**
 - **`default`** — 18 tools: search, read, write, tasks, memory
-- **`full`** — All categories (75 tools)
+- **`full`** — All categories (76 tools)
 
 **Composable bundles** (add to presets or each other):
 - **`graph`** — structural analysis, semantic analysis, paths, [[Hub|hubs]], connections, export (11 tools)
@@ -110,7 +110,7 @@ Controlled by `FLYWHEEL_TOOLS` / `FLYWHEEL_PRESET` env var. Per-tool category ga
 - **`memory`** — session memory + brief (2 tools)
 - **`note-ops`** — delete, move, rename, merge (4 tools)
 - **`temporal`** — time-based vault intelligence (4 tools)
-- **`diagnostics`** — vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export (20 tools)
+- **`diagnostics`** — vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status (21 tools)
 **Categories (12):** `search`, `read`, `write`, `graph`, `schema`, `wikilinks`, `corrections`, `tasks`, `memory`, `note-ops`, `temporal`, `diagnostics`
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -122,7 +122,7 @@ Start with `default`, then add what you need:
 | `memory` | 2 | Session memory + brief |
 | `note-ops` | 4 | Delete, move, rename notes, merge entities |
 | `temporal` | 4 | Time-based vault intelligence: get_context_around_date, predict_stale_notes, track_concept_evolution, temporal_summary |
-| `diagnostics` | 20 | Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export |
+| `diagnostics` | 21 | Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status |
 
 #### Recipes
 
@@ -162,7 +162,7 @@ Unknown names are ignored with a warning. If nothing valid is found, falls back 
 | `memory` | 2 | memory, brief |
 | `note-ops` | 4 | vault_delete_note, vault_move_note, vault_rename_note, merge_entities |
 | `temporal` | 4 | get_context_around_date, predict_stale_notes, track_concept_evolution, temporal_summary |
-| `diagnostics` | 20 | health_check, get_vault_stats, get_folder_structure, refresh_index, get_all_entities, get_unlinked_mentions, vault_growth, vault_activity, flywheel_config, server_log, suggest_entity_merges, dismiss_merge_suggestion, vault_init, flywheel_doctor, flywheel_trust_report, flywheel_benchmark, vault_session_history, vault_entity_history, flywheel_learning_report, flywheel_calibration_export |
+| `diagnostics` | 21 | health_check, pipeline_status, get_vault_stats, get_folder_structure, refresh_index, get_all_entities, get_unlinked_mentions, vault_growth, vault_activity, flywheel_config, server_log, suggest_entity_merges, dismiss_merge_suggestion, vault_init, flywheel_doctor, flywheel_trust_report, flywheel_benchmark, vault_session_history, vault_entity_history, flywheel_learning_report, flywheel_calibration_export |
 
 Deprecated aliases (`minimal`, `writer`, `researcher`, `backlinks`, `structure`, `append`, `frontmatter`, `notes`, `orphans`, `hubs`, `paths`, `health`, `analysis`, `git`, `ops`) still work — they resolve to current category names.
 
@@ -181,8 +181,8 @@ Deprecated aliases (`minimal`, `writer`, `researcher`, `backlinks`, `structure`,
 | corrections | 4 | | Yes |
 | note-ops | 4 | | Yes |
 | temporal | 4 | | Yes |
-| diagnostics | 20 | | Yes |
-| **Total** | **75** | **18** | **75** |
+| diagnostics | 21 | | Yes |
+| **Total** | **76** | **18** | **76** |
 
 ### Semantic Embeddings
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,6 @@
 # Tools
 
-75 tools. Most questions only need one: **search**.
+76 tools. Most questions only need one: **search**.
 
 > **Start here:** Most vaults only need `default` (18 tools). Add bundles as you need them — `graph`, `schema`, `wikilinks`, `temporal`, `diagnostics`. See [CONFIGURATION.md](CONFIGURATION.md) for preset recipes.
 
@@ -36,7 +36,7 @@
 | [Move, rename, or merge notes](#organize-notes) | `vault_move_note` | 4 |
 | [Persistent memory](#session-memory) | `memory`, `brief` | 2 |
 | [Analyze temporal patterns](#temporal-analysis) | `get_context_around_date` | 4 |
-| [Check vault health](#vault-health) | `health_check` | 20 |
+| [Check vault health](#vault-health) | `health_check` | 21 |
 | [Automate workflows](#automation) | `policy` | 2 |
 
 ---
@@ -392,7 +392,8 @@ Monitor, configure, and maintain your vault.
 
 | Tool | What it does |
 |------|-------------|
-| `health_check` | Is the server healthy? Vault accessibility, index freshness, recommendations. |
+| `health_check` | Is the server healthy? Vault accessibility, index freshness, recommendations. Pass `mode="summary"` for lightweight polling, `mode="full"` for complete diagnostics. |
+| `pipeline_status` | Live pipeline activity: whether a batch is running, current step, progress, and recent completions. |
 | `get_vault_stats` | How big is your vault? Notes, links, tags, orphans, recent activity. |
 | `get_folder_structure` | Folder tree with note counts. |
 | `refresh_index` | Force a full index rebuild without restarting. |

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -26,7 +26,7 @@ import type { VaultRegistry } from './vault-registry.js';
 //   memory      - Session memory + brief (2 tools)
 //   note-ops    - File management: delete, move, rename, merge (4 tools)
 //   temporal    - Time-based vault intelligence (4 tools)
-//   diagnostics - Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export (20 tools)
+//   diagnostics - Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status (21 tools)
 //
 // Examples:
 //   FLYWHEEL_TOOLS=default                    # 18 tools
@@ -228,8 +228,9 @@ export const TOOL_CATEGORY: Record<string, ToolCategory> = {
   track_concept_evolution: 'temporal',
   temporal_summary: 'temporal',
 
-  // diagnostics (20 tools) -- vault health, stats, config, activity, merges, doctor, trust, benchmark, history, learning report, calibration export
+  // diagnostics (21 tools) -- vault health, stats, config, activity, merges, doctor, trust, benchmark, history, learning report, calibration export, pipeline status
   health_check: 'diagnostics',
+  pipeline_status: 'diagnostics',
   get_vault_stats: 'diagnostics',
   get_folder_structure: 'diagnostics',
   refresh_index: 'diagnostics',

--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -31,7 +31,7 @@ import type { IndexState } from '../graph.js';
 
 // Shared modules
 import { serverLog } from '../../shared/serverLog.js';
-import { createStepTracker, recordIndexEvent, computeEntityDiff } from '../../shared/indexActivity.js';
+import { createStepTracker, recordIndexEvent, computeEntityDiff, type IndexEventTrigger } from '../../shared/indexActivity.js';
 import { exportHubScores } from '../../shared/hubExport.js';
 import { buildRecencyIndex, loadRecencyFromStateDb, saveRecencyToStateDb } from '../../shared/recency.js';
 import { mineCooccurrences, saveCooccurrenceToStateDb } from '../../shared/cooccurrence.js';
@@ -71,6 +71,45 @@ import {
 } from '../../write/wikilinkFeedback.js';
 import { processPendingCorrections } from '../../write/corrections.js';
 import { recomputeEdgeWeights } from '../../write/edgeWeights.js';
+// ── Pipeline Activity (process-local runtime status) ────────────────
+
+/** Total number of steps in the pipeline (used for progress reporting) */
+const PIPELINE_TOTAL_STEPS = 22;
+
+export interface PipelineActivity {
+  busy: boolean;
+  trigger: IndexEventTrigger | null;
+  started_at: number | null;
+  current_step: string | null;
+  completed_steps: number;
+  total_steps: number;
+  pending_events: number;
+  last_completed_at: number | null;
+  last_completed_trigger: IndexEventTrigger | null;
+  last_completed_duration_ms: number | null;
+  last_completed_files: number | null;
+  last_completed_steps: string[];
+}
+
+const pipelineActivity: PipelineActivity = {
+  busy: false,
+  trigger: null,
+  started_at: null,
+  current_step: null,
+  completed_steps: 0,
+  total_steps: PIPELINE_TOTAL_STEPS,
+  pending_events: 0,
+  last_completed_at: null,
+  last_completed_trigger: null,
+  last_completed_duration_ms: null,
+  last_completed_files: null,
+  last_completed_steps: [],
+};
+
+export function getPipelineActivity(): Readonly<PipelineActivity> {
+  return pipelineActivity;
+}
+
 // Re-exported from index.ts — these are module-level functions that update both globals and VaultContext
 export type IndexStateUpdater = (state: IndexState, error?: Error | null) => void;
 export type VaultIndexUpdater = (index: VaultIndex) => void;
@@ -149,12 +188,37 @@ export class PipelineRunner {
   private suggestionResults: Array<{ file: string; top: Array<{ entity: string; score: number; confidence: string }> }> = [];
 
   constructor(private p: PipelineContext) {
-    this.tracker = createStepTracker();
+    const baseTracker = createStepTracker();
+    // Wrap tracker to update pipeline activity on every step transition
+    this.tracker = {
+      steps: baseTracker.steps,
+      start(name: string, input: Record<string, unknown>) {
+        pipelineActivity.current_step = name;
+        baseTracker.start(name, input);
+      },
+      end(output: Record<string, unknown>) {
+        baseTracker.end(output);
+        pipelineActivity.completed_steps = baseTracker.steps.length;
+      },
+      skip(name: string, reason: string) {
+        baseTracker.skip(name, reason);
+        pipelineActivity.completed_steps = baseTracker.steps.length;
+      },
+    };
     this.batchStart = Date.now();
   }
 
   async run(): Promise<void> {
     const { p, tracker } = this;
+
+    // Set pipeline activity to busy
+    pipelineActivity.busy = true;
+    pipelineActivity.trigger = 'watcher';
+    pipelineActivity.started_at = this.batchStart;
+    pipelineActivity.current_step = null;
+    pipelineActivity.completed_steps = 0;
+    pipelineActivity.total_steps = PIPELINE_TOTAL_STEPS;
+    pipelineActivity.pending_events = p.events.length;
 
     try {
       // Step 0.5: Drain deferred proactive queue (before any file processing)
@@ -202,6 +266,16 @@ export class PipelineRunner {
           steps: tracker.steps,
         });
       }
+
+      // Update pipeline activity — mark completed
+      pipelineActivity.busy = false;
+      pipelineActivity.current_step = null;
+      pipelineActivity.last_completed_at = Date.now();
+      pipelineActivity.last_completed_trigger = 'watcher';
+      pipelineActivity.last_completed_duration_ms = duration;
+      pipelineActivity.last_completed_files = p.events.length;
+      pipelineActivity.last_completed_steps = tracker.steps.map(s => s.name);
+
       serverLog('watcher', `Batch complete: ${p.events.length} files, ${duration}ms, ${tracker.steps.length} steps`);
     } catch (err) {
       p.updateIndexState('error', err instanceof Error ? err : new Error(String(err)));
@@ -217,6 +291,16 @@ export class PipelineRunner {
           steps: tracker.steps,
         });
       }
+
+      // Update pipeline activity — mark completed (with failure)
+      pipelineActivity.busy = false;
+      pipelineActivity.current_step = null;
+      pipelineActivity.last_completed_at = Date.now();
+      pipelineActivity.last_completed_trigger = 'watcher';
+      pipelineActivity.last_completed_duration_ms = duration;
+      pipelineActivity.last_completed_files = p.events.length;
+      pipelineActivity.last_completed_steps = tracker.steps.map(s => s.name);
+
       serverLog('watcher', `Failed to rebuild index: ${err instanceof Error ? err.message : err}`, 'error');
     }
   }
@@ -240,6 +324,8 @@ export class PipelineRunner {
       };
       const batchResult = await processBatch(vaultIndex, p.vp, absoluteBatch);
       this.hasEntityRelevantChanges = batchResult.hasEntityRelevantChanges;
+      // Update builtAt so freshness checks reflect the incremental update
+      vaultIndex.builtAt = new Date();
       serverLog('watcher', `Incremental: ${batchResult.successful}/${batchResult.total} files in ${batchResult.durationMs}ms`);
     }
     p.updateIndexState('ready');

--- a/packages/mcp-server/src/core/shared/indexActivity.ts
+++ b/packages/mcp-server/src/core/shared/indexActivity.ts
@@ -183,6 +183,26 @@ export function computeEntityDiff(
 }
 
 /**
+ * Get most recent successful index event of any trigger type
+ */
+export function getLastSuccessfulEvent(stateDb: StateDb): IndexEvent | null {
+  const row = stateDb.db.prepare(
+    'SELECT * FROM index_events WHERE success = 1 ORDER BY timestamp DESC LIMIT 1'
+  ).get() as RawEventRow | undefined;
+  return row ? rowToEvent(row) : null;
+}
+
+/**
+ * Get most recent event of a specific trigger type
+ */
+export function getLastEventByTrigger(stateDb: StateDb, trigger: IndexEventTrigger): IndexEvent | null {
+  const row = stateDb.db.prepare(
+    'SELECT * FROM index_events WHERE trigger = ? AND success = 1 ORDER BY timestamp DESC LIMIT 1'
+  ).get(trigger) as RawEventRow | undefined;
+  return row ? rowToEvent(row) : null;
+}
+
+/**
  * Get recent index events
  */
 export function getRecentIndexEvents(stateDb: StateDb, limit: number = 20): IndexEvent[] {

--- a/packages/mcp-server/src/tools/read/health.ts
+++ b/packages/mcp-server/src/tools/read/health.ts
@@ -11,7 +11,8 @@ import { detectPeriodicNotes } from './periodic.js';
 import { getActivitySummary } from './temporal.js';
 import type { FlywheelConfig } from '../../core/read/config.js';
 import { SCHEMA_VERSION, type StateDb } from '@velvetmonkey/vault-core';
-import { getRecentIndexEvents, getRecentPipelineEvent, type PipelineStep } from '../../core/shared/indexActivity.js';
+import { getRecentIndexEvents, getRecentPipelineEvent, getLastSuccessfulEvent, getLastEventByTrigger, type PipelineStep } from '../../core/shared/indexActivity.js';
+import { getPipelineActivity } from '../../core/read/watch/pipeline.js';
 import { getFTS5State } from '../../core/read/fts5.js';
 import { hasEmbeddingsIndex, isEmbeddingsBuilding, getEmbeddingsCount, getActiveModelId, diagnoseEmbeddings } from '../../core/read/embeddings.js';
 import { isTaskCacheReady, isTaskCacheBuilding } from '../../core/read/taskCache.js';
@@ -135,6 +136,21 @@ export function registerHealthTools(
       .describe('Current file watcher state'),
     watcher_pending: z.coerce.number().optional()
       .describe('Number of pending file events in the watcher queue'),
+    last_index_activity_at: z.number().optional()
+      .describe('Epoch ms of latest successful index event (any trigger)'),
+    last_index_activity_ago_seconds: z.coerce.number().optional()
+      .describe('Seconds since last successful index event'),
+    last_full_rebuild_at: z.number().optional()
+      .describe('Epoch ms of latest startup_build or manual_refresh event'),
+    last_watcher_batch_at: z.number().optional()
+      .describe('Epoch ms of latest watcher batch event'),
+    pipeline_activity: z.object({
+      busy: z.boolean(),
+      current_step: z.string().nullable(),
+      started_at: z.number().nullable(),
+      progress: z.string().nullable(),
+      last_completed_ago_seconds: z.number().nullable(),
+    }).optional().describe('Live pipeline activity state'),
     dead_link_count: z.coerce.number().describe('Total number of broken/dead wikilinks across the vault'),
     top_dead_link_targets: z.array(z.object({
       target: z.string().describe('The dead link target'),
@@ -222,6 +238,17 @@ export function registerHealthTools(
     tasks_building: boolean;
     watcher_state?: 'starting' | 'ready' | 'rebuilding' | 'dirty' | 'error';
     watcher_pending?: number;
+    last_index_activity_at?: number;
+    last_index_activity_ago_seconds?: number;
+    last_full_rebuild_at?: number;
+    last_watcher_batch_at?: number;
+    pipeline_activity?: {
+      busy: boolean;
+      current_step: string | null;
+      started_at: number | null;
+      progress: string | null;
+      last_completed_ago_seconds: number | null;
+    };
     dead_link_count: number;
     top_dead_link_targets: Array<{ target: string; mention_count: number }>;
     sweep?: SweepResults;
@@ -233,14 +260,19 @@ export function registerHealthTools(
     {
       title: 'Health Check',
       description:
-        'Check MCP server health status. Returns vault accessibility, index freshness, and recommendations. Use at session start to verify MCP is working correctly.',
-      inputSchema: {},
+        'Check MCP server health status. Returns vault accessibility, index freshness, and recommendations. Use at session start to verify MCP is working correctly. ' +
+        'Pass mode="summary" (default) for lightweight polling or mode="full" for complete diagnostics.',
+      inputSchema: {
+        mode: z.enum(['summary', 'full']).optional().default('summary')
+          .describe('Output mode: "summary" omits config, periodic notes, dead links, sweep, and recent pipelines; "full" returns everything'),
+      },
       outputSchema: HealthCheckOutputSchema,
     },
-    async (): Promise<{
+    async ({ mode = 'summary' }): Promise<{
       content: Array<{ type: 'text'; text: string }>;
       structuredContent: HealthCheckOutput;
     }> => {
+      const isFull = mode === 'full';
       const index = getIndex();
       const vaultPath = getVaultPath();
       const recommendations: string[] = [];
@@ -279,8 +311,27 @@ export function registerHealthTools(
 
       // Check index status
       const indexBuilt = indexState === 'ready' && index !== undefined && index.notes !== undefined;
-      const indexAge = indexBuilt && index.builtAt
-        ? Math.floor((Date.now() - index.builtAt.getTime()) / 1000)
+
+      // Canonical timestamps from index_events
+      let lastIndexActivityAt: number | undefined;
+      let lastFullRebuildAt: number | undefined;
+      let lastWatcherBatchAt: number | undefined;
+      if (stateDb) {
+        try {
+          const lastAny = getLastSuccessfulEvent(stateDb);
+          if (lastAny) lastIndexActivityAt = lastAny.timestamp;
+          const lastBuild = getLastEventByTrigger(stateDb, 'startup_build');
+          const lastManual = getLastEventByTrigger(stateDb, 'manual_refresh');
+          lastFullRebuildAt = Math.max(lastBuild?.timestamp ?? 0, lastManual?.timestamp ?? 0) || undefined;
+          const lastWatcher = getLastEventByTrigger(stateDb, 'watcher');
+          if (lastWatcher) lastWatcherBatchAt = lastWatcher.timestamp;
+        } catch { /* ignore */ }
+      }
+
+      // Use last index activity for freshness (not builtAt which may lag)
+      const freshnessTimestamp = lastIndexActivityAt ?? (indexBuilt && index.builtAt ? index.builtAt.getTime() : undefined);
+      const indexAge = freshnessTimestamp
+        ? Math.floor((Date.now() - freshnessTimestamp) / 1000)
         : -1;
       const indexStale = indexBuilt && indexAge > STALE_THRESHOLD_SECONDS;
 
@@ -318,9 +369,9 @@ export function registerHealthTools(
         status = 'healthy';
       }
 
-      // Detect periodic note conventions (only when index is ready)
+      // Detect periodic note conventions (only when index is ready, full mode only)
       let periodicNotes: PeriodicNoteInfo[] | undefined;
-      if (indexBuilt) {
+      if (isFull && indexBuilt) {
         const types = ['daily', 'weekly', 'monthly', 'quarterly', 'yearly'] as const;
         periodicNotes = types.map(type => {
           const result = detectPeriodicNotes(index, type);
@@ -335,11 +386,14 @@ export function registerHealthTools(
         }).filter(p => p.detected);
       }
 
-      // Include config info
-      const config = getConfig();
-      const configInfo = Object.keys(config).length > 0
-        ? config as unknown as Record<string, unknown>
-        : undefined;
+      // Include config info (full mode only)
+      let configInfo: Record<string, unknown> | undefined;
+      if (isFull) {
+        const config = getConfig();
+        configInfo = Object.keys(config).length > 0
+          ? config as unknown as Record<string, unknown>
+          : undefined;
+      }
 
       // Get last rebuild event from StateDb
       let lastRebuild: HealthCheckOutput['last_rebuild'];
@@ -380,32 +434,35 @@ export function registerHealthTools(
           // Ignore errors reading pipeline data
         }
 
-        // Recent pipeline events (last 5 with steps)
-        try {
-          const events = getRecentIndexEvents(stateDb, 10)
-            .filter(e => e.steps && e.steps.length > 0)
-            .slice(0, 5);
-          if (events.length > 0) {
-            recentPipelines = events.map(e => ({
-              timestamp: e.timestamp,
-              trigger: e.trigger,
-              duration_ms: e.duration_ms,
-              files_changed: e.files_changed,
-              changed_paths: e.changed_paths,
-              steps: e.steps!,
-            }));
+        // Recent pipeline events (last 5 with steps) — full mode only
+        if (isFull) {
+          try {
+            const events = getRecentIndexEvents(stateDb, 10)
+              .filter(e => e.steps && e.steps.length > 0)
+              .slice(0, 5);
+            if (events.length > 0) {
+              recentPipelines = events.map(e => ({
+                timestamp: e.timestamp,
+                trigger: e.trigger,
+                duration_ms: e.duration_ms,
+                files_changed: e.files_changed,
+                changed_paths: e.changed_paths,
+                steps: e.steps!,
+              }));
+            }
+          } catch {
+            // Ignore errors reading recent pipeline data
           }
-        } catch {
-          // Ignore errors reading recent pipeline data
         }
       }
 
       const ftsState = getFTS5State();
 
-      // Dead link scan — lightweight, uses already-parsed index outlinks
+      // Dead link scan — full mode only (iterates all outlinks)
       let deadLinkCount = 0;
-      const deadTargetCounts = new Map<string, number>();
-      if (indexBuilt) {
+      let topDeadLinkTargets: Array<{ target: string; mention_count: number }> = [];
+      if (isFull && indexBuilt) {
+        const deadTargetCounts = new Map<string, number>();
         for (const note of index.notes.values()) {
           for (const link of note.outlinks) {
             if (!resolveTarget(index, link.target)) {
@@ -415,11 +472,11 @@ export function registerHealthTools(
             }
           }
         }
+        topDeadLinkTargets = Array.from(deadTargetCounts.entries())
+          .map(([target, mention_count]) => ({ target, mention_count }))
+          .sort((a, b) => b.mention_count - a.mention_count)
+          .slice(0, 5);
       }
-      const topDeadLinkTargets = Array.from(deadTargetCounts.entries())
-        .map(([target, mention_count]) => ({ target, mention_count }))
-        .sort((a, b) => b.mention_count - a.mention_count)
-        .slice(0, 5);
 
       // Compute vault health score (0-100)
       let vault_health_score = 0;
@@ -469,6 +526,20 @@ export function registerHealthTools(
         );
       }
 
+      // Pipeline activity (always included — lightweight process-local read)
+      const activity = getPipelineActivity();
+      const pipelineActivity = {
+        busy: activity.busy,
+        current_step: activity.current_step,
+        started_at: activity.started_at,
+        progress: activity.busy && activity.total_steps > 0
+          ? `${activity.completed_steps}/${activity.total_steps} steps`
+          : null,
+        last_completed_ago_seconds: activity.last_completed_at
+          ? Math.floor((Date.now() - activity.last_completed_at) / 1000)
+          : null,
+      };
+
       const output: HealthCheckOutput = {
         status,
         vault_health_score,
@@ -496,14 +567,20 @@ export function registerHealthTools(
         embeddings_ready: hasEmbeddingsIndex(),
         embeddings_count: getEmbeddingsCount(),
         embedding_model: hasEmbeddingsIndex() ? getActiveModelId() : undefined,
-        embedding_diagnosis: hasEmbeddingsIndex() ? diagnoseEmbeddings(vaultPath) : undefined,
+        embedding_diagnosis: isFull && hasEmbeddingsIndex() ? diagnoseEmbeddings(vaultPath) : undefined,
         tasks_ready: isTaskCacheReady(),
         tasks_building: isTaskCacheBuilding(),
         watcher_state: getWatcherStatus()?.state,
         watcher_pending: getWatcherStatus()?.pendingEvents,
+        last_index_activity_at: lastIndexActivityAt,
+        last_index_activity_ago_seconds: lastIndexActivityAt
+          ? Math.floor((Date.now() - lastIndexActivityAt) / 1000) : undefined,
+        last_full_rebuild_at: lastFullRebuildAt,
+        last_watcher_batch_at: lastWatcherBatchAt,
+        pipeline_activity: pipelineActivity,
         dead_link_count: deadLinkCount,
         top_dead_link_targets: topDeadLinkTargets,
-        sweep: getSweepResults() ?? undefined,
+        sweep: isFull ? (getSweepResults() ?? undefined) : undefined,
         recommendations,
       };
 
@@ -515,6 +592,69 @@ export function registerHealthTools(
           },
         ],
         structuredContent: output,
+      };
+    }
+  );
+
+  // pipeline_status — live pipeline activity surface
+  server.registerTool(
+    'pipeline_status',
+    {
+      title: 'Pipeline Status',
+      description:
+        'Live pipeline activity: whether a batch is running, current step, and recent completions. ' +
+        'Lightweight process-local read — no DB queries unless detail=true.',
+      inputSchema: {
+        detail: z.boolean().optional().default(false)
+          .describe('Include per-step timings for recent runs'),
+      },
+    },
+    async ({ detail = false }): Promise<{
+      content: Array<{ type: 'text'; text: string }>;
+    }> => {
+      const activity = getPipelineActivity();
+      const now = Date.now();
+
+      const output: Record<string, unknown> = {
+        busy: activity.busy,
+        trigger: activity.trigger,
+        started_at: activity.started_at,
+        age_ms: activity.busy && activity.started_at ? now - activity.started_at : null,
+        current_step: activity.current_step,
+        progress: activity.busy && activity.total_steps > 0
+          ? `${activity.completed_steps}/${activity.total_steps} steps`
+          : null,
+        pending_events: activity.pending_events,
+        last_completed: activity.last_completed_at ? {
+          at: activity.last_completed_at,
+          ago_seconds: Math.floor((now - activity.last_completed_at) / 1000),
+          trigger: activity.last_completed_trigger,
+          duration_ms: activity.last_completed_duration_ms,
+          files: activity.last_completed_files,
+          steps: activity.last_completed_steps,
+        } : null,
+      };
+
+      if (detail) {
+        const stateDb = getStateDb();
+        if (stateDb) {
+          try {
+            const events = getRecentIndexEvents(stateDb, 10)
+              .filter(e => e.steps && e.steps.length > 0)
+              .slice(0, 5);
+            output.recent_runs = events.map(e => ({
+              timestamp: e.timestamp,
+              trigger: e.trigger,
+              duration_ms: e.duration_ms,
+              files_changed: e.files_changed,
+              steps: e.steps,
+            }));
+          } catch { /* ignore */ }
+        }
+      }
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
       };
     }
   );
@@ -819,22 +959,33 @@ export function registerHealthTools(
         checks.push({ name: 'vault_access', status: 'error', detail: `Vault not accessible at ${vaultPath}`, fix: 'Check PROJECT_PATH environment variable and directory permissions' });
       }
 
-      // 3. Index state
+      // 3. Index activity freshness (uses index_events, not builtAt)
       const indexState = getIndexState();
       const indexBuilt = indexState === 'ready' && index?.notes !== undefined;
       if (indexState === 'ready' && indexBuilt) {
-        const age = Math.floor((Date.now() - index.builtAt.getTime()) / 1000);
-        if (age > STALE_THRESHOLD_SECONDS) {
-          checks.push({ name: 'index_freshness', status: 'warning', detail: `Index is ${Math.floor(age / 60)} minutes old`, fix: 'Run refresh_index to rebuild' });
-        } else {
-          checks.push({ name: 'index_freshness', status: 'ok', detail: `Index built ${age}s ago, ${index.notes.size} notes, ${index.entities.size} entities` });
+        let activityAge: number | null = null;
+        if (stateDb) {
+          try {
+            const lastEvt = getLastSuccessfulEvent(stateDb);
+            if (lastEvt) activityAge = Math.floor((Date.now() - lastEvt.timestamp) / 1000);
+          } catch { /* ignore */ }
         }
+        // Fall back to builtAt if no events recorded yet
+        const age = activityAge ?? Math.floor((Date.now() - index.builtAt.getTime()) / 1000);
+        if (age > STALE_THRESHOLD_SECONDS) {
+          checks.push({ name: 'index_activity', status: 'warning', detail: `Last index activity ${Math.floor(age / 60)} minutes ago`, fix: 'Run refresh_index to rebuild' });
+        } else {
+          checks.push({ name: 'index_activity', status: 'ok', detail: `Last activity ${age}s ago, ${index.notes.size} notes, ${index.entities.size} entities` });
+        }
+        // Separate snapshot age check (informational only)
+        const snapshotAge = Math.floor((Date.now() - index.builtAt.getTime()) / 1000);
+        checks.push({ name: 'index_snapshot_age', status: 'ok', detail: `In-memory snapshot built ${snapshotAge}s ago` });
       } else if (indexState === 'building') {
         const progress = getIndexProgress();
-        checks.push({ name: 'index_freshness', status: 'warning', detail: `Index building (${progress.parsed}/${progress.total} files)` });
+        checks.push({ name: 'index_activity', status: 'warning', detail: `Index building (${progress.parsed}/${progress.total} files)` });
       } else {
         const err = getIndexError();
-        checks.push({ name: 'index_freshness', status: 'error', detail: `Index in ${indexState} state${err ? ': ' + err.message : ''}`, fix: 'Run refresh_index' });
+        checks.push({ name: 'index_activity', status: 'error', detail: `Index in ${indexState} state${err ? ': ' + err.message : ''}`, fix: 'Run refresh_index' });
       }
 
       // 4. Embedding coverage

--- a/packages/mcp-server/test/write/docs/tool-counts.test.ts
+++ b/packages/mcp-server/test/write/docs/tool-counts.test.ts
@@ -217,6 +217,7 @@ describe('Tool Count Verification', () => {
         'flywheel_learning_report',
         'flywheel_calibration_export',
         'export_graph',
+        'pipeline_status',
       ]);
 
       for (const tool of toolNames) {


### PR DESCRIPTION
## Summary
- **Fix stale-false-positives**: `index_age_seconds` was computed from `index.builtAt` which only updated on full builds, not incremental watcher batches. Now `builtAt` updates after every successful batch, and freshness uses event-based `last_index_activity_at`.
- **Add canonical timestamps**: `last_index_activity_at`, `last_full_rebuild_at`, `last_watcher_batch_at` replace the ambiguous `last_rebuild` (kept for backward compat).
- **Add `pipeline_status` tool and `pipeline_activity` field**: Live step-level visibility into watcher batches — busy state, current step, progress, last completed run.
- **Add `mode` param to `health_check`**: `summary` (default) omits config, periodic notes, dead links, sweep, embedding diagnosis, recent pipelines for lighter polling. `full` returns everything.
- **Fix `flywheel_doctor`**: `index_freshness` → `index_activity` check using event-based timestamps, plus separate `index_snapshot_age` informational check.

## Test plan
- [x] `npm run lint` passes (all 3 workspaces)
- [x] `npm run build` passes
- [x] `npx vitest run` — 2499/2499 tests pass (including updated tool-counts)
- [ ] Manual: edit vault file → `health_check` shows `index_age_seconds < 5` after watcher batch
- [ ] Manual: `pipeline_status` shows busy/current_step during batch, completed summary after
- [ ] Manual: `health_check` with no args omits config/sweep; `mode=full` includes them
- [ ] Manual: `flywheel_doctor` no longer warns stale after watcher batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)