### PR TITLE
feat: T15a — tool selection feedback loop

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -162,7 +162,7 @@ Start with `default`, then add what you need:
 | `memory` | 2 | Session memory + brief |
 | `note-ops` | 4 | Delete, move, rename notes, merge entities |
 | `temporal` | 4 | Time-based vault intelligence: get_context_around_date, predict_stale_notes, track_concept_evolution, temporal_summary |
-| `diagnostics` | 21 | Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status |
+| `diagnostics` | 22 | Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status |
 
 #### Recipes
 
@@ -209,7 +209,7 @@ Unknown names are ignored with a warning. If nothing valid is found, falls back 
 | `memory` | 2 | memory, brief |
 | `note-ops` | 4 | vault_delete_note, vault_move_note, vault_rename_note, merge_entities |
 | `temporal` | 4 | get_context_around_date, predict_stale_notes, track_concept_evolution, temporal_summary |
-| `diagnostics` | 21 | health_check, pipeline_status, get_vault_stats, get_folder_structure, refresh_index, get_all_entities, get_unlinked_mentions, vault_growth, vault_activity, flywheel_config, server_log, suggest_entity_merges, dismiss_merge_suggestion, vault_init, flywheel_doctor, flywheel_trust_report, flywheel_benchmark, vault_session_history, vault_entity_history, flywheel_learning_report, flywheel_calibration_export |
+| `diagnostics` | 22 | health_check, pipeline_status, get_vault_stats, get_folder_structure, refresh_index, get_all_entities, get_unlinked_mentions, vault_growth, vault_activity, flywheel_config, server_log, suggest_entity_merges, dismiss_merge_suggestion, vault_init, flywheel_doctor, flywheel_trust_report, flywheel_benchmark, vault_session_history, vault_entity_history, flywheel_learning_report, flywheel_calibration_export, tool_selection_feedback |
 
 Deprecated aliases (`minimal`, `writer`, `researcher`, `backlinks`, `structure`, `append`, `frontmatter`, `notes`, `orphans`, `hubs`, `paths`, `health`, `analysis`, `git`, `ops`) still work — they resolve to current category names.
 
