### PR TITLE
feat: add minContentMatch threshold to wikilink scoring (T6)

### DIFF
--- a/packages/mcp-server/src/core/shared/types.ts
+++ b/packages/mcp-server/src/core/shared/types.ts
@@ -168,6 +168,8 @@ export interface SuggestionConfig {
   noRelevanceCap: number;
   /** Minimum cooccurrence boost required for graph-only entities (no content overlap) to qualify */
   minCooccurrenceGate: number;
+  /** Hard floor for contentMatch (exact+stem only). Entities below this are excluded from final results. 0 = disabled. */
+  minContentMatch: number;
 }
 
 /**

--- a/packages/mcp-server/src/core/write/wikilinks.ts
+++ b/packages/mcp-server/src/core/write/wikilinks.ts
@@ -850,6 +850,7 @@ const STRICTNESS_CONFIGS: Record<StrictnessMode, SuggestionConfig> = {
     contentRelevanceFloor: 5,
     noRelevanceCap: 12,
     minCooccurrenceGate: 6,
+    minContentMatch: 3,
   },
   balanced: {
     minWordLength: 3,
@@ -862,6 +863,7 @@ const STRICTNESS_CONFIGS: Record<StrictnessMode, SuggestionConfig> = {
     contentRelevanceFloor: 5,
     noRelevanceCap: 10,
     minCooccurrenceGate: 5,
+    minContentMatch: 2,
   },
   aggressive: {
     minWordLength: 3,
@@ -874,6 +876,7 @@ const STRICTNESS_CONFIGS: Record<StrictnessMode, SuggestionConfig> = {
     contentRelevanceFloor: 3,
     noRelevanceCap: 18,
     minCooccurrenceGate: 3,
+    minContentMatch: 0,
   },
 };
 
@@ -1491,8 +1494,8 @@ export async function suggestRelatedLinks(
   }
   const scoredEntities: ScoredEntry[] = [];
   const directlyMatchedEntities = new Set<string>();
-  // Track entities that have actual content matches (not just boosts)
-  const entitiesWithContentMatch = new Set<string>();
+  // Track entities admitted by any scoring path (lexical, cooccurrence, semantic) — minContentMatch gate applied later
+  const entitiesWithAnyScoringPath = new Set<string>();
 
   for (const { entity, category } of entitiesWithTypes) {
     // Get entity name
@@ -1544,7 +1547,7 @@ export async function suggestRelatedLinks(
 
     // Track entities with actual lexical matches (content + fuzzy)
     if (hasLexicalEvidence) {
-      entitiesWithContentMatch.add(entityName);
+      entitiesWithAnyScoringPath.add(entityName);
     }
 
     // Layer 5: Type boost - prioritize people, projects over common technologies
@@ -1692,7 +1695,7 @@ export async function suggestRelatedLinks(
           // Entity passed content overlap or strong co-occurrence check —
           // qualify it for final results
           if (hasContentOverlap || strongCooccurrence) {
-            entitiesWithContentMatch.add(entityName);
+            entitiesWithAnyScoringPath.add(entityName);
           }
 
           // For purely co-occurrence-based suggestions, add relevant boosts.
@@ -1830,8 +1833,8 @@ export async function suggestRelatedLinks(
               },
             });
 
-            // Add to content match set so it passes the gate below
-            entitiesWithContentMatch.add(match.entityName);
+            // Add to scoring-path set — semantic admission; minContentMatch applied at final filter
+            entitiesWithAnyScoringPath.add(match.entityName);
           }
         }
       }
@@ -1848,11 +1851,13 @@ export async function suggestRelatedLinks(
     entry.score = capScoreWithoutContentRelevance(entry.score, contentRelevance, config);
   }
 
-  // Filter to only entities with actual content matches
+  // Filter to entities admitted by a scoring path, then enforce minContentMatch floor
   // This prevents popularity-based suggestions (high hub score, recency) for unrelated content
-  const relevantEntities = scoredEntities.filter(e =>
-    entitiesWithContentMatch.has(e.name)
-  );
+  const relevantEntities = scoredEntities.filter(e => {
+    if (!entitiesWithAnyScoringPath.has(e.name)) return false;
+    if (config.minContentMatch > 0 && e.breakdown.contentMatch < config.minContentMatch) return false;
+    return true;
+  });
 
   // If no content matches at all, return empty rather than popularity-based suggestions
   if (relevantEntities.length === 0) {
@@ -1899,7 +1904,7 @@ export async function suggestRelatedLinks(
         }
         // Also persist entities that were scored but didn't meet threshold
         for (const e of scoredEntities) {
-          if (!entitiesWithContentMatch.has(e.name)) continue;
+          if (!entitiesWithAnyScoringPath.has(e.name)) continue;
           if (relevantEntities.some(r => r.name === e.name)) continue;
           insertStmt.run(
             now,
@@ -1949,9 +1954,7 @@ export async function suggestRelatedLinks(
   // Per-file fatigue: count existing suffix appearances for each entity
   const suffixCandidates = topEntries.filter(e => {
     if (e.score < MIN_SUFFIX_SCORE) return false;
-    if (!(e.breakdown.contentMatch >= MIN_SUFFIX_CONTENT ||
-          e.breakdown.cooccurrenceBoost >= MIN_SUFFIX_CONTENT ||
-          (e.breakdown.semanticBoost ?? 0) >= MIN_SUFFIX_CONTENT)) return false;
+    if (e.breakdown.contentMatch < MIN_SUFFIX_CONTENT) return false;
 
     // Count how many times this entity already appears in → suffix lines
     if (!disabled.has('fatigue')) {

--- a/packages/mcp-server/test/graph-quality/observability.test.ts
+++ b/packages/mcp-server/test/graph-quality/observability.test.ts
@@ -341,18 +341,22 @@ describe('Pillar 6: Pipeline Observability', () => {
 
     it('entities that did not pass threshold have passed=0', () => {
       const filteredRows = vault.stateDb.db.prepare(
-        'SELECT entity, total_score, threshold, passed FROM suggestion_events WHERE passed = 0'
+        'SELECT entity, total_score, threshold, passed, breakdown_json FROM suggestion_events WHERE passed = 0'
       ).all() as Array<{
         entity: string;
         total_score: number;
         threshold: number;
         passed: number;
+        breakdown_json: string;
       }>;
 
-      // There should be some filtered entities (below threshold)
-      // If none, the test still passes since that is a valid state
+      // Entities with passed=0 either:
+      // 1. Scored below the adaptive threshold, OR
+      // 2. Were rejected by the minContentMatch gate (T6) despite meeting the score threshold
       for (const row of filteredRows) {
-        expect(row.total_score).toBeLessThan(row.threshold);
+        const breakdown = JSON.parse(row.breakdown_json);
+        const rejectedByContentFloor = (breakdown.contentMatch ?? 0) < 2; // balanced minContentMatch=2
+        expect(row.total_score < row.threshold || rejectedByContentFloor).toBe(true);
       }
     });
   });

--- a/packages/mcp-server/test/write/core/wikilinks.test.ts
+++ b/packages/mcp-server/test/write/core/wikilinks.test.ts
@@ -2360,7 +2360,7 @@ describe('scoring guardrails', () => {
     expect(uppercase.suggestions).toContain('REST');
   });
 
-  it('caps graph-only score inflation when content relevance is absent', async () => {
+  it('rejects graph-only entity in balanced mode (T6 minContentMatch gate)', async () => {
     createEntityCacheInStateDb(stateDb, tempVault, {
       people: ['Alex Johnson'],
       other: ['Arma Reforger'],
@@ -2398,16 +2398,25 @@ describe('scoring guardrails', () => {
     });
     feedbackTxn();
 
-    const result = await suggestRelatedLinks('Met with Alex Johnson for planning.', {
+    // balanced mode: minContentMatch=2 rejects Arma Reforger (contentMatch=0)
+    const balancedResult = await suggestRelatedLinks('Met with Alex Johnson for planning.', {
       strictness: 'balanced',
       detail: true,
     });
 
-    const arma = result.detailed?.find(entry => entry.entity === 'Arma Reforger');
-    expect(arma).toBeDefined();
-    expect(arma!.breakdown.contentMatch).toBe(0);
-    expect(arma!.breakdown.fuzzyMatch).toBe(0);
-    expect(arma!.totalScore).toBe(10);
+    const armaBalanced = balancedResult.detailed?.find(entry => entry.entity === 'Arma Reforger');
+    expect(armaBalanced).toBeUndefined();
+
+    // aggressive mode: minContentMatch=0 preserves backward compat — graph-only entity survives
+    const aggressiveResult = await suggestRelatedLinks('Met with Alex Johnson for planning.', {
+      strictness: 'aggressive',
+      detail: true,
+    });
+
+    const armaAggressive = aggressiveResult.detailed?.find(entry => entry.entity === 'Arma Reforger');
+    expect(armaAggressive).toBeDefined();
+    expect(armaAggressive!.breakdown.contentMatch).toBe(0);
+    expect(armaAggressive!.breakdown.fuzzyMatch).toBe(0);
   });
 
   it('weak cooccurrence entity excluded when below gate', async () => {
@@ -2902,6 +2911,262 @@ describe('zero-relevance content filtering', () => {
     expect(result.suggestions).not.toContain('Important Person');
     if (result.suggestions.length > 0) {
       expect(result.suggestions).toContain('Random Activity');
+    }
+  });
+});
+
+// ========================================
+// T6: minContentMatch Threshold Tests
+// ========================================
+
+describe('T6 minContentMatch threshold', () => {
+  let tempVault: string;
+  let stateDb: StateDb;
+
+  beforeEach(async () => {
+    tempVault = await createTempVault();
+    stateDb = openStateDb(tempVault);
+    setWriteStateDb(stateDb);
+  });
+
+  afterEach(async () => {
+    setCooccurrenceIndex(null);
+    setWriteStateDb(null);
+    stateDb.db.close();
+    deleteStateDb(tempVault);
+    await cleanupTempVault(tempVault);
+  });
+
+  it('centralized gate rejects entity below minContentMatch in balanced mode', async () => {
+    // Create an entity whose name is a common word — will get a very low stem match
+    // but we want to test the floor. Use a multi-word entity where only one short
+    // stem matches, giving contentMatch < 2.
+    createEntityCacheInStateDb(stateDb, tempVault, {
+      people: ['Alex Johnson'],
+      other: ['Zeta Grid'],
+    });
+
+    await initializeEntityIndex(tempVault);
+
+    // "grid" is not a stopword but "Zeta" won't match anything in content.
+    // Only "grid" stem-matches → contentMatch = stemMatchBonus(5) * IDF ≈ 5 for balanced.
+    // That's above the threshold of 2, so let's use cooccurrence-only to test the floor.
+    const coocIndex: CooccurrenceIndex = {
+      associations: {
+        'Alex Johnson': new Map([['Zeta Grid', 5]]),
+        'Zeta Grid': new Map([['Alex Johnson', 5]]),
+      },
+      minCount: 0.5,
+      documentFrequency: new Map([
+        ['Alex Johnson', 5],
+        ['Zeta Grid', 5],
+      ]),
+      totalNotesScanned: 100,
+      _metadata: {
+        generated_at: new Date().toISOString(),
+        total_associations: 2,
+        notes_scanned: 100,
+      },
+    };
+    saveCooccurrenceToStateDb(stateDb, coocIndex);
+    setCooccurrenceIndex(coocIndex);
+
+    // Content mentions Alex Johnson but not Zeta Grid — Zeta Grid enters via cooccurrence only
+    const result = await suggestRelatedLinks('Met with Alex Johnson to discuss the new plan.', {
+      strictness: 'balanced',
+      detail: true,
+    });
+
+    const zeta = result.detailed?.find(entry => entry.entity === 'Zeta Grid');
+    // Zeta Grid has contentMatch=0, which is below balanced minContentMatch=2
+    expect(zeta).toBeUndefined();
+  });
+
+  it('centralized gate allows entity at or above minContentMatch threshold', async () => {
+    createEntityCacheInStateDb(stateDb, tempVault, {
+      technologies: ['TypeScript'],
+    });
+
+    await initializeEntityIndex(tempVault);
+
+    const result = await suggestRelatedLinks('Working with TypeScript today on the refactor.', {
+      strictness: 'balanced',
+      detail: true,
+    });
+
+    const ts = result.detailed?.find(entry => entry.entity === 'TypeScript');
+    expect(ts).toBeDefined();
+    // exactMatchBonus=10 is well above minContentMatch=2
+    expect(ts!.breakdown.contentMatch).toBeGreaterThanOrEqual(2);
+  });
+
+  it('graph boosts cannot rescue sub-threshold entity in conservative mode', async () => {
+    createEntityCacheWithDetailsInStateDb(stateDb, tempVault, {
+      people: [
+        { name: 'Alex Johnson', path: 'people/Alex Johnson.md', hubScore: 10 },
+      ],
+      other: [
+        // High hub score but no content match
+        { name: 'Phantom Entity', path: 'other/Phantom Entity.md', hubScore: 200 },
+      ],
+    });
+
+    await initializeEntityIndex(tempVault);
+
+    const coocIndex: CooccurrenceIndex = {
+      associations: {
+        'Alex Johnson': new Map([['Phantom Entity', 10]]),
+        'Phantom Entity': new Map([['Alex Johnson', 10]]),
+      },
+      minCount: 0.5,
+      documentFrequency: new Map([
+        ['Alex Johnson', 10],
+        ['Phantom Entity', 10],
+      ]),
+      totalNotesScanned: 100,
+      _metadata: {
+        generated_at: new Date().toISOString(),
+        total_associations: 2,
+        notes_scanned: 100,
+      },
+    };
+    saveCooccurrenceToStateDb(stateDb, coocIndex);
+    setCooccurrenceIndex(coocIndex);
+
+    // Content mentions Alex Johnson but not Phantom Entity
+    const result = await suggestRelatedLinks('Met with Alex Johnson for the quarterly review.', {
+      strictness: 'conservative',
+      detail: true,
+    });
+
+    // Phantom Entity has contentMatch=0, below conservative minContentMatch=3
+    const phantom = result.detailed?.find(entry => entry.entity === 'Phantom Entity');
+    expect(phantom).toBeUndefined();
+  });
+
+  it('aggressive mode preserves graph-only entities in suggestion list', async () => {
+    createEntityCacheInStateDb(stateDb, tempVault, {
+      people: ['Alex Johnson'],
+      other: ['Arma Reforger'],
+    });
+
+    await initializeEntityIndex(tempVault);
+
+    const coocIndex: CooccurrenceIndex = {
+      associations: {
+        'Alex Johnson': new Map([['Arma Reforger', 1]]),
+        'Arma Reforger': new Map([['Alex Johnson', 1]]),
+      },
+      minCount: 0.5,
+      documentFrequency: new Map([
+        ['Alex Johnson', 1],
+        ['Arma Reforger', 1],
+      ]),
+      totalNotesScanned: 100,
+      _metadata: {
+        generated_at: new Date().toISOString(),
+        total_associations: 2,
+        notes_scanned: 100,
+      },
+    };
+    saveCooccurrenceToStateDb(stateDb, coocIndex);
+    setCooccurrenceIndex(coocIndex);
+
+    // Add positive feedback to boost Arma Reforger above thresholds
+    const insertFeedback = stateDb.db.prepare(
+      'INSERT INTO wikilink_feedback (entity, context, note_path, correct) VALUES (?, ?, ?, ?)'
+    );
+    const feedbackTxn = stateDb.db.transaction(() => {
+      for (let i = 0; i < 24; i++) {
+        insertFeedback.run('Arma Reforger', 'test:cap', `notes/${i}.md`, 1);
+      }
+    });
+    feedbackTxn();
+
+    const result = await suggestRelatedLinks('Met with Alex Johnson for planning.', {
+      strictness: 'aggressive',
+      detail: true,
+    });
+
+    // aggressive mode: minContentMatch=0 — graph-only entities survive
+    const arma = result.detailed?.find(entry => entry.entity === 'Arma Reforger');
+    expect(arma).toBeDefined();
+    expect(arma!.breakdown.contentMatch).toBe(0);
+  });
+
+  it('suffix gate rejects graph-only entities even in aggressive mode', async () => {
+    createEntityCacheInStateDb(stateDb, tempVault, {
+      people: ['Alex Johnson'],
+      other: ['Arma Reforger'],
+    });
+
+    await initializeEntityIndex(tempVault);
+
+    const coocIndex: CooccurrenceIndex = {
+      associations: {
+        'Alex Johnson': new Map([['Arma Reforger', 1]]),
+        'Arma Reforger': new Map([['Alex Johnson', 1]]),
+      },
+      minCount: 0.5,
+      documentFrequency: new Map([
+        ['Alex Johnson', 1],
+        ['Arma Reforger', 1],
+      ]),
+      totalNotesScanned: 100,
+      _metadata: {
+        generated_at: new Date().toISOString(),
+        total_associations: 2,
+        notes_scanned: 100,
+      },
+    };
+    saveCooccurrenceToStateDb(stateDb, coocIndex);
+    setCooccurrenceIndex(coocIndex);
+
+    // Add positive feedback to boost Arma Reforger into suggestions
+    const insertFeedback = stateDb.db.prepare(
+      'INSERT INTO wikilink_feedback (entity, context, note_path, correct) VALUES (?, ?, ?, ?)'
+    );
+    const feedbackTxn = stateDb.db.transaction(() => {
+      for (let i = 0; i < 24; i++) {
+        insertFeedback.run('Arma Reforger', 'test:cap', `notes/${i}.md`, 1);
+      }
+    });
+    feedbackTxn();
+
+    const result = await suggestRelatedLinks('Met with Alex Johnson for planning.', {
+      strictness: 'aggressive',
+      detail: true,
+    });
+
+    // Even in aggressive mode, suffix requires contentMatch >= MIN_SUFFIX_CONTENT
+    // Graph-only entity (contentMatch=0) should not appear in suffix
+    if (result.suffix) {
+      expect(result.suffix).not.toContain('Arma Reforger');
+    }
+  });
+
+  it('suffix gate still passes content-matched entities', async () => {
+    // Use a multi-word entity that will score high enough for suffix
+    createEntityCacheWithDetailsInStateDb(stateDb, tempVault, {
+      projects: [
+        { name: 'Project Alpha', path: 'projects/Project Alpha.md', hubScore: 50 },
+      ],
+    });
+
+    await initializeEntityIndex(tempVault);
+
+    const result = await suggestRelatedLinks('Working on the Project Alpha deployment and testing.', {
+      strictness: 'balanced',
+      detail: true,
+    });
+
+    const alpha = result.detailed?.find(entry => entry.entity === 'Project Alpha');
+    if (alpha) {
+      expect(alpha.breakdown.contentMatch).toBeGreaterThanOrEqual(2);
+    }
+    // If it scored high enough, it should be in suggestions
+    if (result.suggestions.includes('Project Alpha')) {
+      expect(result.suggestions).toContain('Project Alpha');
     }
   });
 });


### PR DESCRIPTION
## Summary

- Adds `minContentMatch` hard floor to `SuggestionConfig` — entities with insufficient exact+stem evidence are rejected at the final centralized filter, regardless of graph boosts (hub, cooccurrence, semantic)
- Per-mode values: conservative=3, balanced=2, aggressive=0 (preserves backward compat)
- Tightens suffix gate: removes cooccurrence/semantic fallbacks, requiring direct content evidence for suffix lines in all modes
- Renames `entitiesWithContentMatch` to `entitiesWithAnyScoringPath` for clarity

## Design decisions

- **Centralized final filter** (not per-path gate) — catches all three admission paths uniformly
- **Fuzzy-only candidates intentionally affected** — contentMatch is exact+stem only; fuzzy-only evidence is too weak to stand alone
- **Suffix tightening is intentionally stricter** — applies to all modes including aggressive
- **Observability**: T6-rejected entities persist in suggestion_events with passed=0; breakdown_json.contentMatch=0 makes rejection cause derivable

## Test plan

- [x] Split Arma Reforger test: balanced expects absence, aggressive expects presence
- [x] New T6 test suite: centralized gate, graph-boost rescue prevention, aggressive backward compat, suffix gate
- [x] Updated observability test for T6 rejection semantics
- [x] wikilinks.test.ts — 198/198 passed
- [x] layer-ablation, strictness, scoring-layers — all passed
- [x] observability, observability-apis, smoke — all passed

Generated with [Claude Code](https://claude.com/claude-code)