### PR TITLE
docs: surface multi-vault support in README, SETUP, and COOKBOOK

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[See It Work](#see-it-work)** · **[Get Started](#get-started)** · **[Why Flywheel](#why-flywheel)** · **[Benchmarks](#benchmarks)** · **[Testing](#testing)** · **[Documentation](#documentation)** · **[License](#license)**
 
-Flywheel is an MCP server for Obsidian vaults. It indexes your markdown locally and exposes tools that help AI clients search notes, write safely, query tasks, follow links, and reuse context across sessions.
+Flywheel is an MCP server for Obsidian vaults. It indexes your markdown locally and exposes tools that help AI clients search notes, write safely, query tasks, follow links, and reuse context across sessions. One server can serve multiple vaults with isolated state and cross-vault search.
 
 Search results include more than filenames: Flywheel returns frontmatter, backlinks, outlinks, snippets, and section context so the model can often answer from one call instead of opening file after file. Writes can add wikilinks, use structured section edits, and optionally create auditable git commits.
 
@@ -112,6 +112,22 @@ Start with `default`. Add bundles when you need them, such as `graph`, `schema`,
 
 [Browse all 75 tools ->](docs/TOOLS.md) | [Preset recipes ->](docs/CONFIGURATION.md)
 
+### Multiple vaults
+
+Serve more than one vault from a single Flywheel instance with `FLYWHEEL_VAULTS`:
+
+```json
+{
+  "env": {
+    "FLYWHEEL_VAULTS": "personal:/home/you/obsidian/Personal,work:/home/you/obsidian/Work"
+  }
+}
+```
+
+Search automatically spans all vaults and tags each result with its source vault. Other tools default to the primary vault (first in the list) unless you pass a `vault` parameter. Each vault gets fully isolated state — separate indexes, graph, file watcher, and config.
+
+[Full multi-vault configuration ->](docs/CONFIGURATION.md#multi-vault) | [Client setup examples ->](docs/SETUP.md#multi-vault)
+
 <details>
 <summary><strong>Windows users</strong></summary>
 
@@ -140,6 +156,7 @@ If you want a managed cloud knowledge product, Flywheel is probably the wrong fi
 - **Safer writes:** Mutations operate on markdown structure such as headings, frontmatter, and sections. Entity linking and suggestions are available, but explicit writes remain the default.
 - **Persistent memory:** `brief`, `memory`, and search tools let clients reuse context across sessions without inventing a proprietary storage layer on top of the vault.
 - **Portable graph:** `export_graph` produces [GraphML](https://en.wikipedia.org/wiki/GraphML) that you can inspect in external graph tools such as Gephi or Cytoscape.
+- **Multi-vault:** Serve personal, work, and client vaults from a single server instance. Search spans all vaults by default; other tools target the primary vault unless you specify one. Each vault gets its own index, graph, and config. [Multi-vault setup ->](docs/CONFIGURATION.md#multi-vault)
 - **Auditable behavior:** Core indexing and graph operations run locally. Writes can be committed to git with a single flag, and background behavior is configurable.
 
 ### Link scoring

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -18,6 +18,11 @@ All examples assume Flywheel is connected to your vault. See [SETUP.md](SETUP.md
   - [Find hubs](#find-hubs)
   - [Track graph evolution](#track-graph-evolution)
   - [Visualize your knowledge graph](#visualize-your-knowledge-graph)
+- [Multi-Vault](#multi-vault)
+  - [Search across all vaults](#search-across-all-vaults)
+  - [Search one vault](#search-one-vault)
+  - [Target a specific vault for writes](#target-a-specific-vault-for-writes)
+  - [Identify which vault a result came from](#identify-which-vault-a-result-came-from)
 - [Semantic Search](#semantic-search)
   - [Enable hybrid search](#enable-hybrid-search)
   - [Search by concept](#search-by-concept)
@@ -145,6 +150,40 @@ Export your vault as a graph file and open it in professional visualization tool
 **What's in the export:**
 - **Nodes**: Every note (title, modified date, tags, frontmatter type) + every entity (category, hub score, aliases)
 - **Edges**: Wikilinks (note→note), weighted connections (from feedback learning), co-occurrence relationships (entity↔entity)
+
+---
+
+## Multi-Vault
+
+When Flywheel is configured with `FLYWHEEL_VAULTS`, all tools gain an optional `vault` parameter. These examples assume a two-vault setup: `personal` and `work`.
+
+### Search across all vaults
+
+> "Find all notes about quarterly planning"
+
+When `vault` is omitted, `search` automatically queries every configured vault and merges the results. Each result includes a `vault` field so you can see where it came from.
+
+### Search one vault
+
+> "Search my work vault for notes about the API redesign"
+
+> "Find notes tagged #meeting in my personal vault only"
+
+Passing `vault: "work"` or `vault: "personal"` restricts the search to that vault.
+
+### Target a specific vault for writes
+
+> "Add a task to today's daily note in my work vault: Follow up on the deployment issue"
+
+> "Create a new project note in my personal vault at projects/Garden Redesign.md"
+
+Non-search tools default to the primary vault (first in the list). Pass `vault: "work"` to target a different one.
+
+### Identify which vault a result came from
+
+> "Search for 'budget review' and tell me which vault each result is from"
+
+Cross-vault search results include a `vault` field on every result. Ask Claude to surface it when you need to disambiguate.
 
 ---
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -20,6 +20,7 @@ After trying the [demo vaults](../demos/), point Flywheel at your own Obsidian v
     - [VS Code + GitHub Copilot (HTTP)](#vs-code--github-copilot-http)
     - [Continue (HTTP)](#continue-http)
     - [Other HTTP Clients](#other-http-clients)
+- [Multi-Vault](#multi-vault)
 - [Step 2: First 5 Commands to Try](#step-2-first-5-commands-to-try)
   - [1. Search your vault](#1-search-your-vault)
   - [2. Explore connections](#2-explore-connections)
@@ -140,6 +141,25 @@ Launch:
 cd /path/to/your/vault && claude
 ```
 
+**Multi-vault** — serve two or more vaults from one server:
+
+```json
+{
+  "mcpServers": {
+    "flywheel": {
+      "command": "npx",
+      "args": ["-y", "@velvetmonkey/flywheel-memory"],
+      "env": {
+        "FLYWHEEL_VAULTS": "personal:/home/you/obsidian/Personal,work:/home/you/obsidian/Work",
+        "FLYWHEEL_TOOLS": "default"
+      }
+    }
+  }
+}
+```
+
+The first vault in the list is the **primary**. `search` spans all vaults by default; other tools operate on the primary vault unless you pass `vault: "work"`. See [CONFIGURATION.md](CONFIGURATION.md#multi-vault) for details.
+
 ### Claude Desktop (stdio)
 
 Edit `claude_desktop_config.json` (Settings > Developer > Edit Config):
@@ -160,6 +180,23 @@ Edit `claude_desktop_config.json` (Settings > Developer > Edit Config):
 ```
 
 Claude Desktop requires `VAULT_PATH` because it doesn't launch from the vault directory. Claude Code auto-detects the vault root from the working directory.
+
+**Multi-vault** — replace `VAULT_PATH` with `FLYWHEEL_VAULTS`:
+
+```json
+{
+  "mcpServers": {
+    "flywheel": {
+      "command": "npx",
+      "args": ["-y", "@velvetmonkey/flywheel-memory"],
+      "env": {
+        "FLYWHEEL_VAULTS": "personal:/home/you/obsidian/Personal,work:/home/you/obsidian/Work",
+        "FLYWHEEL_TOOLS": "default"
+      }
+    }
+  }
+}
+```
 
 Restart Claude Desktop after editing the config. Flywheel appears in the MCP server list.
 
@@ -339,6 +376,27 @@ On first run, Flywheel creates a `.flywheel/` directory containing its SQLite in
 > ```
 >
 > See [CONFIGURATION.md](CONFIGURATION.md#custom-categories) for details.
+
+---
+
+## Multi-Vault
+
+All client configs above show a single vault. To serve multiple vaults from one Flywheel instance, replace `VAULT_PATH` with `FLYWHEEL_VAULTS`:
+
+```
+FLYWHEEL_VAULTS="name1:/path/to/vault1,name2:/path/to/vault2"
+```
+
+The first vault is the **primary**. Key behaviors:
+
+| Behavior | `vault` specified | `vault` omitted |
+|----------|-------------------|-----------------|
+| `search` | Searches that vault only | Searches **all** vaults, merges results |
+| All other tools | Operates on that vault | Operates on primary vault |
+
+Each vault gets fully isolated state: separate `.flywheel/state.db`, graph index, file watcher, and runtime config.
+
+Multi-vault examples appear inline in the [Claude Code](#claude-code-stdio) and [Claude Desktop](#claude-desktop-stdio) sections above. For HTTP clients, see the [HTTP multi-vault example](#other-http-clients). Full reference: [CONFIGURATION.md](CONFIGURATION.md#multi-vault).
 
 ---
 


### PR DESCRIPTION
## Summary

- **README**: mention multi-vault in intro paragraph, add bullet to "Why Flywheel", add `FLYWHEEL_VAULTS` config example under "Get Started"
- **SETUP**: add copy-paste multi-vault examples for Claude Code and Claude Desktop stdio configs, add dedicated Multi-Vault section with behavior table and cross-links
- **COOKBOOK**: add Multi-Vault section with 4 prompt categories (cross-vault search, single-vault targeting, vault-specific writes, result attribution)

No runtime changes — documentation only. CONFIGURATION.md remains the canonical deep reference; these edits promote the feature to first-class visibility on the main discovery surfaces.

## Test plan

- [x] `npm run build` passes
- [x] Doc validation tests pass (readme-examples, toc-completeness, claims-truth — 17/17)
- [ ] Verify README multi-vault section renders correctly on GitHub
- [ ] Verify SETUP.md #multi-vault anchor links work from README cross-links
- [ ] Spot-check COOKBOOK prompts map to real tool parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)