@@ -228,7 +228,7 @@ Deprecated aliases (`minimal`, `writer`, `researcher`, `backlinks`, `structure`,
 | corrections | 4 | | Yes |
 | note-ops | 4 | | Yes |
 | temporal | 4 | | Yes |
-| diagnostics | 21 | | Yes |
+| diagnostics | 22 | | Yes |
 | **Total** | **76** | **18** | **76** |
 
 ### Semantic Embeddings

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,6 @@
 # Tools
 
-76 tools. Most questions only need one: **search**.
+77 tools. Most questions only need one: **search**.
 
 > **Start here:** Most vaults only need `default` (18 tools). Add bundles as you need them — `graph`, `schema`, `wikilinks`, `temporal`, `diagnostics`. See [CONFIGURATION.md](CONFIGURATION.md) for preset recipes.
 

--- a/packages/core/src/migrations.ts
+++ b/packages/core/src/migrations.ts
@@ -28,6 +28,7 @@ export const SALVAGE_TABLES = [
   'memories',
   'session_summaries',
   'corrections',
+  'tool_selection_feedback',
 ] as const;
 
 // =============================================================================
@@ -395,6 +396,19 @@ export function initSchema(db: Database.Database): void {
       }
 
       db.prepare('INSERT OR REPLACE INTO schema_version (version) VALUES (?)').run(35);
+    }
+
+
+    // v36: tool_selection_feedback table + query_context on tool_invocations
+    if (currentVersion < 36) {
+      const hasQueryContext = db.prepare(
+        `SELECT COUNT(*) as cnt FROM pragma_table_info('tool_invocations') WHERE name = 'query_context'`
+      ).get() as { cnt: number };
+      if (hasQueryContext.cnt === 0) {
+        db.exec('ALTER TABLE tool_invocations ADD COLUMN query_context TEXT');
+      }
+
+      db.prepare('INSERT OR REPLACE INTO schema_version (version) VALUES (?)').run(36);
     }
 
     db.prepare(

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -10,7 +10,7 @@
 // =============================================================================
 
 /** Current schema version - bump when schema changes */
-export const SCHEMA_VERSION = 35;
+export const SCHEMA_VERSION = 36;
 
 /** State database filename */
 export const STATE_DB_FILENAME = 'state.db';
@@ -208,7 +208,8 @@ CREATE TABLE IF NOT EXISTS tool_invocations (
   duration_ms INTEGER,
   success INTEGER NOT NULL DEFAULT 1,
   response_tokens INTEGER,
-  baseline_tokens INTEGER
+  baseline_tokens INTEGER,
+  query_context TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_tool_inv_ts ON tool_invocations(timestamp);
 CREATE INDEX IF NOT EXISTS idx_tool_inv_tool ON tool_invocations(tool_name, timestamp);
@@ -468,4 +469,23 @@ CREATE TABLE IF NOT EXISTS performance_benchmarks (
 );
 CREATE INDEX IF NOT EXISTS idx_perf_bench_ts ON performance_benchmarks(timestamp);
 CREATE INDEX IF NOT EXISTS idx_perf_bench_name ON performance_benchmarks(benchmark, timestamp);
+
+-- Tool selection feedback (v36: tool selection quality tracking)
+CREATE TABLE IF NOT EXISTS tool_selection_feedback (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp INTEGER NOT NULL,
+  tool_invocation_id INTEGER,
+  tool_name TEXT NOT NULL,
+  query_context TEXT,
+  expected_tool TEXT,
+  expected_category TEXT,
+  correct INTEGER,
+  source TEXT NOT NULL DEFAULT 'explicit',
+  rule_id TEXT,
+  rule_version INTEGER,
+  session_id TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_tsf_tool ON tool_selection_feedback(tool_name);
+CREATE INDEX IF NOT EXISTS idx_tsf_ts ON tool_selection_feedback(timestamp);
 `;

--- a/packages/core/test/backup.test.ts
+++ b/packages/core/test/backup.test.ts
@@ -337,7 +337,7 @@ describe('Backup & Recovery', () => {
   // Extended salvage scenarios
   // ===========================================================================
   describe('salvageFeedbackTables (extended)', () => {
-    it('salvages all 9 SALVAGE_TABLES when populated', () => {
+    it('salvages all 10 SALVAGE_TABLES when populated', () => {
       const sourceDb = openStateDb(testVaultPath);
       const now = Date.now();
 
@@ -369,6 +369,9 @@ describe('Backup & Recovery', () => {
       sourceDb.db.prepare(
         `INSERT INTO corrections (correction_type, description, source) VALUES (?, ?, ?)`
       ).run('wrong_link', 'test correction', 'user');
+      sourceDb.db.prepare(
+        `INSERT INTO tool_selection_feedback (timestamp, tool_name, correct, source) VALUES (?, ?, ?, ?)`
+      ).run(now, 'search', 1, 'explicit');
       sourceDb.close();
 
       const backupPath = `${dbPath}.full-salvage`;
@@ -382,7 +385,7 @@ describe('Backup & Recovery', () => {
 
       try {
         const results = salvageFeedbackTables(targetDb.db, backupPath);
-        // All 9 tables should have been salvaged
+        // All 10 tables should have been salvaged
         for (const table of SALVAGE_TABLES) {
           expect(results[table]).toBeGreaterThanOrEqual(1);
         }

--- a/packages/mcp-server/scripts/generate-tool-embeddings.ts
+++ b/packages/mcp-server/scripts/generate-tool-embeddings.ts
@@ -132,7 +132,13 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const entries = Array.from(catalog.values()).sort((a, b) => a.name.localeCompare(b.name));
+  // Meta-diagnostics tools excluded from semantic routing — they should not be
+  // activated by T14 embedding similarity.
+  const ROUTING_EXCLUDE = new Set(['tool_selection_feedback']);
+
+  const entries = Array.from(catalog.values())
+    .filter((e) => !ROUTING_EXCLUDE.has(e.name))
+    .sort((a, b) => a.name.localeCompare(b.name));
   const toolEntries: ManifestToolEntry[] = [];
 
   console.log(`Embedding ${entries.length} tool descriptions...`);

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -26,7 +26,7 @@ import type { VaultRegistry } from './vault-registry.js';
 //   memory      - Session memory + brief (2 tools)
 //   note-ops    - File management: delete, move, rename, merge (4 tools)
 //   temporal    - Time-based vault intelligence (4 tools)
-//   diagnostics - Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status (21 tools)
+//   diagnostics - Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status, tool selection feedback (22 tools)
 //
 // Examples:
 //   FLYWHEEL_TOOLS=default                    # 18 tools
@@ -230,7 +230,7 @@ export const TOOL_CATEGORY: Record<string, ToolCategory> = {
   track_concept_evolution: 'temporal',
   temporal_summary: 'temporal',
 
-  // diagnostics (21 tools) -- vault health, stats, config, activity, merges, doctor, trust, benchmark, history, learning report, calibration export, pipeline status
+  // diagnostics (22 tools) -- vault health, stats, config, activity, merges, doctor, trust, benchmark, history, learning report, calibration export, pipeline status, tool selection feedback
   health_check: 'diagnostics',
   pipeline_status: 'diagnostics',
   get_vault_stats: 'diagnostics',
@@ -252,6 +252,7 @@ export const TOOL_CATEGORY: Record<string, ToolCategory> = {
   vault_entity_history: 'diagnostics',
   flywheel_learning_report: 'diagnostics',
   flywheel_calibration_export: 'diagnostics',
+  tool_selection_feedback: 'diagnostics',
 
 };
 
@@ -337,6 +338,7 @@ export const TOOL_TIER: Record<string, ToolTier> = {
   vault_entity_history: 3,
   flywheel_learning_report: 3,
   flywheel_calibration_export: 3,
+  tool_selection_feedback: 3,
 };
 
 function assertToolTierCoverage(): void {

--- a/packages/mcp-server/src/core/read/learningReport.ts
+++ b/packages/mcp-server/src/core/read/learningReport.ts
@@ -7,6 +7,7 @@
  */
 
 import type { StateDb } from '@velvetmonkey/vault-core';
+import { getToolSelectionReport, type ToolSelectionReport } from '../shared/toolSelectionFeedback.js';
 
 // =============================================================================
 // TYPES
@@ -26,6 +27,7 @@ export interface LearningReport {
     survival_rate: number | null;
   };
   graph: { link_count: number; entity_count: number };
+  tool_selection?: ToolSelectionReport;
   comparison?: {
     previous_period: { start: string; end: string };
     applications_delta: number;
@@ -199,6 +201,12 @@ export function getLearningReport(
     funnel: queryFunnel(stateDb, bounds.start, bounds.end, bounds.startMs, bounds.endMs),
     graph: { link_count: linkCount, entity_count: entityCount },
   };
+
+  // Tool selection feedback — only include when data exists
+  const toolSelection = getToolSelectionReport(stateDb, daysBack);
+  if (toolSelection) {
+    report.tool_selection = toolSelection;
+  }
 
   if (compare) {
     const prevEnd = new Date(now);

--- a/packages/mcp-server/src/core/shared/toolSelectionFeedback.ts
+++ b/packages/mcp-server/src/core/shared/toolSelectionFeedback.ts
@@ -1,0 +1,292 @@
+/**
+ * Tool Selection Feedback — Core Logic
+ *
+ * Records and queries tool selection quality feedback.
+ * Follows the wikilink_feedback pattern: explicit user feedback drives
+ * Beta-Binomial posterior accuracy scoring per tool.
+ *
+ * Heuristic advisory rows (T15b) use correct=NULL and source='heuristic'
+ * and are excluded from accuracy scoring.
+ */
+
+import type { StateDb } from '@velvetmonkey/vault-core';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface ToolSelectionFeedbackEntry {
+  id: number;
+  timestamp: number;
+  tool_invocation_id: number | null;
+  tool_name: string;
+  query_context: string | null;
+  expected_tool: string | null;
+  expected_category: string | null;
+  correct: boolean | null;  // null = heuristic advisory (T15b)
+  source: 'explicit' | 'heuristic';
+  rule_id: string | null;
+  rule_version: number | null;
+  session_id: string | null;
+}
+
+export interface ToolSelectionStats {
+  tool_name: string;
+  total_feedback: number;
+  correct_count: number;
+  wrong_count: number;
+  posterior_accuracy: number;
+}
+
+export interface ToolSelectionReport {
+  total_feedback: number;
+  confirmed_correct: number;
+  confirmed_wrong: number;
+  accuracy_rate: number | null;
+  top_reported_wrong_tools: Array<{
+    tool_name: string;
+    wrong_count: number;
+    total_feedback: number;
+    wrong_rate: number;
+  }>;
+}
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/** Beta prior for tool selection accuracy (matches wikilink feedback) */
+const PRIOR_ALPHA = 4;
+const PRIOR_BETA = 1;
+
+// =============================================================================
+// RECORD
+// =============================================================================
+
+interface RawInvocationRow {
+  tool_name: string;
+  query_context: string | null;
+  session_id: string | null;
+}
+
+/**
+ * Record tool selection feedback.
+ * When tool_invocation_id is supplied, hydrates tool_name, query_context, and
+ * session_id from the tool_invocations table instead of trusting caller values.
+ */
+export function recordToolSelectionFeedback(
+  stateDb: StateDb,
+  feedback: {
+    tool_invocation_id?: number;
+    tool_name?: string;
+    expected_tool?: string;
+    expected_category?: string;
+    correct: boolean;
+    source?: 'explicit' | 'heuristic';
+    session_id?: string;
+  },
+): number {
+  let toolName = feedback.tool_name ?? '';
+  let queryContext: string | null = null;
+  let sessionId: string | null = feedback.session_id ?? null;
+
+  // Hydrate from invocation if ID supplied
+  if (feedback.tool_invocation_id) {
+    const row = stateDb.db.prepare(
+      'SELECT tool_name, query_context, session_id FROM tool_invocations WHERE id = ?'
+    ).get(feedback.tool_invocation_id) as RawInvocationRow | undefined;
+    if (row) {
+      toolName = row.tool_name;
+      queryContext = row.query_context;
+      sessionId = row.session_id ?? sessionId;
+    }
+  }
+
+  if (!toolName) {
+    throw new Error('tool_name is required when tool_invocation_id is not provided or not found');
+  }
+
+  const result = stateDb.db.prepare(
+    `INSERT INTO tool_selection_feedback
+     (timestamp, tool_invocation_id, tool_name, query_context, expected_tool, expected_category, correct, source, session_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    Date.now(),
+    feedback.tool_invocation_id ?? null,
+    toolName,
+    queryContext,
+    feedback.expected_tool ?? null,
+    feedback.expected_category ?? null,
+    feedback.correct ? 1 : 0,
+    feedback.source ?? 'explicit',
+    sessionId,
+  );
+  return Number(result.lastInsertRowid);
+}
+
+// =============================================================================
+// QUERY
+// =============================================================================
+
+/**
+ * Get recent feedback entries.
+ */
+export function getToolSelectionList(
+  stateDb: StateDb,
+  limit: number = 50,
+): ToolSelectionFeedbackEntry[] {
+  const rows = stateDb.db.prepare(
+    `SELECT * FROM tool_selection_feedback ORDER BY timestamp DESC LIMIT ?`
+  ).all(limit) as Array<{
+    id: number;
+    timestamp: number;
+    tool_invocation_id: number | null;
+    tool_name: string;
+    query_context: string | null;
+    expected_tool: string | null;
+    expected_category: string | null;
+    correct: number | null;
+    source: string;
+    rule_id: string | null;
+    rule_version: number | null;
+    session_id: string | null;
+  }>;
+
+  return rows.map(r => ({
+    id: r.id,
+    timestamp: r.timestamp,
+    tool_invocation_id: r.tool_invocation_id,
+    tool_name: r.tool_name,
+    query_context: r.query_context,
+    expected_tool: r.expected_tool,
+    expected_category: r.expected_category,
+    correct: r.correct === null ? null : r.correct === 1,
+    source: r.source as 'explicit' | 'heuristic',
+    rule_id: r.rule_id,
+    rule_version: r.rule_version,
+    session_id: r.session_id,
+  }));
+}
+
+/**
+ * Get per-tool selection accuracy using Beta-Binomial posterior.
+ * Only explicit feedback with non-NULL correct values contributes.
+ */
+export function getToolSelectionStats(
+  stateDb: StateDb,
+  daysBack: number = 30,
+): ToolSelectionStats[] {
+  const cutoff = Date.now() - daysBack * 24 * 60 * 60 * 1000;
+
+  const rows = stateDb.db.prepare(`
+    SELECT
+      tool_name,
+      COUNT(*) as total_feedback,
+      SUM(CASE WHEN correct = 1 THEN 1 ELSE 0 END) as correct_count,
+      SUM(CASE WHEN correct = 0 THEN 1 ELSE 0 END) as wrong_count
+    FROM tool_selection_feedback
+    WHERE timestamp >= ?
+      AND source = 'explicit'
+      AND correct IS NOT NULL
+    GROUP BY tool_name
+    ORDER BY total_feedback DESC
+  `).all(cutoff) as Array<{
+    tool_name: string;
+    total_feedback: number;
+    correct_count: number;
+    wrong_count: number;
+  }>;
+
+  return rows.map(r => {
+    const alpha = PRIOR_ALPHA + r.correct_count;
+    const beta = PRIOR_BETA + r.wrong_count;
+    return {
+      tool_name: r.tool_name,
+      total_feedback: r.total_feedback,
+      correct_count: r.correct_count,
+      wrong_count: r.wrong_count,
+      posterior_accuracy: Math.round((alpha / (alpha + beta)) * 1000) / 1000,
+    };
+  });
+}
+
+/**
+ * Get tool effectiveness scores for T14 integration.
+ * Returns a map of tool_name → posterior mean accuracy.
+ * Only tools with sufficient explicit feedback are included.
+ */
+export function getToolEffectivenessScores(
+  stateDb: StateDb,
+  minObservations: number = 15,
+): Map<string, number> {
+  const stats = getToolSelectionStats(stateDb, 365);
+  const scores = new Map<string, number>();
+  for (const s of stats) {
+    if (s.total_feedback >= minObservations) {
+      scores.set(s.tool_name, s.posterior_accuracy);
+    }
+  }
+  return scores;
+}
+
+/**
+ * Get summary report for learning report integration.
+ * Returns null when no feedback data exists (keep report clean).
+ */
+export function getToolSelectionReport(
+  stateDb: StateDb,
+  daysBack: number = 7,
+): ToolSelectionReport | null {
+  const cutoff = Date.now() - daysBack * 24 * 60 * 60 * 1000;
+
+  const totals = stateDb.db.prepare(`
+    SELECT
+      COUNT(*) as total_feedback,
+      SUM(CASE WHEN correct = 1 THEN 1 ELSE 0 END) as confirmed_correct,
+      SUM(CASE WHEN correct = 0 THEN 1 ELSE 0 END) as confirmed_wrong
+    FROM tool_selection_feedback
+    WHERE timestamp >= ?
+      AND source = 'explicit'
+      AND correct IS NOT NULL
+  `).get(cutoff) as {
+    total_feedback: number;
+    confirmed_correct: number;
+    confirmed_wrong: number;
+  };
+
+  if (totals.total_feedback === 0) return null;
+
+  const wrongTools = stateDb.db.prepare(`
+    SELECT
+      tool_name,
+      SUM(CASE WHEN correct = 0 THEN 1 ELSE 0 END) as wrong_count,
+      COUNT(*) as total_feedback
+    FROM tool_selection_feedback
+    WHERE timestamp >= ?
+      AND source = 'explicit'
+      AND correct IS NOT NULL
+    GROUP BY tool_name
+    HAVING wrong_count > 0
+    ORDER BY wrong_count DESC
+    LIMIT 10
+  `).all(cutoff) as Array<{
+    tool_name: string;
+    wrong_count: number;
+    total_feedback: number;
+  }>;
+
+  return {
+    total_feedback: totals.total_feedback,
+    confirmed_correct: totals.confirmed_correct,
+    confirmed_wrong: totals.confirmed_wrong,
+    accuracy_rate: totals.total_feedback > 0
+      ? Math.round((totals.confirmed_correct / totals.total_feedback) * 1000) / 1000
+      : null,
+    top_reported_wrong_tools: wrongTools.map(r => ({
+      tool_name: r.tool_name,
+      wrong_count: r.wrong_count,
+      total_feedback: r.total_feedback,
+      wrong_rate: Math.round((r.wrong_count / r.total_feedback) * 1000) / 1000,
+    })),
+  };
+}

--- a/packages/mcp-server/src/core/shared/toolTracking.ts
+++ b/packages/mcp-server/src/core/shared/toolTracking.ts
@@ -2,7 +2,7 @@
  * Tool Invocation Tracking
  *
  * Records and queries tool usage events.
- * Stored in StateDb tool_invocations table (schema v7).
+ * Stored in StateDb tool_invocations table (schema v7, query_context added v36).
  */
 
 import type { StateDb } from '@velvetmonkey/vault-core';
@@ -21,6 +21,7 @@ export interface ToolInvocation {
   success: boolean;
   response_tokens: number | null;
   baseline_tokens: number | null;
+  query_context: string | null;
 }
 
 export interface ToolUsageSummary {
@@ -52,7 +53,8 @@ export interface SessionSummary {
 // =============================================================================
 
 /**
- * Record a tool invocation to StateDb
+ * Record a tool invocation to StateDb.
+ * Returns the inserted row ID so callers can reference it (e.g. for feedback).
  */
 export function recordToolInvocation(
   stateDb: StateDb,
@@ -64,11 +66,12 @@ export function recordToolInvocation(
     success?: boolean;
     response_tokens?: number;
     baseline_tokens?: number;
+    query_context?: string;
   }
-): void {
-  stateDb.db.prepare(
-    `INSERT INTO tool_invocations (timestamp, tool_name, session_id, note_paths, duration_ms, success, response_tokens, baseline_tokens)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+): number {
+  const result = stateDb.db.prepare(
+    `INSERT INTO tool_invocations (timestamp, tool_name, session_id, note_paths, duration_ms, success, response_tokens, baseline_tokens, query_context)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     Date.now(),
     event.tool_name,
@@ -78,7 +81,9 @@ export function recordToolInvocation(
     event.success !== false ? 1 : 0,
     event.response_tokens ?? null,
     event.baseline_tokens ?? null,
+    event.query_context ?? null,
   );
+  return Number(result.lastInsertRowid);
 }
 
 // =============================================================================
@@ -95,6 +100,7 @@ interface RawInvocationRow {
   success: number;
   response_tokens: number | null;
   baseline_tokens: number | null;
+  query_context: string | null;
 }
 
 function rowToInvocation(row: RawInvocationRow): ToolInvocation {
@@ -108,6 +114,7 @@ function rowToInvocation(row: RawInvocationRow): ToolInvocation {
     success: row.success === 1,
     response_tokens: row.response_tokens,
     baseline_tokens: row.baseline_tokens,
+    query_context: row.query_context,
   };
 }
 

--- a/packages/mcp-server/src/tool-registry.ts
+++ b/packages/mcp-server/src/tool-registry.ts
@@ -61,6 +61,7 @@ import { registerSystemTools as registerWriteSystemTools } from './tools/write/s
 import { registerPolicyTools } from './tools/write/policy.js';
 import { registerTagTools } from './tools/write/tags.js';
 import { registerWikilinkFeedbackTools } from './tools/write/wikilinkFeedback.js';
+import { registerToolSelectionFeedbackTools } from './tools/write/toolSelectionFeedback.js';
 import { registerCorrectionTools } from './tools/write/corrections.js';
 import { registerMemoryTools } from './tools/write/memory.js';
 // recall removed — entity/memory search merged into search (uber search)
@@ -334,6 +335,34 @@ export function applyToolGating(
     enableCategory(category, tier);
   }
 
+
+  /** Max length for stored query context */
+  const MAX_QUERY_CONTEXT_LENGTH = 500;
+
+  /** Strict allowlist of intent-bearing param fields */
+  const QUERY_CONTEXT_FIELDS = ['query', 'focus', 'analysis', 'entity', 'heading', 'field', 'date', 'concept'] as const;
+
+  /**
+   * Extract user-intent query context from tool params.
+   * Strict allowlist — excludes content, description, frontmatter, yaml, policy, key, value, mode.
+   */
+  function extractQueryContext(params: unknown): string | undefined {
+    if (!params || typeof params !== 'object') return undefined;
+    const p = params as Record<string, unknown>;
+    const parts: string[] = [];
+    for (const field of QUERY_CONTEXT_FIELDS) {
+      const val = p[field];
+      if (typeof val === 'string' && val.trim()) {
+        parts.push(val.trim());
+      }
+    }
+    if (parts.length === 0) return undefined;
+    const joined = parts.join(' | ').replace(/\s+/g, ' ');
+    return joined.length > MAX_QUERY_CONTEXT_LENGTH
+      ? joined.slice(0, MAX_QUERY_CONTEXT_LENGTH)
+      : joined;
+  }
+
   function wrapWithTracking(toolName: string, handler: (...args: any[]) => any): (...args: any[]) => any {
     return async (...args: any[]) => {
       const start = Date.now();
@@ -399,6 +428,7 @@ export function applyToolGating(
               success,
               response_tokens: responseTokens,
               baseline_tokens: baselineTokens,
+              query_context: extractQueryContext(params),
             });
           } catch {
             // Never let tracking errors affect tool execution
@@ -764,6 +794,7 @@ export function registerAllTools(
   });
   registerTagTools(targetServer, gvi, gvp);
   registerWikilinkFeedbackTools(targetServer, gsd);
+  registerToolSelectionFeedbackTools(targetServer, gsd);
   registerCorrectionTools(targetServer, gsd);
   registerInitTools(targetServer, gvp, gsd);
   registerConfigTools(

--- a/packages/mcp-server/src/tools/read/sessionHistory.ts
+++ b/packages/mcp-server/src/tools/read/sessionHistory.ts
@@ -51,12 +51,14 @@ export function registerSessionHistoryTools(
           content: [{ type: 'text' as const, text: JSON.stringify({
             ...detail.summary,
             invocations: detail.invocations.map(inv => ({
+              invocation_id: inv.id,
               tool: inv.tool_name,
               timestamp: inv.timestamp,
               session_id: inv.session_id,
               note_paths: inv.note_paths,
               duration_ms: inv.duration_ms,
               success: inv.success,
+              query_context: inv.query_context,
             })),
           }, null, 2) }],
         };

--- a/packages/mcp-server/src/tools/write/toolSelectionFeedback.ts
+++ b/packages/mcp-server/src/tools/write/toolSelectionFeedback.ts
@@ -1,0 +1,127 @@
+/**
+ * Tool Selection Feedback tools
+ * Tools: tool_selection_feedback
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { StateDb } from '@velvetmonkey/vault-core';
+import {
+  recordToolSelectionFeedback,
+  getToolSelectionList,
+  getToolSelectionStats,
+} from '../../core/shared/toolSelectionFeedback.js';
+
+/**
+ * Register tool selection feedback tools
+ */
+export function registerToolSelectionFeedbackTools(
+  server: McpServer,
+  getStateDb: () => StateDb | null,
+): void {
+  server.registerTool(
+    'tool_selection_feedback',
+    {
+      title: 'Tool Selection Feedback',
+      description:
+        'Report and query tool selection quality. Tracks whether the right tool was picked for a given query. ' +
+        'Modes: "report" (record feedback — was the tool pick correct or wrong?), ' +
+        '"list" (recent feedback entries), ' +
+        '"stats" (per-tool posterior accuracy from explicit feedback), ' +
+        '"misroutes" (heuristic-detected advisory misroutes — T15b placeholder).',
+      inputSchema: {
+        mode: z.enum(['report', 'list', 'stats', 'misroutes']).describe('Operation mode'),
+        correct: z.boolean().optional().describe('Was the tool selection correct? (required for report mode)'),
+        tool_invocation_id: z.number().optional().describe('ID of the tool invocation being evaluated (preferred — hydrates tool_name, query_context, session_id automatically)'),
+        tool_name: z.string().optional().describe('Tool that was called (used when tool_invocation_id not available)'),
+        expected_tool: z.string().optional().describe('Tool that should have been called instead'),
+        expected_category: z.string().optional().describe('Category that should have been used instead'),
+        reason: z.string().optional().describe('Optional reason for the feedback'),
+        days_back: z.number().min(1).max(365).optional().describe('Lookback period for stats mode (default: 30)'),
+        limit: z.number().min(1).max(200).optional().describe('Max entries for list mode (default: 50)'),
+      },
+    },
+    async (args) => {
+      const stateDb = getStateDb();
+      if (!stateDb) {
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'StateDb not available' }) }],
+          isError: true,
+        };
+      }
+
+      switch (args.mode) {
+        case 'report': {
+          if (args.correct === undefined) {
+            return {
+              content: [{ type: 'text' as const, text: JSON.stringify({ error: 'correct (boolean) is required for report mode' }) }],
+              isError: true,
+            };
+          }
+          if (!args.tool_invocation_id && !args.tool_name) {
+            return {
+              content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Either tool_invocation_id or tool_name is required' }) }],
+              isError: true,
+            };
+          }
+
+          const id = recordToolSelectionFeedback(stateDb, {
+            tool_invocation_id: args.tool_invocation_id,
+            tool_name: args.tool_name,
+            expected_tool: args.expected_tool,
+            expected_category: args.expected_category,
+            correct: args.correct,
+          });
+
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({
+              recorded: true,
+              feedback_id: id,
+              correct: args.correct,
+              tool_invocation_id: args.tool_invocation_id ?? null,
+              tool_name: args.tool_name ?? null,
+              expected_tool: args.expected_tool ?? null,
+              expected_category: args.expected_category ?? null,
+            }, null, 2) }],
+          };
+        }
+
+        case 'list': {
+          const entries = getToolSelectionList(stateDb, args.limit ?? 50);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({
+              count: entries.length,
+              entries,
+            }, null, 2) }],
+          };
+        }
+
+        case 'stats': {
+          const stats = getToolSelectionStats(stateDb, args.days_back ?? 30);
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({
+              period_days: args.days_back ?? 30,
+              tools: stats,
+            }, null, 2) }],
+          };
+        }
+
+        case 'misroutes': {
+          // T15b placeholder — heuristic misroute detection not yet implemented
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({
+              message: 'Heuristic misroute detection not yet implemented (T15b). Use report mode to record explicit feedback.',
+              misroutes: [],
+            }, null, 2) }],
+          };
+        }
+
+        default:
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: `Unknown mode: ${args.mode}` }) }],
+            isError: true,
+          };
+      }
+    }
+  );
+}

