### PR TITLE
feat: pool HTTP McpServers to avoid per-request tool re-registration

### DIFF
--- a/packages/mcp-server/src/core/shared/serverLog.ts
+++ b/packages/mcp-server/src/core/shared/serverLog.ts
@@ -10,7 +10,7 @@ export type LogLevel = 'info' | 'warn' | 'error';
 export type LogComponent =
   | 'server' | 'index' | 'fts5' | 'semantic'
   | 'tasks' | 'watcher' | 'statedb' | 'config'
-  | 'git' | 'hints' | 'policy' | 'sweep' | 'backup';
+  | 'git' | 'hints' | 'policy' | 'sweep' | 'backup' | 'http';
 
 export interface LogEntry {
   ts: number;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { performance } from 'node:perf_hooks';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -209,6 +210,48 @@ function createConfiguredServer(): McpServer {
   applyToolGating(s, enabledCategories, ctx.getStateDb, vaultRegistry, ctx.getVaultPath, buildVaultCallbacks());
   registerAllTools(s, ctx);
   return s;
+}
+
+// ============================================================================
+// HTTP McpServer Pool
+// ============================================================================
+
+const HTTP_POOL_SIZE = 4;
+const httpServerPool: McpServer[] = [];
+let httpRequestCount = 0;
+let httpServerCreateCount = 0;
+let httpServerReuseCount = 0;
+let httpServerDiscardCount = 0;
+
+function acquireHttpServer(): McpServer {
+  const pooled = httpServerPool.pop();
+  if (pooled) {
+    httpServerReuseCount++;
+    return pooled;
+  }
+  httpServerCreateCount++;
+  return createConfiguredServer();
+}
+
+function releaseHttpServer(s: McpServer): void {
+  if (httpServerPool.length < HTTP_POOL_SIZE) {
+    httpServerPool.push(s);
+  }
+  // else silently discard — pool is full
+}
+
+function discardHttpServer(_s: McpServer): void {
+  httpServerDiscardCount++;
+  // Do not requeue — instance may be in a bad state
+}
+
+/** Invalidate all pooled servers (e.g. after secondary vault registration). */
+export function invalidateHttpPool(): void {
+  const count = httpServerPool.length;
+  httpServerPool.length = 0;
+  if (count > 0) {
+    serverLog('http', `Pool invalidated: discarded ${count} cached server(s)`);
+  }
 }
 
 // ============================================================================
@@ -557,17 +600,59 @@ async function main() {
 
     const app = createMcpExpressApp({ host: httpHost });
 
-    // Stateless HTTP — per-request McpServer + StreamableHTTPServerTransport
+    // HTTP — pooled McpServer + per-request StreamableHTTPServerTransport
     app.post('/mcp', async (req: any, res: any) => {
-      const httpServer = createConfiguredServer();
+      const t0 = performance.now();
+      const httpServer = acquireHttpServer();
+      const acquireMs = performance.now() - t0;
+
       const httpTransport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-      await httpServer.connect(httpTransport);
-      await httpTransport.handleRequest(req, res, req.body);
-      res.on('close', () => { httpTransport.close(); httpServer.close(); });
+      let cleanExit = false;
+      try {
+        await httpServer.connect(httpTransport);
+        const connectMs = performance.now() - t0;
+        httpRequestCount++;
+        await httpTransport.handleRequest(req, res, req.body);
+        cleanExit = true;
+        const totalMs = performance.now() - t0;
+        if (totalMs > 25 || acquireMs > 5 || (connectMs - acquireMs) > 5) {
+          serverLog('http', `request: acquire=${acquireMs.toFixed(1)}ms connect=${(connectMs - acquireMs).toFixed(1)}ms total=${totalMs.toFixed(1)}ms`);
+        }
+      } catch (err) {
+        serverLog('http', `request error: ${err instanceof Error ? err.message : err}`, 'error');
+      } finally {
+        try { await httpTransport.close(); } catch { /* best-effort */ }
+        try { await httpServer.close(); } catch { /* best-effort */ }
+        if (cleanExit) {
+          releaseHttpServer(httpServer);
+        } else {
+          discardHttpServer(httpServer);
+        }
+      }
     });
 
     app.get('/health', (_req: any, res: any) => {
-      const health: Record<string, unknown> = { status: 'ok', version: pkg.version, vault: vaultPath };
+      const mem = process.memoryUsage();
+      const health: Record<string, unknown> = {
+        status: 'ok',
+        version: pkg.version,
+        vault: vaultPath,
+        uptime_s: Math.round(process.uptime()),
+        memory: {
+          rss_mb: Math.round(mem.rss / 1048576),
+          heap_used_mb: Math.round(mem.heapUsed / 1048576),
+          heap_total_mb: Math.round(mem.heapTotal / 1048576),
+          external_mb: Math.round(mem.external / 1048576),
+        },
+        http: {
+          requests: httpRequestCount,
+          pool_available: httpServerPool.length,
+          pool_max: HTTP_POOL_SIZE,
+          servers_created: httpServerCreateCount,
+          servers_reused: httpServerReuseCount,
+          servers_discarded: httpServerDiscardCount,
+        },
+      };
       if (vaultRegistry?.isMultiVault) {
         health.vaults = vaultRegistry.getVaultNames();
       }
@@ -596,6 +681,7 @@ async function main() {
         try {
           const ctx = await initializeVault(vc.name, vc.path);
           vaultRegistry!.addContext(ctx);
+          invalidateHttpPool();
           loadVaultCooccurrence(ctx);
           activateVault(ctx);
           await bootVault(ctx, startTime);

--- a/packages/mcp-server/test/write/core/http-pool.test.ts
+++ b/packages/mcp-server/test/write/core/http-pool.test.ts
@@ -1,0 +1,321 @@
+/**
+ * T9: HTTP McpServer Pool Tests
+ *
+ * Tests for pooling semantics:
+ * - Reconnect reuse works (connect → close → reconnect → tools/list)
+ * - Tool metadata survives reconnect
+ * - No concurrent sharing (pool size 1 → second acquire creates fresh)
+ * - Error path discards instance (not returned to pool)
+ * - Pool invalidation after registry growth
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Minimal transport for testing connect/close lifecycle. Calls onclose on close(). */
+function createFakeTransport(): Transport {
+  const t: any = {
+    start: async () => {},
+    close: async () => { t.onclose?.(); },
+    send: async () => {},
+    onclose: undefined,
+    onerror: undefined,
+    onmessage: undefined,
+    sessionId: undefined,
+  };
+  return t as Transport;
+}
+
+/** Register a few tools on a server to simulate real usage. */
+function registerTestTools(server: McpServer): string[] {
+  const names = ['tool_alpha', 'tool_beta', 'tool_gamma'];
+  for (const name of names) {
+    server.tool(name, `Test tool ${name}`, {}, async () => ({
+      content: [{ type: 'text' as const, text: `${name} result` }],
+    }));
+  }
+  return names;
+}
+
+/** Extract tool names from a configured McpServer via its internal registry. */
+function getRegisteredToolNames(server: McpServer): string[] {
+  const tools = (server as any)._registeredTools;
+  return tools ? Object.keys(tools) : [];
+}
+
+// ─── Pool Implementation (mirrors index.ts, isolated for testing) ───────────
+
+function createPool(poolSize: number, factory: () => McpServer) {
+  const pool: McpServer[] = [];
+  let createCount = 0;
+  let reuseCount = 0;
+  let discardCount = 0;
+
+  return {
+    pool,
+    acquire(): McpServer {
+      const pooled = pool.pop();
+      if (pooled) {
+        reuseCount++;
+        return pooled;
+      }
+      createCount++;
+      return factory();
+    },
+    release(s: McpServer): void {
+      if (pool.length < poolSize) {
+        pool.push(s);
+      }
+    },
+    discard(_s: McpServer): void {
+      discardCount++;
+    },
+    invalidate(): void {
+      pool.length = 0;
+    },
+    get stats() {
+      return { createCount, reuseCount, discardCount, available: pool.length };
+    },
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('T9: HTTP McpServer Pool', () => {
+  describe('reconnect reuse', () => {
+    it('server works after close + reconnect with new transport', async () => {
+      const server = new McpServer({ name: 'test', version: '0.0.0' });
+      registerTestTools(server);
+
+      // First connection
+      const transport1 = createFakeTransport();
+      await server.connect(transport1);
+
+      // Verify tools are registered
+      const toolsBefore = getRegisteredToolNames(server);
+      expect(toolsBefore).toContain('tool_alpha');
+
+      // Close (simulates end of HTTP request)
+      await server.close();
+
+      // Second connection — should not throw
+      const transport2 = createFakeTransport();
+      await server.connect(transport2);
+
+      // Tools should still be registered
+      const toolsAfter = getRegisteredToolNames(server);
+      expect(toolsAfter).toContain('tool_alpha');
+      expect(toolsAfter).toContain('tool_beta');
+      expect(toolsAfter).toContain('tool_gamma');
+
+      await server.close();
+    });
+
+    it('tool metadata survives reconnect — same count and names', async () => {
+      const server = new McpServer({ name: 'test', version: '0.0.0' });
+      const expectedNames = registerTestTools(server);
+
+      const transport1 = createFakeTransport();
+      await server.connect(transport1);
+      const before = getRegisteredToolNames(server);
+      await server.close();
+
+      const transport2 = createFakeTransport();
+      await server.connect(transport2);
+      const after = getRegisteredToolNames(server);
+      await server.close();
+
+      expect(after.length).toBe(before.length);
+      for (const name of expectedNames) {
+        expect(after).toContain(name);
+      }
+    });
+  });
+
+  describe('pool acquire/release', () => {
+    it('second acquire from pool size 1 creates fresh instance', () => {
+      const pool = createPool(1, () => {
+        const s = new McpServer({ name: 'test', version: '0.0.0' });
+        registerTestTools(s);
+        return s;
+      });
+
+      const server1 = pool.acquire();
+      // Pool is now empty (server1 was created fresh, not from pool)
+      const server2 = pool.acquire();
+      // server2 is also created fresh — different instance
+      expect(server1).not.toBe(server2);
+      expect(pool.stats.createCount).toBe(2);
+      expect(pool.stats.reuseCount).toBe(0);
+    });
+
+    it('released server is reused on next acquire', async () => {
+      const pool = createPool(2, () => {
+        const s = new McpServer({ name: 'test', version: '0.0.0' });
+        registerTestTools(s);
+        return s;
+      });
+
+      const server1 = pool.acquire();
+      expect(pool.stats.createCount).toBe(1);
+
+      // Simulate clean request lifecycle
+      const transport = createFakeTransport();
+      await server1.connect(transport);
+      await server1.close();
+      pool.release(server1);
+
+      expect(pool.stats.available).toBe(1);
+
+      const server2 = pool.acquire();
+      expect(server2).toBe(server1); // Same instance reused
+      expect(pool.stats.reuseCount).toBe(1);
+      expect(pool.stats.createCount).toBe(1); // No new creation
+    });
+
+    it('pool does not exceed max size', () => {
+      const pool = createPool(2, () => new McpServer({ name: 'test', version: '0.0.0' }));
+
+      const servers = [pool.acquire(), pool.acquire(), pool.acquire()];
+      expect(pool.stats.createCount).toBe(3);
+
+      // Release all 3 — only 2 should fit
+      for (const s of servers) pool.release(s);
+      expect(pool.stats.available).toBe(2);
+    });
+  });
+
+  describe('error path discards', () => {
+    it('discarded server is not returned to pool', () => {
+      const pool = createPool(4, () => new McpServer({ name: 'test', version: '0.0.0' }));
+
+      const server = pool.acquire();
+      pool.discard(server);
+
+      expect(pool.stats.discardCount).toBe(1);
+      expect(pool.stats.available).toBe(0);
+    });
+
+    it('simulated error uses discard path', async () => {
+      const pool = createPool(4, () => {
+        const s = new McpServer({ name: 'test', version: '0.0.0' });
+        registerTestTools(s);
+        return s;
+      });
+
+      const server = pool.acquire();
+      const transport = createFakeTransport();
+      let cleanExit = false;
+      try {
+        await server.connect(transport);
+        // Simulate an error during handleRequest
+        throw new Error('simulated request failure');
+      } catch {
+        // Error caught
+      } finally {
+        try { await server.close(); } catch { /* best-effort */ }
+        if (cleanExit) {
+          pool.release(server);
+        } else {
+          pool.discard(server);
+        }
+      }
+
+      expect(pool.stats.discardCount).toBe(1);
+      expect(pool.stats.available).toBe(0);
+
+      // Next acquire should create fresh
+      const server2 = pool.acquire();
+      expect(server2).not.toBe(server);
+      expect(pool.stats.createCount).toBe(2);
+    });
+  });
+
+  describe('pool invalidation', () => {
+    it('invalidate clears all pooled servers', async () => {
+      const pool = createPool(4, () => {
+        const s = new McpServer({ name: 'test', version: '0.0.0' });
+        registerTestTools(s);
+        return s;
+      });
+
+      // Acquire 3 servers, close them, then release all to fill pool
+      const servers: McpServer[] = [];
+      for (let i = 0; i < 3; i++) {
+        servers.push(pool.acquire());
+      }
+      // Connect and close each so they can be reconnected later
+      for (const s of servers) {
+        const t = createFakeTransport();
+        await s.connect(t);
+        await s.close();
+      }
+      // Release all into pool
+      for (const s of servers) {
+        pool.release(s);
+      }
+      expect(pool.stats.available).toBe(3);
+
+      // Invalidate (simulates secondary vault registration)
+      pool.invalidate();
+      expect(pool.stats.available).toBe(0);
+
+      // Next acquire creates fresh
+      const fresh = pool.acquire();
+      expect(servers).not.toContain(fresh);
+    });
+
+    it('invalidation does not affect future acquire/release', async () => {
+      const pool = createPool(2, () => {
+        const s = new McpServer({ name: 'test', version: '0.0.0' });
+        registerTestTools(s);
+        return s;
+      });
+
+      pool.invalidate(); // No-op on empty pool
+
+      const server = pool.acquire();
+      const transport = createFakeTransport();
+      await server.connect(transport);
+      await server.close();
+      pool.release(server);
+
+      expect(pool.stats.available).toBe(1);
+
+      const reused = pool.acquire();
+      expect(reused).toBe(server);
+      expect(pool.stats.reuseCount).toBe(1);
+    });
+  });
+
+  describe('SDK lifecycle safety', () => {
+    it('connect throws if called without close', async () => {
+      const server = new McpServer({ name: 'test', version: '0.0.0' });
+      registerTestTools(server);
+
+      const transport1 = createFakeTransport();
+      await server.connect(transport1);
+
+      // Second connect without close should throw
+      const transport2 = createFakeTransport();
+      await expect(server.connect(transport2)).rejects.toThrow(/already connected/i);
+
+      await server.close();
+    });
+
+    it('multiple connect/close cycles work', async () => {
+      const server = new McpServer({ name: 'test', version: '0.0.0' });
+      registerTestTools(server);
+
+      for (let i = 0; i < 5; i++) {
+        const transport = createFakeTransport();
+        await server.connect(transport);
+        expect(getRegisteredToolNames(server).length).toBe(3);
+        await server.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **HTTP McpServer pool** (size 4): reuses pre-configured servers across requests instead of creating a fresh one with 75+ tool registrations per `POST /mcp`
- **Defensive lifecycle**: try/finally with `releaseHttpServer()` on clean exit, `discardHttpServer()` on error — no corrupted instances returned to pool
- **Pool invalidation**: clears pool after secondary vault registration so tool schemas reflect updated vault names
- **Observability**: `performance.now()` timing with conditional logging, `/health` enhanced with memory stats and pool counters

## Test plan

- [x] 11 new tests in `http-pool.test.ts` covering reconnect reuse, pool semantics, error-path discard, invalidation, and SDK lifecycle safety
- [x] All existing transport/singleton tests pass (`http-transport`, `singleton-stress`, `singleton-access`)
- [x] `npm run lint` (tsc --noEmit) clean
- [x] `npm run build` clean
- [ ] Manual HTTP smoke: `FLYWHEEL_TRANSPORT=http` then `POST /mcp` with `tools/list`
- [ ] Verify `/health` shows pool counters and memory stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)