### PR TITLE
fix: tighten wikilink scoring for zero-content-evidence entities

### DIFF
--- a/packages/mcp-server/src/core/shared/types.ts
+++ b/packages/mcp-server/src/core/shared/types.ts
@@ -166,6 +166,8 @@ export interface SuggestionConfig {
   contentRelevanceFloor: number;
   /** Maximum score allowed when content relevance stays below the configured floor */
   noRelevanceCap: number;
+  /** Minimum cooccurrence boost required for graph-only entities (no content overlap) to qualify */
+  minCooccurrenceGate: number;
 }
 
 /**

--- a/packages/mcp-server/src/core/write/wikilinks.ts
+++ b/packages/mcp-server/src/core/write/wikilinks.ts
@@ -849,6 +849,7 @@ const STRICTNESS_CONFIGS: Record<StrictnessMode, SuggestionConfig> = {
     fuzzyMatchBonus: 2,        // Low fuzzy bonus — supplementary signal only
     contentRelevanceFloor: 5,
     noRelevanceCap: 12,
+    minCooccurrenceGate: 6,
   },
   balanced: {
     minWordLength: 3,
@@ -859,7 +860,8 @@ const STRICTNESS_CONFIGS: Record<StrictnessMode, SuggestionConfig> = {
     exactMatchBonus: 10,       // Standard bonus for exact matches
     fuzzyMatchBonus: 4,        // Moderate fuzzy bonus
     contentRelevanceFloor: 5,
-    noRelevanceCap: 15,
+    noRelevanceCap: 10,
+    minCooccurrenceGate: 5,
   },
   aggressive: {
     minWordLength: 3,
@@ -871,6 +873,7 @@ const STRICTNESS_CONFIGS: Record<StrictnessMode, SuggestionConfig> = {
     fuzzyMatchBonus: 5,        // Higher fuzzy bonus — discovery mode
     contentRelevanceFloor: 3,
     noRelevanceCap: 18,
+    minCooccurrenceGate: 3,
   },
 };
 
@@ -1679,9 +1682,8 @@ export async function suggestRelatedLinks(
             contentTokens.has(token) || contentStems.has(stem(token))
           );
 
-          // Strong co-occurrence: boost ≥ 4 means at least 2 distinct co-occurring
-          // partners in the current note (each partner capped at ~3 boost)
-          const strongCooccurrence = boost >= 3;
+          // Requires stronger graph signal to admit entities with no content overlap
+          const strongCooccurrence = boost >= config.minCooccurrenceGate;
 
           if (!hasContentOverlap && !strongCooccurrence) {
             continue;  // Skip entities with zero content relevance and weak co-occurrence

--- a/packages/mcp-server/test/write/core/wikilinks.test.ts
+++ b/packages/mcp-server/test/write/core/wikilinks.test.ts
@@ -2407,7 +2407,52 @@ describe('scoring guardrails', () => {
     expect(arma).toBeDefined();
     expect(arma!.breakdown.contentMatch).toBe(0);
     expect(arma!.breakdown.fuzzyMatch).toBe(0);
-    expect(arma!.totalScore).toBe(15);
+    expect(arma!.totalScore).toBe(10);
+  });
+
+  it('weak cooccurrence entity excluded when below gate', async () => {
+    createEntityCacheInStateDb(stateDb, tempVault, {
+      people: ['Alex Johnson'],
+      other: ['Zen Internet'],
+    });
+
+    await initializeEntityIndex(tempVault);
+
+    // Craft cooccurrence with NPMI ~0.31 -> boost = round(0.31 * 12) = 4
+    // This passes old gate (>= 3) but fails new gate (>= 5 in balanced)
+    const coocIndex: CooccurrenceIndex = {
+      associations: {
+        'Alex Johnson': new Map([['Zen Internet', 3]]),
+        'Zen Internet': new Map([['Alex Johnson', 3]]),
+      },
+      minCount: 0.5,
+      documentFrequency: new Map([
+        ['Alex Johnson', 10],
+        ['Zen Internet', 10],
+      ]),
+      totalNotesScanned: 100,
+      _metadata: {
+        generated_at: new Date().toISOString(),
+        total_associations: 2,
+        notes_scanned: 100,
+      },
+    };
+    saveCooccurrenceToStateDb(stateDb, coocIndex);
+    setCooccurrenceIndex(coocIndex);
+
+    const result = await suggestRelatedLinks('Met with Alex Johnson to discuss the project.', {
+      strictness: 'balanced',
+      detail: true,
+    });
+
+    // Content-matched entity should be suggested with score above noRelevanceCap
+    const alex = result.detailed?.find(e => e.entity === 'Alex Johnson');
+    expect(alex).toBeDefined();
+    expect(alex!.breakdown.contentMatch).toBeGreaterThan(0);
+    expect(alex!.totalScore).toBeGreaterThan(10);
+
+    // Weak cooccurrence entity (boost ~4 < gate 5) should be excluded entirely
+    expect(result.suggestions).not.toContain('Zen Internet');
   });
 
   it('uses inferred categories to boost uncategorized entities', async () => {


### PR DESCRIPTION
## Summary

- Lower balanced `noRelevanceCap` (15→10) so graph-only entities can't outscore a single exact content match
- Extract cooccurrence gate threshold into per-mode `minCooccurrenceGate` config field (conservative: 6, balanced: 5, aggressive: 3), replacing hardcoded `boost >= 3`
- Blocks weak single-partner cooccurrence signals (boost 3-4) from surfacing irrelevant entities on unrelated notes

## Test plan

- [x] Updated existing cap test assertion (15→10)
- [x] Added new test: weak cooccurrence entity (boost ~4) excluded when below gate
- [x] 192/192 wikilinks tests pass
- [x] 15/15 scoring layers F1 ablation tests pass — no regression
- [ ] Run `flywheel_calibration_export` before/after to verify survival rates
- [ ] Spot-check Arma Reforger, Zen Internet, HiringCafe no longer appear on unrelated notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)