--- a/packages/mcp-server/test/shared/toolSelectionFeedback.test.ts
+++ b/packages/mcp-server/test/shared/toolSelectionFeedback.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tool Selection Feedback Tests (T15a)
+ *
+ * Tests for query context extraction, feedback recording, hydration,
+ * Beta-Binomial posterior accuracy, and learning report integration.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { openStateDb, deleteStateDb, type StateDb } from '@velvetmonkey/vault-core';
+import { recordToolInvocation } from '../../src/core/shared/toolTracking.js';
+import {
+  recordToolSelectionFeedback,
+  getToolSelectionList,
+  getToolSelectionStats,
+  getToolEffectivenessScores,
+  getToolSelectionReport,
+} from '../../src/core/shared/toolSelectionFeedback.js';
+
+describe('Tool Selection Feedback', () => {
+  let tempDir: string;
+  let stateDb: StateDb;
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'tsf-test-'));
+    stateDb = openStateDb(tempDir);
+  });
+
+  afterAll(async () => {
+    try { stateDb.db.close(); } catch { /* ignore */ }
+    try { deleteStateDb(tempDir); } catch { /* ignore */ }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('recordToolInvocation returns id', () => {
+    it('should return a positive integer id', () => {
+      const id = recordToolInvocation(stateDb, {
+        tool_name: 'search',
+        query_context: 'quarterly review',
+      });
+      expect(id).toBeGreaterThan(0);
+      expect(typeof id).toBe('number');
+    });
+
+    it('should persist query_context', () => {
+      const id = recordToolInvocation(stateDb, {
+        tool_name: 'get_section_content',
+        query_context: 'Log',
+        session_id: 'test-session-1',
+      });
+
+      const row = stateDb.db.prepare(
+        'SELECT query_context, session_id FROM tool_invocations WHERE id = ?'
+      ).get(id) as { query_context: string; session_id: string };
+
+      expect(row.query_context).toBe('Log');
+      expect(row.session_id).toBe('test-session-1');
+    });
+
+    it('should store null query_context when not provided', () => {
+      const id = recordToolInvocation(stateDb, {
+        tool_name: 'vault_add_to_section',
+      });
+
+      const row = stateDb.db.prepare(
+        'SELECT query_context FROM tool_invocations WHERE id = ?'
+      ).get(id) as { query_context: string | null };
+
+      expect(row.query_context).toBeNull();
+    });
+  });
+
+  describe('recordToolSelectionFeedback', () => {
+    it('should record explicit feedback with tool_name', () => {
+      const id = recordToolSelectionFeedback(stateDb, {
+        tool_name: 'search',
+        correct: false,
+        expected_tool: 'temporal_summary',
+        expected_category: 'temporal',
+      });
+      expect(id).toBeGreaterThan(0);
+
+      const entries = getToolSelectionList(stateDb, 1);
+      expect(entries.length).toBeGreaterThan(0);
+      expect(entries[0].tool_name).toBe('search');
+      expect(entries[0].correct).toBe(false);
+      expect(entries[0].expected_tool).toBe('temporal_summary');
+      expect(entries[0].source).toBe('explicit');
+    });
+
+    it('should hydrate from tool_invocation_id', () => {
+      // First create an invocation
+      const invId = recordToolInvocation(stateDb, {
+        tool_name: 'get_backlinks',
+        query_context: 'connections to Alice',
+        session_id: 'hydrate-test',
+      });
+
+      // Record feedback pointing at that invocation
+      const feedbackId = recordToolSelectionFeedback(stateDb, {
+        tool_invocation_id: invId,
+        correct: true,
+      });
+
+      const entries = getToolSelectionList(stateDb, 10);
+      const entry = entries.find(e => e.id === feedbackId);
+      expect(entry).toBeDefined();
+      expect(entry!.tool_name).toBe('get_backlinks');
+      expect(entry!.query_context).toBe('connections to Alice');
+      expect(entry!.session_id).toBe('hydrate-test');
+      expect(entry!.correct).toBe(true);
+    });
+
+    it('should throw when neither tool_invocation_id nor tool_name provided', () => {
+      expect(() => recordToolSelectionFeedback(stateDb, {
+        correct: false,
+      })).toThrow('tool_name is required');
+    });
+  });
+
+  describe('getToolSelectionStats (Beta-Binomial)', () => {
+    let statsDb: StateDb;
+    let statsDir: string;
+
+    beforeAll(async () => {
+      statsDir = await mkdtemp(join(tmpdir(), 'tsf-stats-'));
+      statsDb = openStateDb(statsDir);
+
+      // 8 correct, 2 wrong for 'search'
+      for (let i = 0; i < 8; i++) {
+        recordToolSelectionFeedback(statsDb, { tool_name: 'search', correct: true });
+      }
+      for (let i = 0; i < 2; i++) {
+        recordToolSelectionFeedback(statsDb, { tool_name: 'search', correct: false });
+      }
+
+      // 3 correct, 7 wrong for 'vault_add_to_section'
+      for (let i = 0; i < 3; i++) {
+        recordToolSelectionFeedback(statsDb, { tool_name: 'vault_add_to_section', correct: true });
+      }
+      for (let i = 0; i < 7; i++) {
+        recordToolSelectionFeedback(statsDb, { tool_name: 'vault_add_to_section', correct: false });
+      }
+    });
+
+    afterAll(async () => {
+      try { statsDb.db.close(); } catch { /* ignore */ }
+      try { deleteStateDb(statsDir); } catch { /* ignore */ }
+      await rm(statsDir, { recursive: true, force: true });
+    });
+
+    it('should compute correct posterior for high-accuracy tool', () => {
+      const stats = getToolSelectionStats(statsDb, 30);
+      const searchStat = stats.find(s => s.tool_name === 'search');
+      expect(searchStat).toBeDefined();
+      // posterior = (4 + 8) / (4 + 8 + 1 + 2) = 12/15 = 0.8
+      expect(searchStat!.posterior_accuracy).toBe(0.8);
+      expect(searchStat!.correct_count).toBe(8);
+      expect(searchStat!.wrong_count).toBe(2);
+    });
+
+    it('should compute correct posterior for low-accuracy tool', () => {
+      const stats = getToolSelectionStats(statsDb, 30);
+      const addStat = stats.find(s => s.tool_name === 'vault_add_to_section');
+      expect(addStat).toBeDefined();
+      // posterior = (4 + 3) / (4 + 3 + 1 + 7) = 7/15 ≈ 0.467
+      expect(addStat!.posterior_accuracy).toBe(0.467);
+    });
+  });
+
+  describe('getToolEffectivenessScores', () => {
+    let effDb: StateDb;
+    let effDir: string;
+
+    beforeAll(async () => {
+      effDir = await mkdtemp(join(tmpdir(), 'tsf-eff-'));
+      effDb = openStateDb(effDir);
+
+      // 20 data points for 'search' (above threshold)
+      for (let i = 0; i < 15; i++) {
+        recordToolSelectionFeedback(effDb, { tool_name: 'search', correct: true });
+      }
+      for (let i = 0; i < 5; i++) {
+        recordToolSelectionFeedback(effDb, { tool_name: 'search', correct: false });
+      }
+
+      // 5 data points for 'brief' (below threshold)
+      for (let i = 0; i < 5; i++) {
+        recordToolSelectionFeedback(effDb, { tool_name: 'brief', correct: true });
+      }
+    });
+
+    afterAll(async () => {
+      try { effDb.db.close(); } catch { /* ignore */ }
+      try { deleteStateDb(effDir); } catch { /* ignore */ }
+      await rm(effDir, { recursive: true, force: true });
+    });
+
+    it('should include tools with sufficient observations', () => {
+      const scores = getToolEffectivenessScores(effDb, 15);
+      expect(scores.has('search')).toBe(true);
+      expect(scores.get('search')).toBeGreaterThan(0);
+    });
+
+    it('should exclude tools below observation threshold', () => {
+      const scores = getToolEffectivenessScores(effDb, 15);
+      expect(scores.has('brief')).toBe(false);
+    });
+  });
+
+  describe('getToolSelectionReport', () => {
+    it('should return null when no feedback exists', async () => {
+      const emptyDir = await mkdtemp(join(tmpdir(), 'tsf-empty-'));
+      const emptyDb = openStateDb(emptyDir);
+      try {
+        const report = getToolSelectionReport(emptyDb, 7);
+        expect(report).toBeNull();
+      } finally {
+        try { emptyDb.db.close(); } catch { /* ignore */ }
+        try { deleteStateDb(emptyDir); } catch { /* ignore */ }
+        await rm(emptyDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return report with data when feedback exists', async () => {
+      const reportDir = await mkdtemp(join(tmpdir(), 'tsf-report-'));
+      const reportDb = openStateDb(reportDir);
+      try {
+        recordToolSelectionFeedback(reportDb, { tool_name: 'search', correct: true });
+        recordToolSelectionFeedback(reportDb, { tool_name: 'search', correct: false });
+        recordToolSelectionFeedback(reportDb, { tool_name: 'get_backlinks', correct: false });
+
+        const report = getToolSelectionReport(reportDb, 7);
+        expect(report).not.toBeNull();
+        expect(report!.total_feedback).toBe(3);
+        expect(report!.confirmed_correct).toBe(1);
+        expect(report!.confirmed_wrong).toBe(2);
+        expect(report!.accuracy_rate).toBe(0.333);
+        expect(report!.top_reported_wrong_tools.length).toBeGreaterThan(0);
+      } finally {
+        try { reportDb.db.close(); } catch { /* ignore */ }
+        try { deleteStateDb(reportDir); } catch { /* ignore */ }
+        await rm(reportDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/packages/mcp-server/test/tool-routing.test.ts
+++ b/packages/mcp-server/test/tool-routing.test.ts
@@ -23,8 +23,8 @@ import {
 describe('tool catalog collector', () => {
   const catalog = collectToolCatalog();
 
-  it('collects exactly 76 tools', () => {
-    expect(catalog.size).toBe(76);
+  it('collects exactly 77 tools', () => {
+    expect(catalog.size).toBe(77);
   });
 
   it('tool names match TOOL_CATEGORY keys', () => {
@@ -81,17 +81,21 @@ describe('manifest freshness', () => {
     expect(manifest).toBeDefined();
   });
 
-  it('manifest tool count matches catalog size', async () => {
+  it('manifest tool count matches catalog minus routing-excluded tools', async () => {
     const mod = await import('../src/generated/tool-embeddings.generated.js');
     manifest = mod.TOOL_EMBEDDINGS_MANIFEST;
-    expect(manifest.tools.length).toBe(catalog.size);
+    // tool_selection_feedback is excluded from semantic routing (meta-diagnostics)
+    const ROUTING_EXCLUDED = 1;
+    expect(manifest.tools.length).toBe(catalog.size - ROUTING_EXCLUDED);
   });
 
-  it('manifest tool names match catalog names', async () => {
+  it('manifest tool names match catalog names minus routing-excluded', async () => {
     const mod = await import('../src/generated/tool-embeddings.generated.js');
     manifest = mod.TOOL_EMBEDDINGS_MANIFEST;
     const manifestNames = new Set(manifest.tools.map((t) => t.name));
     const catalogNames = new Set(catalog.keys());
+    // tool_selection_feedback intentionally excluded from semantic routing
+    catalogNames.delete('tool_selection_feedback');
     expect(manifestNames).toEqual(catalogNames);
   });
 

--- a/packages/mcp-server/test/write/docs/tool-counts.test.ts
+++ b/packages/mcp-server/test/write/docs/tool-counts.test.ts
@@ -218,6 +218,7 @@ describe('Tool Count Verification', () => {
         'flywheel_learning_report',
         'flywheel_calibration_export',
         'export_graph',
+        'tool_selection_feedback',
         'pipeline_status',
       ]);
 


### PR DESCRIPTION
## Summary

- Add query context capture alongside every tool invocation (strict allowlist: query, focus, analysis, entity, heading, field, date, concept)
- New `tool_selection_feedback` MCP tool for explicit feedback on whether the right tool was picked (report/list/stats/misroutes modes)
- Beta-Binomial posterior accuracy scoring per tool, matching the proven wikilink_feedback pattern
- `getToolEffectivenessScores()` as a cached hook for T15b → T14 semantic routing integration
- Learning report extended with optional tool_selection section (only when data exists)
- Schema v36: `query_context` on tool_invocations, `tool_selection_feedback` table, SALVAGE_TABLES updated
- `recordToolInvocation()` returns inserted row ID; `vault_session_history` surfaces invocation_id + query_context for feedback targeting
- Tool excluded from T14 semantic routing manifest (meta-diagnostics, tier 3)
- 77 tools total, 22 diagnostics

## Test plan

- [x] 12 new tests in `test/shared/toolSelectionFeedback.test.ts` (invocation ID return, query_context persistence, hydration from invocation, Beta-Binomial posteriors, effectiveness scores, report generation)
- [x] Tool count contracts pass (77 tools, 22 diagnostics, tier-1 at 18)
- [x] Tool routing tests updated (catalog 77, manifest 76 with routing exclusion)
- [x] Backup/salvage test updated for 10 SALVAGE_TABLES
- [x] Full suite: 2,995 pass (3 pre-existing package-startup failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)