### PR TITLE
test: harden T13 tiered tool exposure (16 new tests)

### DIFF
--- a/packages/mcp-server/test/tool-tiering.test.ts
+++ b/packages/mcp-server/test/tool-tiering.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { ALL_CATEGORIES, generateInstructions } from '../src/config.js';
@@ -16,8 +17,12 @@ function createTieredServer() {
     'tiered',
   );
 
-  server.tool('search', async () => ({
+  // search and brief need schemas so params flow through wrapWithTracking
+  server.tool('search', { query: z.string().optional(), focus: z.string().optional() }, async () => ({
     content: [{ type: 'text' as const, text: 'search ok' }],
+  }));
+  server.tool('brief', { focus: z.string().optional() }, async () => ({
+    content: [{ type: 'text' as const, text: 'brief ok' }],
   }));
   server.tool('graph_analysis', async () => ({
     content: [{ type: 'text' as const, text: 'graph ok' }],
@@ -31,9 +36,27 @@ function createTieredServer() {
   server.tool('merge_entities', async () => ({
     content: [{ type: 'text' as const, text: 'merge ok' }],
   }));
+  server.tool('suggest_wikilinks', async () => ({
+    content: [{ type: 'text' as const, text: 'wikilinks ok' }],
+  }));
+  server.tool('vault_record_correction', async () => ({
+    content: [{ type: 'text' as const, text: 'correction ok' }],
+  }));
+  server.tool('get_context_around_date', async () => ({
+    content: [{ type: 'text' as const, text: 'temporal ok' }],
+  }));
 
   controller.finalizeRegistration();
   return { server, controller };
+}
+
+/** Helper to invoke a tool via the MCP tools/call handler */
+async function callTool(server: McpServer, name: string, args: Record<string, unknown> = {}) {
+  const handler = (server as any).server._requestHandlers.get('tools/call');
+  return handler(
+    { method: 'tools/call', params: { name, arguments: args } },
+    {},
+  );
 }
 
 describe('tool tiering', () => {
@@ -74,18 +97,8 @@ describe('tool tiering', () => {
 
   it('executes a hidden tier tool when called directly and reveals its category', async () => {
     const { server, controller } = createTieredServer();
-    const handler = (server as any).server._requestHandlers.get('tools/call');
 
-    const result = await handler(
-      {
-        method: 'tools/call',
-        params: {
-          name: 'graph_analysis',
-          arguments: {},
-        },
-      },
-      {},
-    );
+    const result = await callTool(server, 'graph_analysis');
 
     expect(result.isError).not.toBe(true);
     expect(result.content[0].text).toContain('graph ok');
@@ -112,5 +125,253 @@ describe('tool tiering', () => {
     expect(instructions).toContain('Use "get_backlinks" for per-backlink surrounding text');
     expect(instructions).toContain('## Wikilinks');
     expect(instructions).not.toContain('Ask about graph connections, backlinks, hubs, clusters, or paths');
+  });
+});
+
+// ============================================================================
+// Activation signals
+// ============================================================================
+
+describe('activation signals via search/brief', () => {
+  it('search query with "backlinks" unlocks graph category', async () => {
+    const { server, controller } = createTieredServer();
+    const tools = (server as any)._registeredTools;
+
+    expect(tools.graph_analysis.enabled).toBe(false);
+
+    await callTool(server, 'search', { query: 'show me backlinks for this note' });
+
+    expect(controller.activeCategories.has('graph')).toBe(true);
+    expect(tools.graph_analysis.enabled).toBe(true);
+  });
+
+  it('search query with "schema" unlocks schema category (tier 3)', async () => {
+    const { server, controller } = createTieredServer();
+    const tools = (server as any)._registeredTools;
+
+    expect(tools.vault_schema.enabled).toBe(false);
+
+    await callTool(server, 'search', { query: 'what does the schema look like' });
+
+    expect(controller.activeCategories.has('schema')).toBe(true);
+    expect(tools.vault_schema.enabled).toBe(true);
+  });
+
+  it('search query with "stale notes" unlocks temporal category', async () => {
+    const { server, controller } = createTieredServer();
+
+    await callTool(server, 'search', { query: 'find stale notes that need updating' });
+
+    expect(controller.activeCategories.has('temporal')).toBe(true);
+    expect((server as any)._registeredTools.get_context_around_date.enabled).toBe(true);
+  });
+
+  it('search query with "wikilinks" unlocks wikilinks category', async () => {
+    const { server, controller } = createTieredServer();
+
+    await callTool(server, 'search', { query: 'check wikilinks on my project notes' });
+
+    expect(controller.activeCategories.has('wikilinks')).toBe(true);
+    expect((server as any)._registeredTools.suggest_wikilinks.enabled).toBe(true);
+  });
+
+  it('search query with no signal keywords does not unlock anything', async () => {
+    const { server, controller } = createTieredServer();
+
+    await callTool(server, 'search', { query: 'find notes about cooking recipes' });
+
+    expect(controller.activeCategories.size).toBe(0);
+    expect((server as any)._registeredTools.graph_analysis.enabled).toBe(false);
+    expect((server as any)._registeredTools.vault_schema.enabled).toBe(false);
+  });
+
+  it('brief focus param triggers activation', async () => {
+    const { server, controller } = createTieredServer();
+
+    await callTool(server, 'brief', { focus: 'review backlinks and connections' });
+
+    expect(controller.activeCategories.has('graph')).toBe(true);
+  });
+
+  it('multiple signals in one query unlock multiple categories', async () => {
+    const { server, controller } = createTieredServer();
+
+    await callTool(server, 'search', { query: 'check backlinks and wikilinks for stale notes' });
+
+    expect(controller.activeCategories.has('graph')).toBe(true);
+    expect(controller.activeCategories.has('wikilinks')).toBe(true);
+    expect(controller.activeCategories.has('temporal')).toBe(true);
+  });
+
+  it('tier-2 signal does not unlock tier-3 categories', async () => {
+    const { server, controller } = createTieredServer();
+
+    await callTool(server, 'search', { query: 'show me backlinks and connections' });
+
+    expect(controller.activeCategories.has('graph')).toBe(true);
+    // schema (tier 3) and note-ops (tier 3) should stay locked
+    expect(controller.activeCategories.has('schema')).toBe(false);
+    expect(controller.activeCategories.has('note-ops')).toBe(false);
+    expect((server as any)._registeredTools.vault_schema.enabled).toBe(false);
+  });
+
+  it('non-search/brief tool calls do not trigger activation signals', async () => {
+    const { server, controller } = createTieredServer();
+
+    // Direct-call graph_analysis — it auto-enables its own category,
+    // but should NOT parse its params for activation of other categories
+    await callTool(server, 'graph_analysis', { query: 'wikilinks and schema' });
+
+    // graph is enabled (direct call auto-enable), but wikilinks/schema should NOT be
+    expect(controller.activeCategories.has('graph')).toBe(true);
+    expect(controller.activeCategories.has('wikilinks')).toBe(false);
+    expect(controller.activeCategories.has('schema')).toBe(false);
+  });
+});
+
+// ============================================================================
+// Token savings measurement
+// ============================================================================
+
+describe('token savings', () => {
+  it('tier-1 instructions are significantly smaller than full instructions', () => {
+    const tier1Only = generateInstructions(new Set(ALL_CATEGORIES), null, new Set());
+    const partialActive = generateInstructions(
+      new Set(ALL_CATEGORIES),
+      null,
+      new Set(['graph', 'wikilinks']),
+    );
+    const allActive = generateInstructions(
+      new Set(ALL_CATEGORIES),
+      null,
+      new Set(ALL_CATEGORIES),
+    );
+
+    // tier-1 < partial < all
+    expect(tier1Only.length).toBeLessThan(partialActive.length);
+    expect(partialActive.length).toBeLessThan(allActive.length);
+
+    // tier-1 should be at least 30% smaller than all-active
+    const savings = 1 - tier1Only.length / allActive.length;
+    expect(savings).toBeGreaterThanOrEqual(0.3);
+  });
+
+  it('escalation hints add minimal overhead compared to full category guidance', () => {
+    const tier1Only = generateInstructions(new Set(ALL_CATEGORIES), null, new Set());
+    const noTiering = generateInstructions(new Set(ALL_CATEGORIES), null);
+
+    // Without tiering (undefined activeTierCategories), all categories show full guidance
+    // With tiering + empty set, only tier-1 + hints shown — should be smaller
+    expect(tier1Only.length).toBeLessThan(noTiering.length);
+  });
+});
+
+// ============================================================================
+// Override modes
+// ============================================================================
+
+describe('override modes', () => {
+  it('minimal mode blocks activation signals from enabling tools', async () => {
+    const { server, controller } = createTieredServer();
+    const tools = (server as any)._registeredTools;
+
+    controller.setOverride('minimal');
+
+    await callTool(server, 'search', { query: 'show me backlinks' });
+
+    // Signal fired but minimal mode prevents enablement
+    expect(tools.graph_analysis.enabled).toBe(false);
+  });
+
+  it('full override enables all tools regardless of activation state', () => {
+    const { server, controller } = createTieredServer();
+    const tools = (server as any)._registeredTools;
+
+    controller.setOverride('full');
+
+    expect(tools.search.enabled).toBe(true);
+    expect(tools.graph_analysis.enabled).toBe(true);
+    expect(tools.vault_schema.enabled).toBe(true);
+    expect(tools.health_check.enabled).toBe(true);
+    expect(tools.merge_entities.enabled).toBe(true);
+  });
+
+  it('direct call to tier-3 tool in minimal mode returns error', async () => {
+    const { server, controller } = createTieredServer();
+
+    controller.setOverride('minimal');
+
+    // Minimal mode blocks even direct calls
+    const result = await callTool(server, 'vault_schema');
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('disabled');
+  });
+
+  it('switching from full back to auto re-applies tier restrictions', () => {
+    const { server, controller } = createTieredServer();
+    const tools = (server as any)._registeredTools;
+
+    controller.setOverride('full');
+    expect(tools.graph_analysis.enabled).toBe(true);
+
+    controller.setOverride('auto');
+    expect(tools.graph_analysis.enabled).toBe(false);
+    expect(tools.search.enabled).toBe(true);
+  });
+});
+
+// ============================================================================
+// Multi-vault tier isolation
+// ============================================================================
+
+describe('multi-vault tier isolation', () => {
+  it('tier state is per-controller — unlocking on one does not affect another', () => {
+    const serverA = new McpServer({ name: 'vault-a', version: '0.0.0' });
+    const controllerA = applyToolGating(
+      serverA,
+      new Set(ALL_CATEGORIES),
+      () => null,
+      null,
+      undefined,
+      undefined,
+      'tiered',
+    );
+    serverA.tool('search', { query: z.string().optional() }, async () => ({
+      content: [{ type: 'text' as const, text: 'a' }],
+    }));
+    serverA.tool('graph_analysis', async () => ({
+      content: [{ type: 'text' as const, text: 'a' }],
+    }));
+    controllerA.finalizeRegistration();
+
+    const serverB = new McpServer({ name: 'vault-b', version: '0.0.0' });
+    const controllerB = applyToolGating(
+      serverB,
+      new Set(ALL_CATEGORIES),
+      () => null,
+      null,
+      undefined,
+      undefined,
+      'tiered',
+    );
+    serverB.tool('search', { query: z.string().optional() }, async () => ({
+      content: [{ type: 'text' as const, text: 'b' }],
+    }));
+    serverB.tool('graph_analysis', async () => ({
+      content: [{ type: 'text' as const, text: 'b' }],
+    }));
+    controllerB.finalizeRegistration();
+
+    // Unlock graph on vault A
+    controllerA.enableTierCategory('graph');
+
+    // Vault A: graph enabled
+    expect((serverA as any)._registeredTools.graph_analysis.enabled).toBe(true);
+    expect(controllerA.activeCategories.has('graph')).toBe(true);
+
+    // Vault B: graph still disabled
+    expect((serverB as any)._registeredTools.graph_analysis.enabled).toBe(false);
+    expect(controllerB.activeCategories.has('graph')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Add 16 new tests to `tool-tiering.test.ts` (22 total, up from 6), closing T13 acceptance gaps
- **Activation signals**: 9 tests verifying search/brief query params trigger correct category unlocks, no-signal queries stay locked, tier-2 signals don't unlock tier-3, non-search tools don't trigger signals
- **Token savings**: 2 tests confirming tier-1 instructions are ≥30% smaller than full, and tiered mode is smaller than non-tiered
- **Override modes**: 4 tests for minimal/full/auto override behavior including direct-call blocking
- **Multi-vault isolation**: 1 test proving tier state is per-controller, not global

## Test plan
- [x] All 22 tool-tiering tests pass
- [x] Build clean (`npm run build`)
- [x] Full suite: 2,943 tests pass; 13 pre-existing failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)