### PR TITLE
chore: bump vault-core to 2.1.5

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps `@velvetmonkey/vault-core` from 2.1.4 → 2.1.5 and publishes to npm
- Fixes CI package-startup test failure: published vault-core 2.1.4 didn't export `isCommonWordEntity` (added in #146 but never released)

## Test plan
- [ ] CI package-startup tests pass (the failing tests from main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)