### PR TITLE
chore: add missing demo entity notes for carter-strategy

### DIFF
--- a/demos/carter-strategy/team/Emily Chen.md
+++ b/demos/carter-strategy/team/Emily Chen.md
@@ -1,0 +1,36 @@
+---
+type: person
+aliases:
+  - Emily
+role: Data Manager
+company: "[[Acme Corp]]"
+email: emily.chen@acmecorp.com
+---
+# [[Emily Chen]]
+
+## Overview
+
+Data Manager at [[Acme Corp]]. Day-to-day contact for the [[Acme Data Migration]] project, responsible for production sign-off and data validation.
+
+## Role
+
+- **Title**: Data Manager
+- **Company**: [[Acme Corp]]
+- **Relationship**: Day-to-day project contact
+
+## Engagement History
+
+| Project | Role | Period |
+|---------|------|--------|
+| [[Acme Data Migration]] | Data validation & production sign-off | Oct 2025 - present |
+
+## Notes
+
+- Responsible for production access sign-off before cutover
+- Key contact for data quality and validation requirements
+- [[Sarah Mitchell]] wants her involved in scoping the [[Acme Analytics Add-on]] after cutover
+- Works alongside [[James Rodriguez]] on the Acme technical team
+
+---
+
+*Last updated: 2026-03-20*

--- a/demos/carter-strategy/team/James Rodriguez.md
+++ b/demos/carter-strategy/team/James Rodriguez.md
@@ -1,0 +1,37 @@
+---
+type: person
+aliases:
+  - James
+role: IT Director
+company: "[[Acme Corp]]"
+email: james.rodriguez@acmecorp.com
+phone: "+1 555-0198"
+---
+# [[James Rodriguez]]
+
+## Overview
+
+IT Director at [[Acme Corp]]. Technical lead for the [[Acme Data Migration]] project, responsible for infrastructure and legacy system decommissioning.
+
+## Role
+
+- **Title**: IT Director
+- **Company**: [[Acme Corp]]
+- **Relationship**: Technical counterpart since project kickoff, Oct 2025
+
+## Engagement History
+
+| Project | Role | Period |
+|---------|------|--------|
+| [[Acme Data Migration]] | Technical lead (client side) | Oct 2025 - present |
+
+## Notes
+
+- Owns the legacy Oracle decommission timeline — awaiting IT confirmation
+- Key escalation path for infrastructure decisions
+- Works closely with [[Marcus Webb]] on cutover planning
+- Reports to [[Sarah Mitchell]]
+
+---
+
+*Last updated: 2026-03-20*

--- a/demos/carter-strategy/team/Tom Huang.md
+++ b/demos/carter-strategy/team/Tom Huang.md
@@ -1,0 +1,36 @@
+---
+type: person
+aliases:
+  - Tom
+role: VP Engineering
+company: "[[Nexus Health]]"
+email: tom.huang@nexushealth.io
+---
+# [[Tom Huang]]
+
+## Overview
+
+VP of Engineering at [[Nexus Health]]. Technical contact for the proposed [[Nexus Health Cloud Assessment]] engagement.
+
+## Role
+
+- **Title**: VP Engineering
+- **Company**: [[Nexus Health]]
+- **Relationship**: Technical contact since discovery call, Mar 2026
+
+## Engagement History
+
+| Project | Role | Period |
+|---------|------|--------|
+| [[Nexus Health Cloud Assessment]] | Technical sponsor | Proposed — pending start |
+
+## Notes
+
+- Confirmed [[Nexus Health]] wants to proceed with the Cloud Assessment
+- Waiting for [[Leila Farouk]] to become available (April 2026)
+- Key decision-maker on infrastructure and engineering at Nexus
+- Reports to [[Dr. Anika Patel]]
+
+---
+
+*Last updated: 2026-03-20*


### PR DESCRIPTION
## Summary
- Add 3 entity notes missing from the carter-strategy demo vault: James Rodriguez, Emily Chen, Tom Huang
- Referenced in demo video script (Beats 1-4) but had no vault files, blocking auto-wikilink suggestions

## Test plan
- [ ] run-demo-test.sh --seed-only completes
- [ ] Auto-wikilinks fire for all three names during demo playthrough