### PR TITLE
docs: reframe presets around adaptive full and fixed agent (T12-T15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,10 @@
 ```
 packages/mcp-server/src/
 ├── index.ts                    # MCP server entry point + tool preset gating
+├── tool-registry.ts            # Tool gating, tiering, activation tracking
+├── config.ts                   # Tool categories, tiers, presets, instructions
 ├── tools/
+│   ├── toolCatalog.ts          # Tool metadata collection for embedding manifest
 │   ├── read/                   # Read-side tool registrations (20 files, helpers omitted)
 │   │   ├── query.ts            # search
 │   │   ├── primitives.ts       # get_note_structure, get_section_content, find_sections, tasks
@@ -52,17 +55,21 @@ packages/mcp-server/src/
 │       ├── merge.ts            # merge_entities, absorb_as_alias
 │       ├── corrections.ts      # vault_record_correction, vault_list_corrections, vault_resolve_correction
 │       ├── wikilinkFeedback.ts # wikilink_feedback
+│       ├── toolSelectionFeedback.ts # tool_selection_feedback
 │       ├── tags.ts             # rename_tag
 │       ├── memory.ts           # memory
 │       ├── config.ts           # flywheel_config
 │       ├── enrich.ts           # vault_init
 │       ├── system.ts           # vault_undo_last_mutation
 │       └── policy.ts           # policy
-└── core/
-    ├── read/                   # Read-side core logic (graph, vault, parser, fts5, config, watcher)
-    ├── write/                  # Write-side core logic (writer, wikilinks, git, validator, policy engine)
-    ├── shared/                 # Shared utilities (recency, cooccurrence, retrievalCooccurrence, hub export, stemmer, metrics, indexActivity, toolTracking, graphSnapshots)
-    └── semantic/               # Semantic search (embeddings.ts — embedding generation, similarity.ts — hybrid ranking)
+├── core/
+│   ├── read/                   # Read-side core logic (graph, vault, parser, fts5, config, watcher)
+│   │   └── toolRouting.ts      # Semantic tool routing, manifest loading
+│   ├── write/                  # Write-side core logic (writer, wikilinks, git, validator, policy engine)
+│   ├── shared/                 # Shared utilities (recency, cooccurrence, retrievalCooccurrence, hub export, stemmer, metrics, indexActivity, toolTracking, graphSnapshots, toolSelectionFeedback)
+│   └── semantic/               # Semantic search (embeddings.ts — embedding generation, similarity.ts — hybrid ranking)
+└── generated/
+    └── tool-embeddings.generated.ts  # Pre-computed tool embedding manifest
 ```
 
 ### Multi-Vault & Transport
@@ -81,6 +88,7 @@ packages/mcp-server/src/
 - Transport env vars: `FLYWHEEL_TRANSPORT` (stdio/http/both), `FLYWHEEL_HTTP_PORT` (default 3111), `FLYWHEEL_HTTP_HOST` (default 127.0.0.1).
 - Multi-vault: `FLYWHEEL_VAULTS=name1:/path1,name2:/path2`. First vault is primary. Falls back to `PROJECT_PATH`/`VAULT_PATH` for single-vault mode.
 - Cross-vault search: `wrapWithVaultActivation` detects `search` tool with no `vault` param → calls `crossVaultSearch()` which iterates all contexts, runs search per vault, merges results with `vault` field, sorts by `rrf_score`. Returns `method: 'cross_vault'`.
+- Tool routing: `FLYWHEEL_TOOL_ROUTING` (pattern/hybrid/semantic). Default is `hybrid` when `full` preset is active, `pattern` otherwise.
 
 ### Dependencies
 
@@ -102,15 +110,15 @@ Controlled by `FLYWHEEL_TOOLS` / `FLYWHEEL_PRESET` env var. Per-tool category ga
 - **`agent`** — 18 tools: search, read, write, tasks, memory
 
 **Composable bundles** (add to presets or each other):
-- **`graph`** — structural analysis, semantic analysis, paths, [[Hub|hubs]], connections, export (11 tools)
-- **`schema`** — schema intelligence + migrations (7 tools)
-- **`wikilinks`** — suggestions, validation, discovery (7 tools)
-- **`corrections`** — correction recording + resolution (4 tools)
-- **`tasks`** — task queries and mutations (3 tools)
-- **`memory`** — session memory + brief (2 tools)
-- **`note-ops`** — delete, move, rename, merge (4 tools)
-- **`temporal`** — time-based vault intelligence (4 tools)
-- **`diagnostics`** — vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status, tool selection feedback (22 tools)
+- **`graph`** — structural analysis, semantic analysis, paths, [[Hub|hubs]], connections, export
+- **`schema`** — schema intelligence + migrations
+- **`wikilinks`** — suggestions, validation, discovery
+- **`corrections`** — correction recording + resolution
+- **`tasks`** — task queries and mutations
+- **`memory`** — session memory + brief
+- **`note-ops`** — delete, move, rename, merge
+- **`temporal`** — time-based vault intelligence
+- **`diagnostics`** — vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status, tool selection feedback
 **Categories (12):** `search`, `read`, `write`, `graph`, `schema`, `wikilinks`, `corrections`, `tasks`, `memory`, `note-ops`, `temporal`, `diagnostics`
 
 ---

--- a/README.md
+++ b/README.md
@@ -99,18 +99,18 @@ Flywheel watches the vault, maintains local indexes, and serves the graph to MCP
 
 ### Tool presets
 
-| Preset | Tools | What you get |
-|--------|-------|--------------|
-| `default` | 18 | search, read, write, tasks, memory |
-| `full` | 75 | all tool categories |
+| Preset | Behaviour |
+|--------|-----------|
+| `full` (default) | All capabilities, progressively disclosed as your queries need them |
+| `agent` | Fixed reduced set — search, read, write, tasks, memory |
 
-Start with `default`. Add bundles when you need them, such as `graph`, `schema`, `wikilinks`, `temporal`, or `diagnostics`.
+Out of the box, Flywheel progressively surfaces specialised tools as the conversation needs them. For a fixed reduced set, use `agent`. Compose bundles for custom configurations.
 
 ```json
-{ "env": { "FLYWHEEL_TOOLS": "default,graph" } }
+{ "env": { "FLYWHEEL_TOOLS": "agent,graph" } }
 ```
 
-[Browse all 75 tools ->](docs/TOOLS.md) | [Preset recipes ->](docs/CONFIGURATION.md)
+[Browse all tools ->](docs/TOOLS.md) | [Preset recipes ->](docs/CONFIGURATION.md)
 
 ### Multiple vaults
 
@@ -165,6 +165,8 @@ If you want a managed cloud knowledge product, Flywheel is probably the wrong fi
 **Hybrid search** — Keyword search (BM25) finds what you said. Semantic search finds what you meant. Both fused via Reciprocal Rank Fusion, running locally. Nothing leaves your machine.
 
 **Multi-vault** — One server, multiple vaults, isolated state. Search without a vault filter queries all vaults and merges results.
+
+**Adaptive tool loading** — Under `full`, specialised tools surface when the conversation needs them. The default context stays focused; graph, schema, and temporal capabilities appear on demand.
 
 **Auditable writes** — Every mutation is git-committed, conflict-detected (SHA-256 content hash), and policy-governed. One undo reverts any change.
 
@@ -253,7 +255,7 @@ E2E with Claude Sonnet (latest checked-in 695-question run): **97.4%** single-ho
 | Doc | Why read it |
 |---|---|
 | [PROVE-IT.md](docs/PROVE-IT.md) | Start here to see the project working quickly |
-| [TOOLS.md](docs/TOOLS.md) | Full reference for all 75 tools |
+| [TOOLS.md](docs/TOOLS.md) | Full tool reference |
 | [COOKBOOK.md](docs/COOKBOOK.md) | Example prompts by use case |
 | [SETUP.md](docs/SETUP.md) | Full setup guide for your vault |
 | [CONFIGURATION.md](docs/CONFIGURATION.md) | Environment variables, presets, and custom tool sets |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 [← Back to docs](README.md)
 
-Flywheel Memory is a single MCP server that gives AI agents full read/write access to Obsidian vaults. It builds an in-memory index of every note, then exposes 75 tools for search, graph queries, and mutations.
+Flywheel Memory is a single MCP server that gives AI agents full read/write access to Obsidian vaults. It builds an in-memory index of every note, then exposes tools for search, graph queries, and mutations.
 
 - [Source Structure](#source-structure)
 - [Startup Flow](#startup-flow)
@@ -42,6 +42,13 @@ Flywheel Memory is a single MCP server that gives AI agents full read/write acce
   - [What's recorded](#whats-recorded)
   - [How to inspect](#how-to-inspect)
   - [Network access model](#network-access-model)
+- [Tool Selection & Routing](#tool-selection--routing)
+  - [Tiered Visibility](#tiered-visibility)
+  - [Pattern Routing](#pattern-routing)
+  - [Semantic Routing](#semantic-routing)
+  - [Routing Modes](#routing-modes)
+  - [Tool Invocation Tracking](#tool-invocation-tracking)
+  - [Feedback Loop](#feedback-loop)
 - [Module-Level State Isolation](#module-level-state-isolation)
   - [The Rule](#the-rule)
   - [Modules following this pattern](#modules-following-this-pattern)
@@ -57,9 +64,12 @@ packages/
 ├── mcp-server/                  # The MCP server (published as @velvetmonkey/flywheel-memory)
 │   └── src/
 │       ├── index.ts             # Entry point, tool preset gating, startup
+│       ├── config.ts            # Tool categories, tiers, presets, instruction generation
+│       ├── tool-registry.ts     # Tool gating, tiering, activation tracking
 │       ├── vault-registry.ts    # Multi-vault context management (VaultRegistry, parseVaultConfig)
 │       ├── vault-scope.ts       # Per-request vault isolation via AsyncLocalStorage
 │       ├── tools/
+│       │   ├── toolCatalog.ts   # Tool metadata collection for embedding manifest
 │       │   ├── read/            # Read tool registrations
 │       │   │   ├── query.ts     # search (unified: metadata + content + entities)
 │       │   │   ├── graph.ts     # get_backlinks (+ bidirectional), get_forward_links
@@ -84,59 +94,63 @@ packages/
 │       │       ├── system.ts    # vault_undo_last_mutation
 │       │       ├── policy.ts    # policy (unified: list, validate, preview, execute, author, revise)
 │       │       ├── memory.ts    # memory (agent working memory)
-│       │       └── config.ts    # flywheel_config (runtime configuration)
-│       └── core/
-│           ├── read/            # Read-side core logic
-│           │   ├── graph.ts     # Index building, backlinks, hubs, orphans, path finding
-│           │   ├── vault.ts     # Vault scanner (find all .md files)
-│           │   ├── parser.ts    # Note parser (frontmatter, outlinks, tags)
-│           │   ├── fts5.ts      # FTS5 full-text search
-│           │   ├── embeddings.ts # Embedding generation (all-MiniLM-L6-v2)
-│           │   ├── similarity.ts # Semantic similarity search
-│           │   ├── semantic.ts  # Hybrid search (BM25 + semantic via RRF)
-│           │   ├── config.ts    # Config inference and storage
-│           │   ├── types.ts     # VaultIndex, VaultNote, Backlink types
-│           │   ├── constants.ts # MAX_LIMIT and other constants
-│           │   ├── indexGuard.ts # Require-index-ready guard
-│           │   └── watch/       # File watcher subsystem
-│           │       ├── index.ts          # Vault watcher factory
-│           │       ├── eventQueue.ts     # Per-path debouncing
-│           │       ├── batchProcessor.ts # Event coalescing
-│           │       ├── incrementalIndex.ts # Incremental index updates
-│           │       ├── pathFilter.ts     # Path filtering (.obsidian, .git, etc.)
-│           │       └── selfHeal.ts       # Error recovery
-│           ├── write/           # Write-side core logic
-│           │   ├── writer.ts    # File read/write, section finding, content insertion
-│           │   ├── wikilinks.ts # Auto-wikilink application on writes
-│           │   ├── git.ts       # Git commit, undo, diff
-│           │   ├── validator.ts # Input validation and normalization
-│           │   ├── hints.ts     # Mutation hints
-│           │   ├── mutation-helpers.ts # Shared helpers (withVaultFile, error handling)
-│           │   └── policy/      # Policy execution engine
-│           │       ├── executor.ts  # Policy runner
-│           │       ├── parser.ts    # YAML policy parser
-│           │       ├── schema.ts    # Policy schema validation
-│           │       ├── conditions.ts # Conditional execution
-│           │       ├── template.ts  # Variable templating
-│           │       ├── storage.ts   # Policy file storage
-│           │       └── types.ts     # Policy types
-│           │   ├── memory.ts    # Agent memory lifecycle (store, search, brief)
-│           │   ├── corrections.ts # Pending correction processing
-│           │   ├── edgeWeights.ts # Edge weight computation
-│           │   └── wikilinkFeedback.ts # Wikilink feedback tracking
-│           └── shared/          # Shared between read/write
-│               ├── recency.ts   # Entity recency tracking
-│               ├── cooccurrence.ts # Co-occurrence analysis
-│               ├── hubExport.ts # Hub score export to StateDb
-│               ├── stemmer.ts   # Porter stemming
-│               ├── edgeWeights.ts # Edge weight scoring and persistence
-│               ├── taskCache.ts # Task cache for fast queries
-│               ├── toolTracking.ts # Tool invocation tracking
-│               ├── indexActivity.ts # Index rebuild activity logging
-│               ├── graphSnapshots.ts # Graph topology snapshots
-│               ├── retrievalCooccurrence.ts # Retrieval co-occurrence scoring (Adamic-Adar)
-│               ├── levenshtein.ts # Levenshtein distance for fuzzy matching
-│               └── metrics.ts    # Vault growth metrics
+│       │       ├── config.ts    # flywheel_config (runtime configuration)
+│       │       └── toolSelectionFeedback.ts # tool_selection_feedback
+│       ├── core/
+│       │   ├── read/            # Read-side core logic
+│       │   │   ├── graph.ts     # Index building, backlinks, hubs, orphans, path finding
+│       │   │   ├── vault.ts     # Vault scanner (find all .md files)
+│       │   │   ├── parser.ts    # Note parser (frontmatter, outlinks, tags)
+│       │   │   ├── fts5.ts      # FTS5 full-text search
+│       │   │   ├── embeddings.ts # Embedding generation (all-MiniLM-L6-v2)
+│       │   │   ├── similarity.ts # Semantic similarity search
+│       │   │   ├── semantic.ts  # Hybrid search (BM25 + semantic via RRF)
+│       │   │   ├── toolRouting.ts # Semantic tool routing, manifest loading
+│       │   │   ├── config.ts    # Config inference and storage
+│       │   │   ├── types.ts     # VaultIndex, VaultNote, Backlink types
+│       │   │   ├── constants.ts # MAX_LIMIT and other constants
+│       │   │   ├── indexGuard.ts # Require-index-ready guard
+│       │   │   └── watch/       # File watcher subsystem
+│       │   │       ├── index.ts          # Vault watcher factory
+│       │   │       ├── eventQueue.ts     # Per-path debouncing
+│       │   │       ├── batchProcessor.ts # Event coalescing
+│       │   │       ├── incrementalIndex.ts # Incremental index updates
+│       │   │       ├── pathFilter.ts     # Path filtering (.obsidian, .git, etc.)
+│       │   │       └── selfHeal.ts       # Error recovery
+│       │   ├── write/           # Write-side core logic
+│       │   │   ├── writer.ts    # File read/write, section finding, content insertion
+│       │   │   ├── wikilinks.ts # Auto-wikilink application on writes
+│       │   │   ├── git.ts       # Git commit, undo, diff
+│       │   │   ├── validator.ts # Input validation and normalization
+│       │   │   ├── hints.ts     # Mutation hints
+│       │   │   ├── mutation-helpers.ts # Shared helpers (withVaultFile, error handling)
+│       │   │   └── policy/      # Policy execution engine
+│       │   │       ├── executor.ts  # Policy runner
+│       │   │       ├── parser.ts    # YAML policy parser
+│       │   │       ├── schema.ts    # Policy schema validation
+│       │   │       ├── conditions.ts # Conditional execution
+│       │   │       ├── template.ts  # Variable templating
+│       │   │       ├── storage.ts   # Policy file storage
+│       │   │       └── types.ts     # Policy types
+│       │   │   ├── memory.ts    # Agent memory lifecycle (store, search, brief)
+│       │   │   ├── corrections.ts # Pending correction processing
+│       │   │   ├── edgeWeights.ts # Edge weight computation
+│       │   │   └── wikilinkFeedback.ts # Wikilink feedback tracking
+│       │   └── shared/          # Shared between read/write
+│       │       ├── recency.ts   # Entity recency tracking
+│       │       ├── cooccurrence.ts # Co-occurrence analysis
+│       │       ├── hubExport.ts # Hub score export to StateDb
+│       │       ├── stemmer.ts   # Porter stemming
+│       │       ├── edgeWeights.ts # Edge weight scoring and persistence
+│       │       ├── taskCache.ts # Task cache for fast queries
+│       │       ├── toolTracking.ts # Tool invocation and selection feedback tracking
+│       │       ├── indexActivity.ts # Index rebuild activity logging
+│       │       ├── graphSnapshots.ts # Graph topology snapshots
+│       │       ├── retrievalCooccurrence.ts # Retrieval co-occurrence scoring (Adamic-Adar)
+│       │       ├── levenshtein.ts # Levenshtein distance for fuzzy matching
+│       │       └── metrics.ts    # Vault growth metrics
+│       └── generated/
+│           └── tool-embeddings.generated.ts  # Pre-computed tool embedding manifest (checked in)
 ├── core/                        # Shared library (@velvetmonkey/vault-core)
 │   └── src/
 │       ├── sqlite.ts            # SQLite StateDb (consolidated state)
@@ -440,6 +454,12 @@ New tables are added directly to `SCHEMA_SQL` with `CREATE TABLE IF NOT EXISTS`,
 | v28 | Added `content_hashes` table (write conflict detection) |
 | v29 | Added `idx_wl_feedback_note_path` index on `wikilink_feedback(note_path)` for temporal analysis queries |
 | v30 | Added `response_tokens`/`baseline_tokens` on `tool_invocations` (token economics) + `retrieval_cooccurrence` table |
+| v31 | Added `proactive_queue` table (deferred proactive linking) |
+| v32 | Recreated `entity_changes` with rowid PK (drops composite PK that caused UNIQUE constraint crashes) |
+| v33 | Added `performance_benchmarks` table (longitudinal tracking) |
+| v34 | Rebuilt `entities_fts` as contentless FTS5 (fixes aliases column mismatch) |
+| v35 | Added `matched_term` column on `wikilink_feedback` and `wikilink_applications` (per-alias feedback tracking) |
+| v36 | Added `tool_selection_feedback` table + `query_context` column on `tool_invocations` |
 
 ---
 
@@ -525,6 +545,73 @@ Core indexing, search, graph analysis, and all write operations run with **zero 
 This is enforced by CI tests in `test/write/security/sovereignty.test.ts` that scan all production source files for network call patterns. Any new network call site must be added to an explicit allowlist with documentation.
 
 No telemetry. No analytics. No phone-home. No remote git operations.
+
+---
+
+## Tool Selection & Routing
+
+When `FLYWHEEL_TOOLS=full` (the default), tools are progressively disclosed across three tiers rather than registered all at once. The `tool-registry.ts` module manages this via `applyToolGating()`, which monkey-patches `server.tool()` to track registrations and control visibility through a `ToolTierController`.
+
+### Tiered Visibility
+
+| Tier | Visibility | Categories |
+|------|-----------|------------|
+| 1 | Always visible | search, read, write, tasks, memory |
+| 2 | Context-triggered | graph, wikilinks, corrections, temporal, diagnostics |
+| 3 | On-demand | schema, note-ops, deep diagnostics |
+
+Under `agent`, all tools in the preset are always visible with no tier gating.
+
+### Pattern Routing
+
+Seven `ACTIVATION_PATTERNS` in `tool-registry.ts` match query text from `search` and `brief` calls:
+
+- **Tier 2:** graph (backlinks, connections, hubs, paths), wikilinks (stubs, unlinked mentions), corrections (wrong links, mistakes), temporal (history, evolution, stale notes), diagnostics (health, config, pipeline)
+- **Tier 3:** schema (frontmatter, conventions, rename field), note-ops (delete note, move note, merge)
+
+### Semantic Routing
+
+A pre-generated embedding manifest (`generated/tool-embeddings.generated.ts`) contains 384-dimensional vectors for each tool description, computed with `Xenova/all-MiniLM-L6-v2`. At query time, `toolRouting.ts` embeds the query and scores it against the manifest:
+
+- Minimum query length: 2 tokens and 12 non-space characters
+- Cosine similarity threshold: 0.30
+- Tier-1 tools are skipped (always visible)
+- Collapses to one activation per category (highest-scoring tool's tier)
+- Returns at most 3 category/tier pairs
+
+Semantic routing fires only on hybrid search calls (requires `init_semantic`).
+
+### Routing Modes
+
+Controlled by `FLYWHEEL_TOOL_ROUTING`:
+
+| Mode | Behaviour |
+|------|-----------|
+| `pattern` | Regex activation only |
+| `hybrid` | Pattern + semantic signals combined (default when `full`) |
+| `semantic` | Semantic-only for hybrid search; regex fallback elsewhere |
+
+Both signal types are unioned. Per category, the highest tier from either signal wins.
+
+### Tool Invocation Tracking
+
+Every tool call is recorded by `recordToolInvocation()` in `core/shared/toolTracking.ts`:
+
+- Timestamp, tool name, session ID, affected note paths, duration, success/failure
+- `query_context`: extracted from a strict parameter allowlist (`query`, `focus`, `analysis`, `entity`, `heading`, `field`, `date`, `concept`), max 500 characters
+- Token estimates: `response_tokens` (from response size) and `baseline_tokens` (from file sizes)
+
+Invocations are stored in the `tool_invocations` table and purged after 90 days.
+
+### Feedback Loop
+
+The `tool_selection_feedback` table (schema v36) stores explicit feedback on whether the right tool was selected:
+
+- `tool_invocation_id` links to the original call (hydrates tool name, query context, session)
+- `correct` (boolean) drives accuracy scoring
+- `source`: `explicit` (user feedback) or `heuristic` (automated advisory, `correct = NULL`)
+
+Accuracy is computed as a Beta-Binomial posterior with prior α=4, β=1: `posterior = (α + correct_count) / (α + β + total_count)`. Tools need at least 15 observations before scores are reported.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -69,7 +69,7 @@ Two layers of configuration: **environment variables** set in your MCP config (s
 }
 ```
 
-No `FLYWHEEL_TOOLS` needed — defaults to `default` (18 tools). Add it only to override.
+No `FLYWHEEL_TOOLS` needed — defaults to `full` (adaptive progressive loading). Add it only to override.
 
 ### Claude Desktop (`claude_desktop_config.json`)
 
@@ -136,100 +136,116 @@ Vault root detection order:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `FLYWHEEL_TOOLS` | `default` | Preset, bundle, or comma-separated category list |
+| `FLYWHEEL_TOOLS` | `full` | Preset, bundle, or comma-separated category list |
 | `FLYWHEEL_PRESET` | — | Alias for `FLYWHEEL_TOOLS` (either works) |
 
 #### Quick Start
 
-| Preset | Tools | Use case |
-|--------|-------|----------|
-| `default` (default) | 18 | Note-taking essentials + memory — search, read, write, tasks, memory |
-| `full` | 76 | Everything (all 12 categories, with tiered visibility by default) |
-
-The fewer tools you load, the less context Claude needs to pick the right one.
+| Preset | Behaviour |
+|--------|-----------|
+| `full` (default) | All capabilities with progressive disclosure — tools surface as needed |
+| `agent` | Fixed reduced set — search, read, write, tasks, memory |
 
 #### Composable Bundles
 
-Start with `default`, then add what you need:
+Start with `agent`, then add what you need:
 
-| Bundle | Tools | What it adds |
-|--------|-------|--------------|
-| `graph` | 11 | Structural analysis, semantic analysis, backlinks, forward links, hubs, paths, connections, graph export |
-| `schema` | 7 | Schema inspection, conventions, validation, note intelligence, migrations, tag rename |
-| `wikilinks` | 7 | Link suggestions, validation, feedback, discovery |
-| `corrections` | 4 | Correction recording + resolution |
-| `tasks` | 3 | Task queries and mutations (already included in `default`) |
-| `memory` | 2 | Session memory + brief |
-| `note-ops` | 4 | Delete, move, rename notes, merge entities |
-| `temporal` | 4 | Time-based vault intelligence: get_context_around_date, predict_stale_notes, track_concept_evolution, temporal_summary |
-| `diagnostics` | 22 | Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status |
+| Bundle | What it adds |
+|--------|--------------|
+| `graph` | Structural analysis, semantic analysis, backlinks, forward links, hubs, paths, connections, graph export |
+| `schema` | Schema inspection, conventions, validation, note intelligence, migrations, tag rename |
+| `wikilinks` | Link suggestions, validation, feedback, discovery |
+| `corrections` | Correction recording + resolution |
+| `tasks` | Task queries and mutations (already included in `agent`) |
+| `memory` | Session memory + brief |
+| `note-ops` | Delete, move, rename notes, merge entities |
+| `temporal` | Time-based vault intelligence: get_context_around_date, predict_stale_notes, track_concept_evolution, temporal_summary |
+| `diagnostics` | Vault health, stats, config, activity, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status |
 
 #### Recipes
 
-| Config | Tools | What you get |
-|--------|-------|--------------|
-| `default` | 18 | search, read, write, tasks, memory |
-| `default,graph` | 29 | default + graph analysis, semantic analysis, paths, hubs |
-| `default,graph,wikilinks` | 36 | + link suggestions, validation |
-| `full` | 76 | All 12 categories |
+| Config | What you get |
+|--------|--------------|
+| `agent` | search, read, write, tasks, memory |
+| `agent,graph` | agent + graph analysis, semantic analysis, paths, hubs |
+| `agent,graph,wikilinks` | + link suggestions, validation |
+| `full` | All categories, progressively disclosed |
 
 #### How It Works
 
 Set `FLYWHEEL_TOOLS` to a preset, one or more bundles, individual categories, or any combination — comma-separated. Bundles expand to their constituent categories, and duplicates are deduplicated automatically.
 
-Flywheel uses tiered exposure by default when all categories are enabled (the `full` preset):
-- Tier 1 stays visible at startup: the 18 tools from the `agent` core
-- Tier 2 unlocks when the conversation clearly shifts into graph, wikilink, correction, temporal, or diagnostics work
-- Tier 3 stays on-demand for explicit schema operations, note operations, and deep diagnostics
+`full` is the default. With no `FLYWHEEL_TOOLS` set, all categories are enabled and tools are progressively disclosed across three tiers:
+
+- **Tier 1** stays visible at startup: the core tools from `agent` (search, read, write, tasks, memory)
+- **Tier 2** unlocks when the conversation shifts into graph, wikilink, correction, temporal, or diagnostics work
+- **Tier 3** stays on-demand for schema operations, note operations, and deep diagnostics
+
+`agent` is the fixed alternative — all tools in the preset are always visible, with no tier gating.
+
+`default` is a deprecated alias for `full`, retained for backward compatibility.
 
 Use `flywheel_config({ mode: "set", key: "tool_tier_override", value: "full" })` to reveal everything immediately, or `"minimal"` to keep only tier-1 tools advertised.
 
 ```json
 {
   "env": {
-    "FLYWHEEL_TOOLS": "default,graph,tasks"
+    "FLYWHEEL_TOOLS": "agent,graph,tasks"
   }
 }
 ```
 
-Unknown names are ignored with a warning. If nothing valid is found, falls back to `default`.
+Unknown names are ignored with a warning. If nothing valid is found, falls back to `full`.
+
+#### Tool Routing
+
+`FLYWHEEL_TOOL_ROUTING` controls how tier-2 and tier-3 tools are activated:
+
+| Mode | Behaviour |
+|------|-----------|
+| `pattern` | Regex-only activation from query keywords |
+| `hybrid` (default under `full`) | Regex + semantic embedding signals combined |
+| `semantic` | Semantic-only for hybrid search calls; regex fallback elsewhere |
+
+Semantic activation fires only on `search` and `brief` calls that use the hybrid search path (requires `init_semantic`). The query is embedded and compared against a pre-generated tool description manifest. Hits with cosine similarity ≥ 0.30 activate the corresponding category, up to three categories per query. Both pattern and semantic signals are combined; the highest tier per category wins.
+
+Custom `EMBEDDING_MODEL` users fall back to `pattern` unless the tool manifest was regenerated for that model (`npm run generate:tool-embeddings`).
 
 #### Category Reference
 
-| Category | Tools | What's included |
-|----------|-------|-----------------|
-| `search` | 3 | search, init_semantic, find_similar |
-| `read` | 3 | get_note_structure, get_section_content, find_sections |
-| `write` | 7 | vault_add_to_section, vault_remove_from_section, vault_replace_in_section, vault_update_frontmatter, vault_create_note, vault_undo_last_mutation, policy |
-| `graph` | 11 | graph_analysis, semantic_analysis, get_backlinks, get_forward_links, get_connection_strength, list_entities, get_link_path, get_common_neighbors, get_weighted_links, get_strong_connections, export_graph |
-| `schema` | 7 | vault_schema, schema_conventions, schema_validate, note_intelligence, rename_field, migrate_field_values, rename_tag |
-| `wikilinks` | 7 | suggest_wikilinks, validate_links, wikilink_feedback, discover_stub_candidates, discover_cooccurrence_gaps, suggest_entity_aliases, unlinked_mentions_report |
-| `corrections` | 4 | vault_record_correction, vault_list_corrections, vault_resolve_correction, absorb_as_alias |
-| `tasks` | 3 | tasks, vault_toggle_task, vault_add_task |
-| `memory` | 2 | memory, brief |
-| `note-ops` | 4 | vault_delete_note, vault_move_note, vault_rename_note, merge_entities |
-| `temporal` | 4 | get_context_around_date, predict_stale_notes, track_concept_evolution, temporal_summary |
-| `diagnostics` | 22 | health_check, pipeline_status, get_vault_stats, get_folder_structure, refresh_index, get_all_entities, get_unlinked_mentions, vault_growth, vault_activity, flywheel_config, server_log, suggest_entity_merges, dismiss_merge_suggestion, vault_init, flywheel_doctor, flywheel_trust_report, flywheel_benchmark, vault_session_history, vault_entity_history, flywheel_learning_report, flywheel_calibration_export, tool_selection_feedback |
+| Category | What's included |
+|----------|-----------------|
+| `search` | search, init_semantic, find_similar |
+| `read` | get_note_structure, get_section_content, find_sections |
+| `write` | vault_add_to_section, vault_remove_from_section, vault_replace_in_section, vault_update_frontmatter, vault_create_note, vault_undo_last_mutation, policy |
+| `graph` | graph_analysis, semantic_analysis, get_backlinks, get_forward_links, get_connection_strength, list_entities, get_link_path, get_common_neighbors, get_weighted_links, get_strong_connections, export_graph |
+| `schema` | vault_schema, schema_conventions, schema_validate, note_intelligence, rename_field, migrate_field_values, rename_tag |
+| `wikilinks` | suggest_wikilinks, validate_links, wikilink_feedback, discover_stub_candidates, discover_cooccurrence_gaps, suggest_entity_aliases, unlinked_mentions_report |
+| `corrections` | vault_record_correction, vault_list_corrections, vault_resolve_correction, absorb_as_alias |
+| `tasks` | tasks, vault_toggle_task, vault_add_task |
+| `memory` | memory, brief |
+| `note-ops` | vault_delete_note, vault_move_note, vault_rename_note, merge_entities |
+| `temporal` | get_context_around_date, predict_stale_notes, track_concept_evolution, temporal_summary |
+| `diagnostics` | health_check, pipeline_status, get_vault_stats, get_folder_structure, refresh_index, get_all_entities, get_unlinked_mentions, vault_growth, vault_activity, flywheel_config, server_log, suggest_entity_merges, dismiss_merge_suggestion, vault_init, flywheel_doctor, flywheel_trust_report, flywheel_benchmark, vault_session_history, vault_entity_history, flywheel_learning_report, flywheel_calibration_export, tool_selection_feedback |
 
 Deprecated aliases (`minimal`, `writer`, `researcher`, `backlinks`, `structure`, `append`, `frontmatter`, `notes`, `orphans`, `hubs`, `paths`, `health`, `analysis`, `git`, `ops`) still work — they resolve to current category names.
 
 #### Preset → Category Mapping
 
-| Category | Tools | `default` | `full` |
-|----------|------:|:---------:|:------:|
-| search | 3 | Yes | Yes |
-| read | 3 | Yes | Yes |
-| write | 7 | Yes | Yes |
-| tasks | 3 | Yes | Yes |
-| memory | 2 | Yes | Yes |
-| graph | 11 | | Yes |
-| schema | 7 | | Yes |
-| wikilinks | 7 | | Yes |
-| corrections | 4 | | Yes |
-| note-ops | 4 | | Yes |
-| temporal | 4 | | Yes |
-| diagnostics | 22 | | Yes |
-| **Total** | **76** | **18** | **76** |
+| Category | `agent` | `full` |
+|----------|:-------:|:------:|
+| search | Yes | Yes |
+| read | Yes | Yes |
+| write | Yes | Yes |
+| tasks | Yes | Yes |
+| memory | Yes | Yes |
+| graph | | Yes |
+| schema | | Yes |
+| wikilinks | | Yes |
+| corrections | | Yes |
+| note-ops | | Yes |
+| temporal | | Yes |
+| diagnostics | | Yes |
 
 ### Semantic Embeddings
 
@@ -257,7 +273,7 @@ Any HuggingFace Transformers-compatible model can be used — unknown models aut
 | `FLYWHEEL_SKIP_FTS5` | `false` | Skip FTS5 full-text search index build at startup. Useful for testing. |
 | `FLYWHEEL_SKIP_EMBEDDINGS` | `false` | Skip automatic embedding rebuild at startup |
 | `FLYWHEEL_AGENT_ID` | — | Agent identifier for multi-agent memory provenance. When set, memories stored via the `memory` tool are tagged with this ID. |
-| `FLYWHEEL_TOOL_ROUTING` | `hybrid` | Tool activation routing mode. `pattern` = regex-only (T13 behavior), `hybrid` = regex + semantic embedding signals, `semantic` = semantic-only for hybrid search calls (regex fallback elsewhere). Default is `hybrid` when tiered exposure is active, `pattern` otherwise. Semantic activation only fires on search calls that use the hybrid search path (requires `init_semantic`). Custom `EMBEDDING_MODEL` users fall back to `pattern` unless the manifest was regenerated for that model. |
+| `FLYWHEEL_TOOL_ROUTING` | `hybrid` | Tool activation routing mode. `pattern` = regex-only (T13 behavior), `hybrid` = regex + semantic embedding signals, `semantic` = semantic-only for hybrid search calls (regex fallback elsewhere). Default is `hybrid` when tiered exposure is active, `pattern` otherwise. Semantic activation only fires on search calls that use the hybrid search path (requires `init_semantic`). Custom `EMBEDDING_MODEL` users fall back to `pattern` unless the manifest was regenerated for that model. See [Tool Routing](#tool-routing) above for details. |
 
 ### Transport
 
@@ -634,26 +650,26 @@ Smallest tool set for voice pipelines or mobile contexts:
 ```json
 {
   "env": {
-    "FLYWHEEL_TOOLS": "default"
+    "FLYWHEEL_TOOLS": "agent"
   }
 }
 ```
 
 ### Note-Taking + Tasks
 
-Daily notes, task management, basic editing — the `default` preset includes tasks:
+Daily notes, task management, basic editing — the `agent` preset includes tasks:
 
 ```json
 {
   "env": {
-    "FLYWHEEL_TOOLS": "default"
+    "FLYWHEEL_TOOLS": "agent"
   }
 }
 ```
 
 ### Memory-Enabled Sessions
 
-Memory tools (brief, memory) are included in the default preset. No additional configuration needed.
+Memory tools (brief, memory) are included in the `agent` preset. No additional configuration needed.
 
 ### Knowledge Work
 
@@ -662,7 +678,7 @@ Note-taking + graph navigation for research and consulting:
 ```json
 {
   "env": {
-    "FLYWHEEL_TOOLS": "default,graph,tasks"
+    "FLYWHEEL_TOOLS": "agent,graph,tasks"
   }
 }
 ```
@@ -674,7 +690,7 @@ Full graph + schema + wikilink intelligence for deep analysis:
 ```json
 {
   "env": {
-    "FLYWHEEL_TOOLS": "default,graph,wikilinks"
+    "FLYWHEEL_TOOLS": "agent,graph,wikilinks"
   }
 }
 ```

--- a/docs/OPENCLAW.md
+++ b/docs/OPENCLAW.md
@@ -59,8 +59,7 @@ Add Flywheel to `~/.openclaw/openclaw.json`:
         "command": "npx",
         "args": ["-y", "@velvetmonkey/flywheel-memory"],
         "env": {
-          "VAULT_PATH": "/path/to/your/vault",
-          "FLYWHEEL_TOOLS": "default"
+          "VAULT_PATH": "/path/to/your/vault"
         }
       }
     }
@@ -71,7 +70,7 @@ Add Flywheel to `~/.openclaw/openclaw.json`:
 This is the minimum useful integration:
 
 - `VAULT_PATH` points Flywheel at the Obsidian vault you want the bot to use
-- `FLYWHEEL_TOOLS` chooses how much of Flywheel's tool surface OpenClaw sees
+- Flywheel defaults to the full tool surface. Set `FLYWHEEL_TOOLS` to restrict it (see Step 4).
 
 Restart OpenClaw after editing the config.
 
@@ -146,13 +145,13 @@ OpenClaw's `bindings[]` model is the right place to decide which conversations g
 
 | Preset | When to use it | What you get |
 |--------|----------------|--------------|
-| `default` | Best starting point for most OpenClaw bots | search, read, write, tasks, memory |
-| `full` | When the bot should be able to use the entire vault surface | all 75 Flywheel tools |
-| `default,graph,wikilinks` | Good middle ground for assistant-style bots that need richer graph context | default plus graph and linking tools |
+| `agent` | Best starting point for most OpenClaw bots | search, read, write, tasks, memory |
+| `full` | When the bot should be able to use the entire vault surface | all Flywheel tools, progressively disclosed |
+| `agent,graph,wikilinks` | Good middle ground for assistant-style bots that need richer graph context | agent plus graph and linking tools |
 
 Recommended starting point:
 
-- Start with `default` for note capture, search, task updates, and general vault Q&A.
+- Start with `agent` for note capture, search, task updates, and general vault Q&A.
 - Move to `full` when you want graph analysis, schema tools, diagnostics, temporal tools, or policy authoring without revisiting the config.
 - Use explicit bundles if you know exactly what the bot should and should not be able to touch.
 
@@ -241,8 +240,7 @@ That matters for Codex, Claude Code, and other ACP-backed sessions launched from
         "command": "npx",
         "args": ["-y", "@velvetmonkey/flywheel-memory"],
         "env": {
-          "VAULT_PATH": "/home/you/obsidian/WorkVault",
-          "FLYWHEEL_TOOLS": "default"
+          "VAULT_PATH": "/home/you/obsidian/WorkVault"
         }
       }
     }

--- a/docs/PROVE-IT.md
+++ b/docs/PROVE-IT.md
@@ -371,6 +371,6 @@ Flywheel's enriched search returns frontmatter, ranked backlinks, ranked outlink
 ## Next Steps
 
 - **[SETUP.md](SETUP.md)** -- Full setup guide for your own vault
-- **[TOOLS.md](TOOLS.md)** -- Reference for all 75 tools
+- **[TOOLS.md](TOOLS.md)** -- Reference for all tools
 - **[ALGORITHM.md](ALGORITHM.md)** -- How scoring, ranking, and wikilink suggestion work
 - **[COOKBOOK.md](COOKBOOK.md)** -- Example prompts by use case

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@
 |----------|-------------|--------------|
 | [SETUP.md](SETUP.md) | Set up your own vault — prerequisites, config, first commands | "How do I get started with my own vault?" |
 | [OPENCLAW.md](OPENCLAW.md) | Wire Flywheel into OpenClaw with MCP, agent bindings, and tool presets | "How should I set up Flywheel behind an OpenClaw bot?" |
-| [TOOLS.md](TOOLS.md) | Full tool reference — 75 tools across 12 categories | "What tools are available and what do they do?" |
+| [TOOLS.md](TOOLS.md) | Full tool reference | "What tools are available and what do they do?" |
 | [COOKBOOK.md](COOKBOOK.md) | Example prompts organized by use case | "What can I ask Claude to do with my vault?" |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Index strategy, FTS5 search, graph model, auto-wikilinks | "How does Flywheel work under the hood?" |
 | [CONFIGURATION.md](CONFIGURATION.md) | Environment variables, tool presets, platform setup | "How do I customize my setup?" |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -126,10 +126,7 @@ Create `.mcp.json` in your vault root:
   "mcpServers": {
     "flywheel": {
       "command": "npx",
-      "args": ["-y", "@velvetmonkey/flywheel-memory"],
-      "env": {
-        "FLYWHEEL_TOOLS": "default"
-      }
+      "args": ["-y", "@velvetmonkey/flywheel-memory"]
     }
   }
 }
@@ -150,8 +147,7 @@ cd /path/to/your/vault && claude
       "command": "npx",
       "args": ["-y", "@velvetmonkey/flywheel-memory"],
       "env": {
-        "FLYWHEEL_VAULTS": "personal:/home/you/obsidian/Personal,work:/home/you/obsidian/Work",
-        "FLYWHEEL_TOOLS": "default"
+        "FLYWHEEL_VAULTS": "personal:/home/you/obsidian/Personal,work:/home/you/obsidian/Work"
       }
     }
   }
@@ -171,8 +167,7 @@ Edit `claude_desktop_config.json` (Settings > Developer > Edit Config):
       "command": "npx",
       "args": ["-y", "@velvetmonkey/flywheel-memory"],
       "env": {
-        "VAULT_PATH": "/path/to/your/vault",
-        "FLYWHEEL_TOOLS": "default"
+        "VAULT_PATH": "/path/to/your/vault"
       }
     }
   }
@@ -190,8 +185,7 @@ Claude Desktop requires `VAULT_PATH` because it doesn't launch from the vault di
       "command": "npx",
       "args": ["-y", "@velvetmonkey/flywheel-memory"],
       "env": {
-        "FLYWHEEL_VAULTS": "personal:/home/you/obsidian/Personal,work:/home/you/obsidian/Work",
-        "FLYWHEEL_TOOLS": "default"
+        "FLYWHEEL_VAULTS": "personal:/home/you/obsidian/Personal,work:/home/you/obsidian/Work"
       }
     }
   }
@@ -214,8 +208,7 @@ Add this to `~/.openclaw/openclaw.json`:
         "command": "npx",
         "args": ["-y", "@velvetmonkey/flywheel-memory"],
         "env": {
-          "VAULT_PATH": "/path/to/your/vault",
-          "FLYWHEEL_TOOLS": "default"
+          "VAULT_PATH": "/path/to/your/vault"
         }
       }
     }
@@ -225,14 +218,14 @@ Add this to `~/.openclaw/openclaw.json`:
 
 Restart OpenClaw. Flywheel appears as an MCP server with search, read, write, and memory tools.
 
-The `default` preset includes search, read, write, tasks, and memory. For everything, use `"full"`.
+Flywheel defaults to the full tool surface. Use `"FLYWHEEL_TOOLS": "agent"` for a reduced set (search, read, write, tasks, memory).
 
 Recommended next step: read the dedicated [OpenClaw integration guide](OPENCLAW.md). It covers the pattern that works best in practice:
 
 - configure Flywheel on the OpenClaw gateway/agent
 - route the right channels to a dedicated OpenClaw agent
 - keep OpenClaw workspace and Obsidian vault separate unless you intentionally want them combined
-- choose `FLYWHEEL_TOOLS` based on whether you want basic note memory (`default`) or the full vault surface (`full`)
+- choose `FLYWHEEL_TOOLS` based on whether you want the full vault surface (default) or a reduced set (`agent`)
 
 OpenClaw connects via stdio here, same as Claude Desktop. For HTTP transport (e.g., running Flywheel as a shared service), see the [HTTP Clients](#http-clients-cursor-windsurf-vs-code-continue) section below.
 
@@ -438,13 +431,13 @@ Flywheel auto-links any mentions of existing notes. If your vault has `Stacy Tho
 
 ## Step 3: Choose a Tool Preset
 
-Flywheel defaults to the `full` preset (77 tools with tiered progressive disclosure).
-Use `"agent"` for a minimal 18-tool set (search, read, write, tasks, memory). Add bundles for graph analysis, wikilinks, or other capabilities:
+Flywheel defaults to the `full` preset (adaptive progressive disclosure).
+Use `"agent"` for a fixed reduced set (search, read, write, tasks, memory). Add bundles for graph analysis, wikilinks, or other capabilities:
 
 ```json
 {
   "env": {
-    "FLYWHEEL_TOOLS": "default,graph,tasks"
+    "FLYWHEEL_TOOLS": "agent,graph"
   }
 }
 ```
@@ -615,7 +608,7 @@ Flywheel looks for a vault root by walking up from the working directory, checki
 
 ### "Too many tools" / Claude picks the wrong tool
 
-Reduce the tool set. Switch from `full` to `default` or a specific bundle combination. Fewer tools = better tool selection by Claude.
+Reduce the tool set. Switch from `full` to `agent` or a specific bundle combination. Fewer tools = better tool selection by Claude.
 
 ### "Permission denied" on file writes
 
@@ -666,6 +659,6 @@ All vault operations work without git. You just won't have undo or commit histor
 ## Next Steps
 
 - **[COOKBOOK.md](COOKBOOK.md)** -- Example prompts organized by use case
-- **[TOOLS.md](TOOLS.md)** -- Full reference for all 75 tools
+- **[TOOLS.md](TOOLS.md)** -- Full tool reference
 - **[CONFIGURATION.md](CONFIGURATION.md)** -- All environment variables and advanced options
 - **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** -- Error recovery and diagnostics

--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -63,7 +63,7 @@ What it **does not** contain: entity names, note paths, note content, file names
 
 ## How to export
 
-The calibration export tool is in the **`diagnostics`** bundle, available in the `full` preset. If you're using `default` or `agent`, add diagnostics to your config: `FLYWHEEL_TOOLS=default,diagnostics` (see [CONFIGURATION.md](CONFIGURATION.md) for details).
+The calibration export tool is in the **`diagnostics`** bundle, available in the `full` preset. If you're using `agent`, add diagnostics to your config: `FLYWHEEL_TOOLS=agent,diagnostics` (see [CONFIGURATION.md](CONFIGURATION.md) for details).
 
 Ask your AI client:
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,8 +1,8 @@
 # Tools
 
-77 tools. Most questions only need one: **search**.
+Start with `search`. Specialised tools surface automatically when the query calls for them.
 
-> **Progressive disclosure:** All 77 tools are available by default, but only the core 18 are visible at startup. The rest surface automatically when your queries signal a need for graph analysis, temporal tools, schema intelligence, etc. Use `FLYWHEEL_TOOLS=agent` if you prefer a fixed 18-tool set.
+> **Start here:** `full` (the default) progressively discloses tools as needed. Use `agent` for a fixed reduced set. See [CONFIGURATION.md](CONFIGURATION.md) for presets.
 
 - [At a Glance](#at-a-glance)
 - [Find Anything](#find-anything)
@@ -41,21 +41,21 @@
 
 ## At a Glance
 
-| I want to... | Start here | Tools |
-|---|---|--:|
-| [Ask my vault a question](#find-anything) | `search` | 3 |
-| [Read a specific note](#read-deeper) | `get_note_structure` | 3 |
-| [Write or edit content](#write--edit) | `vault_add_to_section` | 5 |
-| [Work with tasks](#tasks) | `tasks` | 3 |
-| [Explore how notes connect](#explore-connections) | `get_backlinks`, `graph_analysis`, `semantic_analysis` | 11 |
-| [Improve my wikilinks](#wikilinks--linking) | `suggest_wikilinks` | 7 |
-| [Clean up my schema](#schema--consistency) | `vault_schema`, `schema_conventions`, `schema_validate` | 7 |
-| [Record corrections](#corrections) | `vault_record_correction` | 4 |
-| [Move, rename, or merge notes](#organize-notes) | `vault_move_note` | 4 |
-| [Persistent memory](#session-memory) | `memory`, `brief` | 2 |
-| [Analyze temporal patterns](#temporal-analysis) | `get_context_around_date` | 4 |
-| [Check vault health](#vault-health) | `health_check` | 21 |
-| [Automate workflows](#automation) | `policy` | 2 |
+| I want to... | Start here |
+|---|---|
+| [Ask my vault a question](#find-anything) | `search` |
+| [Read a specific note](#read-deeper) | `get_note_structure` |
+| [Write or edit content](#write--edit) | `vault_add_to_section` |
+| [Work with tasks](#tasks) | `tasks` |
+| [Explore how notes connect](#explore-connections) | `get_backlinks`, `graph_analysis`, `semantic_analysis` |
+| [Improve my wikilinks](#wikilinks--linking) | `suggest_wikilinks` |
+| [Clean up my schema](#schema--consistency) | `vault_schema`, `schema_conventions`, `schema_validate` |
+| [Record corrections](#corrections) | `vault_record_correction` |
+| [Move, rename, or merge notes](#organize-notes) | `vault_move_note` |
+| [Persistent memory](#session-memory) | `memory`, `brief` |
+| [Analyze temporal patterns](#temporal-analysis) | `get_context_around_date` |
+| [Check vault health](#vault-health) | `health_check` |
+| [Automate workflows](#automation) | `policy` |
 
 ---
 
@@ -366,7 +366,7 @@ Move, rename, delete, or merge — all backlinks update automatically.
 
 ## Session Memory
 
-Persistent working memory across sessions. Included in the default preset.
+Persistent working memory across sessions. Included in the `agent` preset and always visible under `full`.
 
 ### `memory`
 
@@ -385,7 +385,7 @@ Store and retrieve facts, preferences, and observations. Each memory has a key, 
 
 Cold-start context for any session. Builds a token-budgeted summary of recent sessions, active entities, stored memories, pending corrections, and vault pulse — so an agent can pick up where it left off without reading the whole vault.
 
-Available in the `default` preset via the `memory` category.
+Available in the `agent` preset via the `memory` category.
 
 **Parameters:** `max_tokens`, `focus`
 
@@ -431,6 +431,51 @@ Monitor, configure, and maintain your vault.
 | `vault_entity_history` | Unified entity timeline across all tables: applications, feedback, suggestions, edge weights, metadata changes, memories, corrections. |
 | `flywheel_learning_report` | Narrative report of auto-linking learning progress: applications by day, feedback split, survival rate, top rejected entities, suggestion funnel, graph growth. Supports period-over-period comparison. |
 | `flywheel_calibration_export` | Anonymized aggregate scoring data for cross-vault algorithm calibration. No entity names or paths. Includes: funnel, per-layer contributions, survival by category, score distribution, suppression stats, threshold sweep. |
+| `tool_selection_feedback` | Report and query tool selection quality. Modes: report (record correct/wrong), list (recent feedback), stats (per-tool posterior accuracy via Beta-Binomial), misroutes (heuristic advisory). |
+
+---
+
+## Tool Selection Intelligence
+
+Under `full` (the default preset), Flywheel progressively discloses tools across three tiers rather than advertising the entire catalogue at once:
+
+| Tier | Visibility | Categories |
+|------|-----------|------------|
+| 1 | Always visible | search, read, write, tasks, memory |
+| 2 | Context-triggered | graph, wikilinks, temporal, corrections, diagnostics |
+| 3 | On-demand | schema, note-ops, deep diagnostics |
+
+Under `agent`, all tools in the preset are always visible with no tier gating.
+
+### How activation works
+
+When you run `search` or `brief`, Flywheel scans the query for activation signals using two methods:
+
+- **Pattern routing** — regex patterns detect intent keywords. A query mentioning "backlinks" or "hubs" activates the graph category; "schema" or "rename field" activates schema tools.
+- **Semantic routing** — the query is embedded and compared against a pre-generated tool description manifest (cosine similarity ≥ 0.30). At most three categories are activated per query.
+
+Both signal types are combined. The highest tier per category wins. Tools become visible for the remainder of the session once activated.
+
+The routing mode is controlled by `FLYWHEEL_TOOL_ROUTING`:
+
+| Mode | Behaviour |
+|------|-----------|
+| `pattern` | Regex activation only |
+| `hybrid` (default under `full`) | Regex + semantic signals combined |
+| `semantic` | Semantic-only for hybrid search calls; regex fallback elsewhere |
+
+Semantic routing requires `init_semantic` to have been run. Custom `EMBEDDING_MODEL` users fall back to `pattern` unless the tool manifest was regenerated for that model.
+
+### Feedback
+
+`tool_selection_feedback` records whether the right tool was picked for a given query. Over time, this builds per-tool accuracy scores (Beta-Binomial posterior) that can inform routing adjustments.
+
+| Mode | What it does |
+|------|-------------|
+| `report` | Record whether a tool selection was correct or wrong |
+| `list` | Recent feedback entries |
+| `stats` | Per-tool posterior accuracy from explicit feedback |
+| `misroutes` | Heuristic-detected advisory misroutes |
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -288,12 +288,12 @@ The write tools detect when the content would be identical after the operation a
 
 ### "Too many tools" warning from Claude
 
-You're loading more tools than Claude needs. Switch to a smaller preset:
+You're loading more tools than Claude needs. Switch to the `agent` preset, which exposes a fixed reduced set:
 
 ```json
 {
   "env": {
-    "FLYWHEEL_TOOLS": "default"
+    "FLYWHEEL_TOOLS": "agent"
   }
 }
 ```

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -111,7 +111,7 @@ The demo vaults in this repo cover these personas with production-realistic data
 
 ### Flywheel Memory
 
-The MCP server. 75 tools across 12 categories give Claude structured access to Obsidian vaults: search, graph queries, schema intelligence, content mutations, task management, agent memory, and policy automation. Published as `@velvetmonkey/flywheel-memory`.
+The MCP server. tools across 12 categories give Claude structured access to Obsidian vaults: search, graph queries, schema intelligence, content mutations, task management, agent memory, and policy automation. Published as `@velvetmonkey/flywheel-memory`.
 
 ### Vault-Core
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -7,7 +7,7 @@
 | Doc | What |
 |-----|------|
 | [README](../../README.md) | Overview, demos, get started |
-| [TOOLS.md](../../docs/TOOLS.md) | All 75 tools |
+| [TOOLS.md](../../docs/TOOLS.md) | All tools |
 | [ALGORITHM.md](../../docs/ALGORITHM.md) | Link scoring |
 | [CONFIGURATION.md](../../docs/CONFIGURATION.md) | Env vars, presets |
 | [SETUP.md](../../docs/SETUP.md) | Client setup |

--- a/packages/mcp-server/test/write/docs/tool-counts.test.ts
+++ b/packages/mcp-server/test/write/docs/tool-counts.test.ts
@@ -1,8 +1,9 @@
 /**
- * Tool Count Verification Tests
+ * Tool Registration & Documentation Contract Tests
  *
- * Ensures documentation tool counts match actual implementation.
- * Prevents documentation from becoming stale.
+ * Source invariants: tool registrations match TOOL_CATEGORY, TOOL_TIER,
+ * and PRESETS. Documentation wording contracts: user-facing docs describe
+ * presets and routing correctly and contain no stale count-based language.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -13,6 +14,7 @@ import { VALID_CONFIG_KEYS } from '../../../src/tools/write/config.js';
 
 const TOOLS_DIR = path.join(__dirname, '../../../src/tools');
 const DOCS_DIR = path.join(__dirname, '../../../../../docs');
+const ROOT_DIR = path.join(__dirname, '../../../../..');
 const CONFIG_PATH = path.join(__dirname, '../../../src/config.ts');
 
 /**
@@ -54,198 +56,139 @@ async function countToolsInSource(): Promise<{
 }
 
 /**
- * Extract claimed tool count from documentation
+ * Strip fenced code blocks from markdown content for prose-only scanning.
  */
-async function extractDocToolCount(docPath: string): Promise<number | null> {
-  try {
-    const content = await fs.readFile(docPath, 'utf-8');
-
-    // Look for patterns like "11 tools" or "51 query tools"
-    const matches = content.match(/(\d+)\s+(?:mutation\s+)?tools?/gi);
-    if (matches) {
-      // Return the first match's number
-      const firstMatch = matches[0].match(/(\d+)/);
-      return firstMatch ? parseInt(firstMatch[1], 10) : null;
-    }
-
-    return null;
-  } catch {
-    return null;
-  }
+function stripFencedCode(content: string): string {
+  return content.replace(/```[\s\S]*?```/g, '');
 }
 
-describe('Tool Count Verification', () => {
-  describe('flywheel-memory tools', () => {
-    it('should have the expected number of mutation tools', async () => {
-      const { total, byFile, toolNames } = await countToolsInSource();
+/**
+ * Read a doc file relative to the repo root.
+ */
+async function readDoc(relativePath: string): Promise<string> {
+  return fs.readFile(path.join(ROOT_DIR, relativePath), 'utf-8');
+}
 
-      // Log for debugging
-      console.log('Tools by file:', byFile);
-      console.log('Total tools:', total);
-      console.log('Tool names:', toolNames);
+// Files subject to stale-copy scanning (excludes CLAUDE.md and docs/TESTING.md)
+const SCANNED_DOCS = [
+  'README.md',
+  'docs/TOOLS.md',
+  'docs/CONFIGURATION.md',
+  'docs/ARCHITECTURE.md',
+  'docs/SETUP.md',
+  'docs/PROVE-IT.md',
+  'docs/VISION.md',
+  'docs/OPENCLAW.md',
+  'docs/TROUBLESHOOTING.md',
+  'docs/SHARING.md',
+  'docs/README.md',
+  'packages/mcp-server/README.md',
+];
 
-      // The exact count depends on implementation
-      // Core mutation tools: add, remove, replace (3)
-      // Task tools: toggle, add (2)
-      // Frontmatter tools: update, add (2)
-      // Note tools: create, delete (2)
-      // System tools: list_sections, undo (2)
-      // Move tools: move, rename (2)
-      // Policy tools: 9
+// =============================================================================
+// Tool Registration Verification
+// =============================================================================
 
-      // Total should be around 22 based on grep results
-      expect(total).toBeGreaterThanOrEqual(10);
-    });
-
-    it('should have all core mutation tools registered', async () => {
-      const { toolNames } = await countToolsInSource();
-      const toolSet = new Set(toolNames);
-
-      // Core mutation tools that should always exist
-      const coreMutationTools = [
-        'vault_add_to_section',
-        'vault_remove_from_section',
-        'vault_replace_in_section',
-      ];
-
-      for (const tool of coreMutationTools) {
-        expect(toolSet.has(tool), `Missing core tool: ${tool}`).toBe(true);
-      }
-    });
-
-    it('should have all task tools registered', async () => {
-      const { toolNames } = await countToolsInSource();
-      const toolSet = new Set(toolNames);
-
-      const taskTools = [
-        'vault_toggle_task',
-        'vault_add_task',
-      ];
-
-      for (const tool of taskTools) {
-        expect(toolSet.has(tool), `Missing task tool: ${tool}`).toBe(true);
-      }
-    });
-
-    it('should have all frontmatter tools registered', async () => {
-      const { toolNames } = await countToolsInSource();
-      const toolSet = new Set(toolNames);
-
-      const frontmatterTools = [
-        'vault_update_frontmatter',
-      ];
-
-      for (const tool of frontmatterTools) {
-        expect(toolSet.has(tool), `Missing frontmatter tool: ${tool}`).toBe(true);
-      }
-    });
-
-    it('should have all note management tools registered', async () => {
-      const { toolNames } = await countToolsInSource();
-      const toolSet = new Set(toolNames);
-
-      const noteTools = [
-        'vault_create_note',
-        'vault_delete_note',
-      ];
-
-      for (const tool of noteTools) {
-        expect(toolSet.has(tool), `Missing note tool: ${tool}`).toBe(true);
-      }
-    });
-
-    it('should have all system tools registered', async () => {
-      const { toolNames } = await countToolsInSource();
-      const toolSet = new Set(toolNames);
-
-      const systemTools = [
-        'vault_undo_last_mutation',
-      ];
-
-      for (const tool of systemTools) {
-        expect(toolSet.has(tool), `Missing system tool: ${tool}`).toBe(true);
-      }
-    });
+describe('Tool Registration Verification', () => {
+  it('should have at least 10 mutation tools', async () => {
+    const { total } = await countToolsInSource();
+    expect(total).toBeGreaterThanOrEqual(10);
   });
 
-  describe('documentation accuracy', () => {
-    it('should have key tools documented in TOOLS.md', async () => {
-      const toolsPath = path.join(DOCS_DIR, 'TOOLS.md');
-      const content = await fs.readFile(toolsPath, 'utf-8');
+  it('should have all core mutation tools registered', async () => {
+    const { toolNames } = await countToolsInSource();
+    const toolSet = new Set(toolNames);
 
-      // TOOLS.md should mention key tools
-      expect(content).toContain('vault_add_to_section');
-      expect(content).toContain('vault_toggle_task');
-    });
-
-    it('should document config keys in CONFIGURATION.md', async () => {
-      const configPath = path.join(DOCS_DIR, 'CONFIGURATION.md');
-      const content = await fs.readFile(configPath, 'utf-8');
-
-      // All settable config keys should be documented
-      expect(content).toContain('wikilink_strictness');
-      expect(content).toContain('exclude_entities');
-      expect(content).toContain('exclude_entity_folders');
-      expect(content).toContain('implicit_detection');
-
-      // paths/templates should be documented as read-only
-      expect(content).toContain('read-only');
-    });
+    for (const tool of [
+      'vault_add_to_section',
+      'vault_remove_from_section',
+      'vault_replace_in_section',
+    ]) {
+      expect(toolSet.has(tool), `Missing core tool: ${tool}`).toBe(true);
+    }
   });
 
-  describe('tool naming conventions', () => {
-    it('should use valid prefixes or known standalone names', async () => {
-      const { toolNames } = await countToolsInSource();
+  it('should have all task tools registered', async () => {
+    const { toolNames } = await countToolsInSource();
+    const toolSet = new Set(toolNames);
 
-      // Some consolidated tools use short, non-prefixed names
-      const ALLOWED_STANDALONE = new Set([
-        'search', 'tasks', 'graph_analysis', 'vault_schema', 'schema_conventions', 'schema_validate',
-        'semantic_analysis', 'note_intelligence', 'policy',
-        'health_check', 'refresh_index', 'suggest_wikilinks', 'validate_links',
-        'rename_field', 'migrate_field_values',
-        'rename_tag', 'wikilink_feedback',
-        'init_semantic',
-        'list_entities', 'flywheel_config',
-        'server_log',
-        'suggest_entity_merges', 'dismiss_merge_suggestion',
-        'suggest_entity_aliases', 'merge_entities', 'absorb_as_alias',
-        'unlinked_mentions_report', 'discover_stub_candidates', 'discover_cooccurrence_gaps',
-        'memory', 'brief',
-        'predict_stale_notes', 'track_concept_evolution', 'temporal_summary',
-        'flywheel_doctor',
-        'flywheel_trust_report',
-        'flywheel_benchmark',
-        'flywheel_learning_report',
-        'flywheel_calibration_export',
-        'export_graph',
-        'tool_selection_feedback',
-        'pipeline_status',
-      ]);
+    for (const tool of ['vault_toggle_task', 'vault_add_task']) {
+      expect(toolSet.has(tool), `Missing task tool: ${tool}`).toBe(true);
+    }
+  });
 
-      for (const tool of toolNames) {
-        const hasValidPrefix = tool.startsWith('vault_') || tool.startsWith('policy_') || tool.startsWith('get_') || tool.startsWith('find_') || ALLOWED_STANDALONE.has(tool);
-        expect(hasValidPrefix, `Tool ${tool} should start with vault_ or policy_ or be an allowed standalone name`).toBe(true);
-      }
-    });
+  it('should have all frontmatter tools registered', async () => {
+    const { toolNames } = await countToolsInSource();
+    const toolSet = new Set(toolNames);
+    expect(toolSet.has('vault_update_frontmatter'), 'Missing frontmatter tool').toBe(true);
+  });
 
-    it('should use snake_case for tool names', async () => {
-      const { toolNames } = await countToolsInSource();
+  it('should have all note management tools registered', async () => {
+    const { toolNames } = await countToolsInSource();
+    const toolSet = new Set(toolNames);
 
-      for (const tool of toolNames) {
-        // Should not have camelCase humps (capital letters)
-        const hasCamelCase = /[A-Z]/.test(tool);
-        expect(hasCamelCase, `Tool ${tool} should use snake_case`).toBe(false);
+    for (const tool of ['vault_create_note', 'vault_delete_note']) {
+      expect(toolSet.has(tool), `Missing note tool: ${tool}`).toBe(true);
+    }
+  });
 
-        // Should only contain lowercase letters and underscores
-        const validPattern = /^[a-z_]+$/;
-        expect(validPattern.test(tool), `Tool ${tool} should only contain lowercase letters and underscores`).toBe(true);
-      }
-    });
+  it('should have all system tools registered', async () => {
+    const { toolNames } = await countToolsInSource();
+    const toolSet = new Set(toolNames);
+    expect(toolSet.has('vault_undo_last_mutation'), 'Missing system tool').toBe(true);
   });
 });
 
 // =============================================================================
-// Documentation Contract Tests
+// Tool Naming Conventions
+// =============================================================================
+
+describe('Tool Naming Conventions', () => {
+  it('should use valid prefixes or known standalone names', async () => {
+    const { toolNames } = await countToolsInSource();
+
+    const ALLOWED_STANDALONE = new Set([
+      'search', 'tasks', 'graph_analysis', 'vault_schema', 'schema_conventions', 'schema_validate',
+      'semantic_analysis', 'note_intelligence', 'policy',
+      'health_check', 'refresh_index', 'suggest_wikilinks', 'validate_links',
+      'rename_field', 'migrate_field_values',
+      'rename_tag', 'wikilink_feedback',
+      'init_semantic',
+      'list_entities', 'flywheel_config',
+      'server_log',
+      'suggest_entity_merges', 'dismiss_merge_suggestion',
+      'suggest_entity_aliases', 'merge_entities', 'absorb_as_alias',
+      'unlinked_mentions_report', 'discover_stub_candidates', 'discover_cooccurrence_gaps',
+      'memory', 'brief',
+      'predict_stale_notes', 'track_concept_evolution', 'temporal_summary',
+      'flywheel_doctor',
+      'flywheel_trust_report',
+      'flywheel_benchmark',
+      'flywheel_learning_report',
+      'flywheel_calibration_export',
+      'export_graph',
+      'tool_selection_feedback',
+      'pipeline_status',
+    ]);
+
+    for (const tool of toolNames) {
+      const hasValidPrefix = tool.startsWith('vault_') || tool.startsWith('policy_') || tool.startsWith('get_') || tool.startsWith('find_') || ALLOWED_STANDALONE.has(tool);
+      expect(hasValidPrefix, `Tool ${tool} should start with vault_ or policy_ or be an allowed standalone name`).toBe(true);
+    }
+  });
+
+  it('should use snake_case for tool names', async () => {
+    const { toolNames } = await countToolsInSource();
+
+    for (const tool of toolNames) {
+      expect(/[A-Z]/.test(tool), `Tool ${tool} should use snake_case`).toBe(false);
+      expect(/^[a-z_]+$/.test(tool), `Tool ${tool} should only contain lowercase letters and underscores`).toBe(true);
+    }
+  });
+});
+
+// =============================================================================
+// Documentation Contracts — Source Invariants
 // =============================================================================
 
 /**
@@ -271,7 +214,6 @@ async function parsePresetsFromSource(): Promise<Record<string, string[]>> {
   const match = source.match(/const PRESETS[^{]*\{([\s\S]*?)\n\};/);
   if (!match) throw new Error('Could not find PRESETS in config.ts');
   const result: Record<string, string[]> = {};
-  // Match lines like: default: ['search', 'read', 'write', 'tasks'],
   const presetLines = [...match[1].matchAll(/^\s*(\w[\w-]*):\s*\[([^\]]*)\]/gm)];
   for (const [, name, categoriesStr] of presetLines) {
     const categories = [...categoriesStr.matchAll(/'([\w-]+)'/g)].map(m => m[1]);
@@ -282,29 +224,7 @@ async function parsePresetsFromSource(): Promise<Record<string, string[]>> {
   return result;
 }
 
-describe('Documentation Contracts', () => {
-  it('CONFIGURATION.md category counts match TOOL_CATEGORY source', async () => {
-    const byCategory = await parseToolCategoryFromSource();
-    const configContent = await fs.readFile(path.join(DOCS_DIR, 'CONFIGURATION.md'), 'utf-8');
-
-    // Parse the composable bundles table: | `category` | N |
-    const bundleRows = [...configContent.matchAll(/\|\s*`(\w[\w-]*)`\s*\|\s*(\d+)\s*\|/g)];
-    const docCounts: Record<string, number> = {};
-    for (const [, cat, count] of bundleRows) {
-      // Only track categories that exist in TOOL_CATEGORY
-      if (byCategory[cat]) {
-        docCounts[cat] = parseInt(count, 10);
-      }
-    }
-
-    // Every category in source should appear in doc with correct count
-    for (const [cat, tools] of Object.entries(byCategory)) {
-      if (docCounts[cat] !== undefined) {
-        expect(docCounts[cat], `CONFIGURATION.md claims ${cat} has ${docCounts[cat]} tools, source has ${tools.length}`).toBe(tools.length);
-      }
-    }
-  });
-
+describe('Documentation Contracts — Source Invariants', () => {
   it('CONFIGURATION.md settable keys match VALID_CONFIG_KEYS', async () => {
     const configContent = await fs.readFile(path.join(DOCS_DIR, 'CONFIGURATION.md'), 'utf-8');
 
@@ -312,40 +232,28 @@ describe('Documentation Contracts', () => {
       expect(configContent, `VALID_CONFIG_KEYS key "${key}" not documented in CONFIGURATION.md`).toContain(key);
     }
 
-    // paths and templates should NOT be in VALID_CONFIG_KEYS
     expect(VALID_CONFIG_KEYS['paths']).toBeUndefined();
     expect(VALID_CONFIG_KEYS['templates']).toBeUndefined();
-
-    // Doc should mention read-only
     expect(configContent).toContain('read-only');
   });
 
-  it('TOOLS.md total tool count matches source', async () => {
-    const byCategory = await parseToolCategoryFromSource();
+  it('TOOLS.md documents key tools', async () => {
     const toolsContent = await fs.readFile(path.join(DOCS_DIR, 'TOOLS.md'), 'utf-8');
-
-    const totalInSource = Object.values(byCategory).reduce((sum, tools) => sum + tools.length, 0);
-
-    // TOOLS.md total should match TOOL_CATEGORY count
-    const match = toolsContent.match(/(\d+)\s+tools/);
-    expect(match, 'TOOLS.md should contain a tool count').toBeTruthy();
-
-    const docTotal = parseInt(match![1], 10);
-    expect(docTotal, `TOOLS.md claims ${docTotal} tools, source has ${totalInSource}`).toBe(totalInSource);
+    expect(toolsContent).toContain('vault_add_to_section');
+    expect(toolsContent).toContain('vault_toggle_task');
   });
 
   it('preset compositions match source', async () => {
     const presets = await parsePresetsFromSource();
 
-    // full uses [...ALL_CATEGORIES] spread, so regex parser won't capture it — verify via runtime import
+    // full uses [...ALL_CATEGORIES] spread — verify via runtime import
     expect(PRESETS.full.length).toBe(ALL_CATEGORIES.length);
     expect(presets['agent']).toEqual(['search', 'read', 'write', 'tasks', 'memory']);
-    // default is now a deprecated alias to full
   });
 });
 
 // =============================================================================
-// Tool Gating Invariants (T11)
+// Tool Gating Invariants
 // =============================================================================
 
 describe('Tool Gating Invariants', () => {
@@ -384,9 +292,9 @@ describe('Tool Gating Invariants', () => {
   });
 
   it('tier-1 tools exactly match the agent preset tool set', () => {
-    const defaultCategories = new Set(PRESETS.agent);
-    const defaultPresetTools = Object.entries(TOOL_CATEGORY)
-      .filter(([, category]) => defaultCategories.has(category))
+    const agentCategories = new Set(PRESETS.agent);
+    const agentPresetTools = Object.entries(TOOL_CATEGORY)
+      .filter(([, category]) => agentCategories.has(category))
       .map(([tool]) => tool)
       .sort();
     const tierOneTools = Object.entries(TOOL_TIER)
@@ -394,15 +302,141 @@ describe('Tool Gating Invariants', () => {
       .map(([tool]) => tool)
       .sort();
 
-    expect(tierOneTools).toEqual(defaultPresetTools);
+    expect(tierOneTools).toEqual(agentPresetTools);
     expect(tierOneTools).toHaveLength(18);
   });
 
-  it('tier counts match the expected 18/58 split', () => {
+  it('tier counts match the expected 18/remainder split', () => {
     const tierOneCount = Object.values(TOOL_TIER).filter((tier) => tier === 1).length;
     const higherTierCount = Object.values(TOOL_TIER).filter((tier) => tier > 1).length;
 
     expect(tierOneCount).toBe(18);
     expect(higherTierCount).toBe(Object.keys(TOOL_TIER).length - 18);
+  });
+});
+
+// =============================================================================
+// Documentation Wording Contracts
+// =============================================================================
+
+describe('Documentation Wording Contracts', () => {
+  it('TOOLS.md describes progressive disclosure', async () => {
+    const content = await readDoc('docs/TOOLS.md');
+    expect(content).toMatch(/progressively/i);
+  });
+
+  it('TOOLS.md documents tool_selection_feedback', async () => {
+    const content = await readDoc('docs/TOOLS.md');
+    expect(content).toContain('tool_selection_feedback');
+  });
+
+  it('CONFIGURATION.md documents FLYWHEEL_TOOL_ROUTING', async () => {
+    const content = await readDoc('docs/CONFIGURATION.md');
+    expect(content).toContain('FLYWHEEL_TOOL_ROUTING');
+  });
+
+  it('docs describe full as the default adaptive preset', async () => {
+    const tools = await readDoc('docs/TOOLS.md');
+    const config = await readDoc('docs/CONFIGURATION.md');
+    const combined = tools + config;
+
+    // Must mention full as default somewhere
+    expect(combined).toMatch(/`full`[^`]*default|default[^`]*`full`/i);
+  });
+
+  it('docs describe agent as the fixed reduced preset', async () => {
+    const tools = await readDoc('docs/TOOLS.md');
+    const config = await readDoc('docs/CONFIGURATION.md');
+    const combined = tools + config;
+
+    expect(combined).toMatch(/`agent`[^`]*fixed|fixed[^`]*`agent`/i);
+  });
+});
+
+// =============================================================================
+// Stale Copy Detection
+// =============================================================================
+
+describe('Stale Copy Detection', () => {
+  describe('prose scan (fenced code stripped)', () => {
+    it('no user-facing "N tools" phrasing in prose', async () => {
+      const failures: string[] = [];
+
+      for (const docPath of SCANNED_DOCS) {
+        try {
+          const raw = await readDoc(docPath);
+          const prose = stripFencedCode(raw);
+          const matches = prose.match(/(?<!tier-)\b\d+\s+tools\b/gi);
+          if (matches) {
+            failures.push(`${docPath}: ${matches.join(', ')}`);
+          }
+        } catch {
+          // File may not exist in all configurations
+        }
+      }
+
+      expect(failures, `Stale "N tools" phrasing found:\n${failures.join('\n')}`).toHaveLength(0);
+    });
+
+    it('no "Start with default" recommendations in prose', async () => {
+      const failures: string[] = [];
+
+      for (const docPath of SCANNED_DOCS) {
+        try {
+          const raw = await readDoc(docPath);
+          const prose = stripFencedCode(raw);
+          const matches = prose.match(/Start with.*\bdefault\b/gi);
+          if (matches) {
+            failures.push(`${docPath}: ${matches.join(', ')}`);
+          }
+        } catch {
+          // skip missing files
+        }
+      }
+
+      expect(failures, `Stale "Start with default" found:\n${failures.join('\n')}`).toHaveLength(0);
+    });
+
+    it('no "Included in the default preset" in prose', async () => {
+      const failures: string[] = [];
+
+      for (const docPath of SCANNED_DOCS) {
+        try {
+          const raw = await readDoc(docPath);
+          const prose = stripFencedCode(raw);
+          if (prose.includes('Included in the default preset')) {
+            failures.push(docPath);
+          }
+        } catch {
+          // skip missing files
+        }
+      }
+
+      expect(failures, `Stale "Included in the default preset" found:\n${failures.join('\n')}`).toHaveLength(0);
+    });
+  });
+
+  describe('raw scan (includes code blocks)', () => {
+    it('no FLYWHEEL_TOOLS or FLYWHEEL_PRESET set to "default" in examples', async () => {
+      const failures: string[] = [];
+
+      for (const docPath of SCANNED_DOCS) {
+        try {
+          const raw = await readDoc(docPath);
+          // Match "FLYWHEEL_TOOLS": "default" or "FLYWHEEL_PRESET": "default"
+          if (/(?:"FLYWHEEL_TOOLS"|"FLYWHEEL_PRESET")\s*:\s*"default"/.test(raw)) {
+            failures.push(`${docPath}: JSON example sets FLYWHEEL_TOOLS/PRESET to "default"`);
+          }
+          // Match FLYWHEEL_TOOLS=default (not followed by comma — that would be default,something)
+          if (/FLYWHEEL_TOOLS=default(?:[^,\w]|$)/.test(raw)) {
+            failures.push(`${docPath}: env example sets FLYWHEEL_TOOLS=default`);
+          }
+        } catch {
+          // skip missing files
+        }
+      }
+
+      expect(failures, `Stale default preset examples:\n${failures.join('\n')}`).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Remove user-facing tool counts from prose, links, and table columns across 13 docs
- Reposition full as the default adaptive preset with progressive disclosure; agent as the fixed reduced alternative; default as a deprecated alias (documented once in CONFIGURATION.md)
- Add Tool Selection Intelligence section to TOOLS.md: tiered visibility, pattern + semantic routing, FLYWHEEL_TOOL_ROUTING, and tool_selection_feedback
- Add Tool Selection and Routing section and schema history v31-v36 to ARCHITECTURE.md
- Update source structure in CLAUDE.md and ARCHITECTURE.md with routing/feedback files
- Rewrite doc-contract tests: wording contracts replace count assertions, two-pass stale-copy scans

## Test plan

- [x] npx vitest run packages/mcp-server/test/write/docs/tool-counts.test.ts - 25 passed
- [x] npx vitest run packages/mcp-server/test/tool-routing.test.ts - 32 passed
- [x] npx vitest run packages/mcp-server/test/tool-tiering.test.ts - 36 passed
- [x] npx vitest run packages/mcp-server/test/write/docs/ - 40 passed (all doc tests)
- [x] rg sweep: no stale 75/76/77 tools, Start with default, or FLYWHEEL_TOOLS=default in scanned docs