### PR TITLE
docs: T18 — Windows path friction visibility pass

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -42,6 +42,7 @@ After trying the [demo vaults](../demos/), point Flywheel at your own Obsidian v
   - ["Vault not found"](#vault-not-found)
   - ["Too many tools" / Claude picks the wrong tool](#too-many-tools--claude-picks-the-wrong-tool)
   - ["Permission denied" on file writes](#permission-denied-on-file-writes)
+  - [Server silently fails on Windows](#server-silently-fails-on-windows)
   - [Stale search results](#stale-search-results)
   - [Git-related errors](#git-related-errors)
 - [Git Integration (Optional)](#git-integration-optional)
@@ -86,6 +87,8 @@ Flywheel connects to your MCP client immediately, then builds indexes in the bac
 ## Windows
 
 On Windows, the MCP config differs from macOS/Linux in three ways:
+
+> **If you're on Windows, read this before configuring your client below.** The three differences here cause silent failures if missed.
 
 1. **`cmd /c` wrapper** — use `"command": "cmd"` with `"args": ["/c", "npx", ...]` instead of `"command": "npx"`. Windows installs npx as a batch script (`npx.cmd`) which MCP clients can't execute directly — without this wrapper the server silently fails.
 2. **`VAULT_PATH`** — set to your vault's Windows path (e.g. `C:\Users\you\obsidian\MyVault`)
@@ -135,6 +138,8 @@ Create `.mcp.json` in your vault root:
 }
 ```
 
+> **Windows?** Use `"command": "cmd"` with `"args": ["/c", "npx", "-y", "@velvetmonkey/flywheel-memory"]` and add `"FLYWHEEL_WATCH_POLL": "true"` to `env`. [Full example →](CONFIGURATION.md#windows)
+
 Launch:
 
 ```bash
@@ -179,6 +184,8 @@ Edit `claude_desktop_config.json` (Settings > Developer > Edit Config):
 }
 ```
 
+> **Windows?** Use `"command": "cmd"` with `"args": ["/c", "npx", "-y", "@velvetmonkey/flywheel-memory"]`, set `VAULT_PATH` to a backslash-escaped Windows path (e.g. `C:\\Users\\you\\obsidian\\MyVault`), and add `"FLYWHEEL_WATCH_POLL": "true"`. [Full example →](CONFIGURATION.md#windows)
+
 Claude Desktop requires `VAULT_PATH` because it doesn't launch from the vault directory. Claude Code auto-detects the vault root from the working directory.
 
 **Multi-vault** — replace `VAULT_PATH` with `FLYWHEEL_VAULTS`:
@@ -222,6 +229,8 @@ Add this to `~/.openclaw/openclaw.json`:
   }
 }
 ```
+
+> **Windows?** Use `"command": "cmd"` with `"args": ["/c", "npx", "-y", "@velvetmonkey/flywheel-memory"]`, set `VAULT_PATH` to a backslash-escaped Windows path (e.g. `C:\\Users\\you\\obsidian\\MyVault`), and add `"FLYWHEEL_WATCH_POLL": "true"`. [Full example →](CONFIGURATION.md#windows)
 
 Restart OpenClaw. Flywheel appears as an MCP server with search, read, write, and memory tools.
 
@@ -621,12 +630,20 @@ Reduce the tool set. Switch from `full` to `default` or a specific bundle combin
 
 Flywheel writes to files in your vault directory and creates `.flywheel/` for its index. Make sure the user running Claude has write access to the vault folder.
 
+### Server silently fails on Windows
+
+Windows installs `npx` as a batch script (`npx.cmd`) which MCP clients can't execute directly via `spawn()`. The server process exits immediately with no error message — the client typically reports "Connection closed" or simply never lists Flywheel.
+
+**Fix:** Use `"command": "cmd"` with `"args": ["/c", "npx", ...]` instead of `"command": "npx"`. Also add `"FLYWHEEL_WATCH_POLL": "true"` to `env` — without it, edits you make in Obsidian won't appear in search results. See the [Windows section](#windows) or [CONFIGURATION.md](CONFIGURATION.md#windows) for the full config.
+
 ### Stale search results
 
 The index rebuilds automatically via file watcher, but if results seem stale:
 
 1. Ask Claude to "refresh the index" (uses the `refresh_index` tool)
 2. Or delete `.flywheel/` and restart -- it rebuilds in seconds
+
+**Windows:** Make sure `FLYWHEEL_WATCH_POLL=true` is set — native file events are unreliable on Windows. See [Windows](#windows).
 
 ### Git-related errors
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -22,6 +22,11 @@ Error recovery and diagnostics for Flywheel Memory.
   - [Git Lock Contention: Symptoms](#symptoms-1)
   - [Git Lock Contention: Recovery](#recovery-1)
   - [Git Lock Contention: Prevention](#prevention-1)
+- [Windows](#windows)
+  - [Server silently fails to start](#server-silently-fails-to-start)
+  - [Edits in Obsidian don't appear in search](#edits-in-obsidian-dont-appear-in-search)
+  - [VAULT_PATH on Windows vs WSL](#vault_path-on-windows-vs-wsl)
+  - [Multi-vault drive letter paths](#multi-vault-drive-letter-paths)
 - [Index Rebuild](#index-rebuild)
   - [When to use `refresh_index`](#when-to-use-refresh_index)
   - [What it does](#what-it-does)
@@ -201,6 +206,66 @@ rm /path/to/your/vault/.git/index.lock
 
 - Avoid force-killing Claude Code or the MCP server during write operations
 - If you see this error frequently, check if another tool (Obsidian git plugin, cron job, etc.) is running git commands on the same vault
+
+---
+
+## Windows
+
+### Server silently fails to start
+
+**Symptom:** MCP client shows "Connection closed" or Flywheel never appears in the server list. No error message.
+
+**Cause:** Windows installs `npx` as `npx.cmd` (a batch script). MCP clients use `spawn()` which cannot execute `.cmd` files directly.
+
+**Fix:** Use `cmd /c` as the command wrapper:
+
+```json
+{
+  "command": "cmd",
+  "args": ["/c", "npx", "-y", "@velvetmonkey/flywheel-memory"],
+  "env": {
+    "VAULT_PATH": "C:\\Users\\you\\obsidian\\MyVault",
+    "FLYWHEEL_WATCH_POLL": "true"
+  }
+}
+```
+
+See [CONFIGURATION.md](CONFIGURATION.md#windows) for the full client config.
+
+### Edits in Obsidian don't appear in search
+
+**Symptom:** Flywheel starts successfully and initial searches work, but notes you edit or create in Obsidian don't appear in search results until you restart the server.
+
+**Cause:** Native Windows file system events (`ReadDirectoryChangesW`) are unreliable. Flywheel's file watcher misses changes.
+
+**Fix:** Add `"FLYWHEEL_WATCH_POLL": "true"` to your MCP config `env` block. This switches to polling mode, which reliably detects changes with a small delay (~10 seconds by default, configurable via `FLYWHEEL_POLL_INTERVAL`).
+
+### VAULT_PATH on Windows vs WSL
+
+| Context | Path format | Example |
+|---------|------------|---------|
+| Native Windows | Windows backslash path | `C:\\Users\\you\\obsidian\\MyVault` |
+| Flywheel inside WSL | Linux path | `/home/you/obsidian/MyVault` |
+| Windows Obsidian opening a WSL vault | `\\wsl$\\...` (for Obsidian/Explorer only — not for `VAULT_PATH`) | `\\wsl$\Ubuntu\home\you\obsidian\MyVault` |
+
+The `\\wsl$` network share lets Windows Obsidian access files on the WSL filesystem, but Flywheel running inside WSL must use the native Linux path. See [SETUP.md > WSL2](SETUP.md#wsl2-keep-your-vault-on-the-linux-filesystem) for the recommended setup.
+
+### Multi-vault drive letter paths
+
+Windows drive letters create ambiguity with the `name:path` separator in `FLYWHEEL_VAULTS`. A single-character vault name followed by `:\` looks like a drive letter:
+
+```
+# Ambiguous — is "C" a vault name or a drive letter?
+FLYWHEEL_VAULTS="C:\Users\you\obsidian\MyVault"
+```
+
+**Fix:** Always use descriptive vault names:
+
+```
+FLYWHEEL_VAULTS="personal:C:\Users\you\obsidian\Personal,work:D:\Users\you\obsidian\Work"
+```
+
+See [CONFIGURATION.md](CONFIGURATION.md#multi-vault) for all multi-vault options.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add inline Windows callouts beside each stdio client config snippet in SETUP.md (`cmd /c` wrapper, `FLYWHEEL_WATCH_POLL`, backslash paths) so users see the requirements at point-of-use
- Add `### Server silently fails on Windows` to Common Issues and extend `### Stale search results` with a Windows note
- Add a dedicated `## Windows` troubleshooting section with 4 subsections: silent startup failure, stale file watching, VAULT_PATH differences (native Windows vs WSL vs `\\wsl$`), and multi-vault drive letter ambiguity
- CONFIGURATION.md remains unchanged as the canonical full Windows config reference

## Test plan

- [ ] Read SETUP.md top-to-bottom as a Windows user — each stdio section has a visible callout below its first config snippet
- [ ] Verify both manual TOCs match final heading text
- [ ] Check all internal links resolve: `#windows`, `#server-silently-fails-on-windows`, `CONFIGURATION.md#windows`, `CONFIGURATION.md#multi-vault`, `SETUP.md#wsl2-keep-your-vault-on-the-linux-filesystem`
- [ ] Confirm CONFIGURATION.md is the only full Windows config example

🤖 Generated with [Claude Code](https://claude.com/claude-code)