### PR TITLE
test: T16 — clock test for MCP/StateDb graph consistency

### DIFF
--- a/packages/mcp-server/src/tools/read/system.ts
+++ b/packages/mcp-server/src/tools/read/system.ts
@@ -30,7 +30,7 @@ import {
 import { initializeEntityIndex, setCooccurrenceIndex } from '../../core/write/wikilinks.js';
 import { exportHubScores } from '../../core/shared/hubExport.js';
 import { computeGraphMetrics, recordGraphSnapshot } from '../../core/shared/graphSnapshots.js';
-import { updateSuppressionList } from '../../core/write/wikilinkFeedback.js';
+import { updateSuppressionList, updateStoredNoteLinks } from '../../core/write/wikilinkFeedback.js';
 import { buildTaskCache } from '../../core/read/taskCache.js';
 import { buildRecencyIndex, saveRecencyToStateDb } from '../../core/shared/recency.js';
 import { mineCooccurrences, saveCooccurrenceToStateDb } from '../../core/shared/cooccurrence.js';
@@ -53,6 +53,7 @@ export function registerSystemTools(
     entities_count: z.number().describe('Number of entities (titles + aliases)'),
     fts5_notes: z.number().describe('Number of notes in FTS5 search index'),
     edges_recomputed: z.number().optional().describe('Number of edges with recomputed weights'),
+    note_links_synced: z.number().optional().describe('Number of notes whose note_links were synced'),
     hub_scores: z.number().optional().describe('Number of hub scores exported'),
     graph_snapshot: z.boolean().optional().describe('Whether graph topology snapshot was recorded'),
     suppression_list: z.boolean().optional().describe('Whether wikilink suppression list was updated'),
@@ -71,6 +72,7 @@ export function registerSystemTools(
     entities_count: number;
     fts5_notes: number;
     edges_recomputed?: number;
+    note_links_synced?: number;
     hub_scores?: number;
     graph_snapshot?: boolean;
     suppression_list?: boolean;
@@ -161,6 +163,35 @@ export function registerSystemTools(
           console.error('[Flywheel] FTS5 rebuild failed:', err);
         }
 
+
+        // Step 4b: Sync note_links from rebuilt VaultIndex
+        let noteLinksSynced = 0;
+        if (stateDb) {
+          tracker.start('note_links_sync', {});
+          try {
+            const indexPaths = new Set<string>();
+            for (const [notePath, note] of newIndex.notes) {
+              indexPaths.add(notePath);
+              const targets = new Set(note.outlinks.map(link => link.target.toLowerCase()));
+              updateStoredNoteLinks(stateDb, notePath, targets);
+              noteLinksSynced++;
+            }
+            // Remove stale source rows for notes no longer in the index
+            const dbSourcePaths = stateDb.db.prepare(
+              'SELECT DISTINCT note_path FROM note_links'
+            ).all() as Array<{ note_path: string }>;
+            for (const row of dbSourcePaths) {
+              if (!indexPaths.has(row.note_path)) {
+                stateDb.db.prepare('DELETE FROM note_links WHERE note_path = ?').run(row.note_path);
+              }
+            }
+            tracker.end({ notes: noteLinksSynced });
+            console.error(`[Flywheel] note_links synced for ${noteLinksSynced} notes`);
+          } catch (err) {
+            tracker.end({ error: String(err) });
+            console.error('[Flywheel] note_links sync failed:', err);
+          }
+        }
         // Step 5: Recompute edge weights
         let edgesRecomputed = 0;
         if (stateDb) {
@@ -370,6 +401,7 @@ export function registerSystemTools(
           entities_count: newIndex.entities.size,
           fts5_notes: fts5Notes,
           edges_recomputed: edgesRecomputed,
+          note_links_synced: noteLinksSynced || undefined,
           hub_scores: hubScoresExported || undefined,
           graph_snapshot: graphSnapshotRecorded || undefined,
           suppression_list: suppressionUpdated || undefined,

--- a/packages/mcp-server/test/graph-quality/clock-helpers.ts
+++ b/packages/mcp-server/test/graph-quality/clock-helpers.ts
@@ -1,0 +1,161 @@
+/**
+ * Clock Test helpers — snapshot builders and cross-layer assertions for T16.
+ */
+
+import { expect } from 'vitest';
+import type { TestClient } from '../read/helpers/createTestServer.js';
+import type { StateDb } from '@velvetmonkey/vault-core';
+
+// ── JSON extraction ─────────────────────────────────────────────
+
+/** Call an MCP tool and parse the first text content block as JSON */
+export async function callJsonTool(
+  client: TestClient,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<any> {
+  const result = await client.callTool(name, args);
+  const text = result?.content?.[0]?.text;
+  if (!text) throw new Error(`${name} returned no text content`);
+  return JSON.parse(text);
+}
+
+// ── Inventory helpers ───────────────────────────────────────────
+
+/** Return sorted paths of all notes under the test/ folder.
+ *  Metadata search (no query) returns { notes }, FTS search returns { results }. */
+export async function searchInventory(client: TestClient): Promise<string[]> {
+  const data = await callJsonTool(client, 'search', {
+    folder: 'test',
+    limit: 100,
+    sort_by: 'title',
+    order: 'asc',
+  });
+  // Metadata search returns `notes`, not `results`
+  const items: Array<{ path: string }> = data.notes ?? data.results ?? [];
+  return items.map(r => r.path).sort();
+}
+
+/** Content search (FTS5) — returns paths of matching notes */
+export async function searchContent(
+  client: TestClient,
+  query: string,
+): Promise<string[]> {
+  const data = await callJsonTool(client, 'search', {
+    query,
+    limit: 20,
+    consumer: 'human',
+  });
+  // FTS/hybrid search returns `results`
+  const items: Array<{ path: string }> = data.results ?? data.notes ?? [];
+  return items.map(r => r.path);
+}
+
+// ── MCP surface snapshot ────────────────────────────────────────
+
+export interface McpSnapshot {
+  inventory: string[];                         // sorted note paths
+  backlinks: Record<string, string[]>;         // path → sorted source paths
+  forwardLinks: Record<string, string[]>;      // path → sorted target names (lowercase)
+  structures: Record<string, any>;             // path → get_note_structure result
+}
+
+export async function snapshotMcpState(
+  client: TestClient,
+  paths: string[],
+): Promise<McpSnapshot> {
+  const inventory = await searchInventory(client);
+
+  const backlinks: Record<string, string[]> = {};
+  const forwardLinks: Record<string, string[]> = {};
+  const structures: Record<string, any> = {};
+
+  for (const p of paths) {
+    try {
+      const bl = await callJsonTool(client, 'get_backlinks', { path: p });
+      backlinks[p] = (bl.backlinks ?? []).map((b: any) => b.source).sort();
+    } catch {
+      backlinks[p] = [];
+    }
+
+    try {
+      const fl = await callJsonTool(client, 'get_forward_links', { path: p });
+      forwardLinks[p] = (fl.forward_links ?? []).map((l: any) =>
+        (l.target ?? '').toLowerCase()
+      ).sort();
+    } catch {
+      forwardLinks[p] = [];
+    }
+
+    try {
+      structures[p] = await callJsonTool(client, 'get_note_structure', { path: p });
+    } catch {
+      structures[p] = null;
+    }
+  }
+
+  return { inventory, backlinks, forwardLinks, structures };
+}
+
+// ── DB snapshot ─────────────────────────────────────────────────
+
+export interface DbSnapshot {
+  ftsPaths: string[];                            // sorted paths in notes_fts
+  noteLinks: Array<{ source: string; target: string }>;  // sorted
+}
+
+export function snapshotDbState(stateDb: StateDb): DbSnapshot {
+  const ftsRows = stateDb.db
+    .prepare('SELECT DISTINCT path FROM notes_fts ORDER BY path')
+    .all() as Array<{ path: string }>;
+  const ftsPaths = ftsRows.map(r => r.path);
+
+  const linkRows = stateDb.db
+    .prepare('SELECT note_path, target FROM note_links ORDER BY note_path, target')
+    .all() as Array<{ note_path: string; target: string }>;
+  const noteLinks = linkRows.map(r => ({ source: r.note_path, target: r.target }));
+
+  return { ftsPaths, noteLinks };
+}
+
+// ── Cross-layer assertions ──────────────────────────────────────
+
+export function assertCrossLayerConsistency(mcp: McpSnapshot, db: DbSnapshot): void {
+  // Every inventory note should be in FTS
+  for (const p of mcp.inventory) {
+    expect(db.ftsPaths, `FTS missing inventory note ${p}`).toContain(p);
+  }
+
+  // Forward link targets in MCP should match DB note_links for each note
+  for (const [notePath, mcpTargets] of Object.entries(mcp.forwardLinks)) {
+    const dbTargets = db.noteLinks
+      .filter(r => r.source === notePath)
+      .map(r => r.target)
+      .sort();
+    expect(mcpTargets, `forward links mismatch for ${notePath}`).toEqual(dbTargets);
+  }
+}
+
+// ── Invariant assertions ────────────────────────────────────────
+
+export function assertInvariants(mcp: McpSnapshot): void {
+  // Live-link/backlink symmetry: if A has forward link to B (and B is in inventory),
+  // then B should have A in backlinks
+  for (const [source, targets] of Object.entries(mcp.forwardLinks)) {
+    for (const target of targets) {
+      // Find the inventory path that matches the target
+      const targetPath = mcp.inventory.find(
+        p => p.toLowerCase().replace(/\.md$/, '') === target ||
+             p.toLowerCase() === target ||
+             p.toLowerCase() === target + '.md'
+      );
+      if (targetPath && mcp.backlinks[targetPath]) {
+        expect(
+          mcp.backlinks[targetPath],
+          `backlink symmetry: ${targetPath} should have backlink from ${source}`
+        ).toContain(source);
+      }
+      // Dead links (target not in inventory) are expected to lack backlinks — skip
+    }
+  }
+}

--- a/packages/mcp-server/test/graph-quality/clock.test.ts
+++ b/packages/mcp-server/test/graph-quality/clock.test.ts
@@ -1,0 +1,283 @@
+/**
+ * T16 — Clock Test: Graph black-box testing via MCP tools
+ *
+ * A 10-tick sequential test that builds and mutates a graph one step at a time
+ * through the MCP tool surface, then asserts MCP output and StateDb state agree
+ * after every mutation.
+ */
+
+import { describe, test, beforeAll, afterAll, expect } from 'vitest';
+import { createWriteTestServer, type WriteTestServerContext } from '../helpers/createWriteTestServer.js';
+import { connectTestClient, type TestClient } from '../read/helpers/createTestServer.js';
+import { registerMoveNoteTools } from '../../src/tools/write/move-notes.js';
+import {
+  callJsonTool,
+  searchInventory,
+  searchContent,
+  snapshotMcpState,
+  snapshotDbState,
+  assertCrossLayerConsistency,
+  assertInvariants,
+  type McpSnapshot,
+  type DbSnapshot,
+} from './clock-helpers.js';
+
+describe('Clock Test — T16', () => {
+  let ctx: WriteTestServerContext;
+  let client: TestClient;
+
+  // Snapshots after each tick for regression checks
+  const snapshots: Array<{ mcp: McpSnapshot; db: DbSnapshot }> = [];
+
+  // Note paths (updated as mutations happen)
+  let alphaPath = 'test/alpha.md';
+  const bravoPath = 'test/bravo.md';
+  const charliePath = 'test/charlie.md';
+
+  beforeAll(async () => {
+    ctx = await createWriteTestServer();
+    registerMoveNoteTools(ctx.server, () => ctx.vaultPath);
+    client = connectTestClient(ctx.server);
+  }, 30_000);
+
+  afterAll(async () => {
+    await ctx?.cleanup();
+  });
+
+  /** Helper: refresh index, snapshot MCP + DB, run invariants */
+  async function refreshAndSnapshot(paths: string[]): Promise<{ mcp: McpSnapshot; db: DbSnapshot }> {
+    await callJsonTool(client, 'refresh_index', {});
+    const mcp = await snapshotMcpState(client, paths);
+    const db = snapshotDbState(ctx.stateDb!);
+    snapshots.push({ mcp, db });
+    assertCrossLayerConsistency(mcp, db);
+    assertInvariants(mcp);
+    return { mcp, db };
+  }
+
+  // ── Tick functions ────────────────────────────────────────────
+
+  async function tick1_createAlpha() {
+    await callJsonTool(client, 'vault_create_note', {
+      path: 'test/alpha.md',
+      content: '# Alpha\n\nA rocketry project.',
+      frontmatter: { type: 'project' },
+      skipWikilinks: true,
+    });
+
+    const { mcp, db } = await refreshAndSnapshot([alphaPath]);
+
+    expect(mcp.inventory).toEqual([alphaPath]);
+    expect(mcp.backlinks[alphaPath]).toEqual([]);
+    expect(mcp.forwardLinks[alphaPath]).toEqual([]);
+    expect(mcp.structures[alphaPath]?.frontmatter?.type).toBe('project');
+    expect(db.ftsPaths).toContain(alphaPath);
+    expect(db.noteLinks).toEqual([]);
+  }
+
+  async function tick2_createBravoLinkingAlpha() {
+    await callJsonTool(client, 'vault_create_note', {
+      path: bravoPath,
+      content: '# Bravo\n\nSupports [[Alpha]] with propulsion.',
+      skipWikilinks: true,
+    });
+
+    const { mcp, db } = await refreshAndSnapshot([alphaPath, bravoPath]);
+
+    expect(mcp.inventory).toEqual([alphaPath, bravoPath]);
+    expect(mcp.backlinks[alphaPath]).toContain(bravoPath);
+    expect(mcp.forwardLinks[bravoPath].length).toBeGreaterThan(0);
+    // Propulsion content search
+    const propHits = await searchContent(client, 'propulsion');
+    expect(propHits).toContain(bravoPath);
+    // DB should have bravo -> alpha link
+    expect(db.noteLinks.some(l => l.source === bravoPath && l.target === 'alpha')).toBe(true);
+  }
+
+  async function tick3_addLinkToAlpha() {
+    await callJsonTool(client, 'vault_add_to_section', {
+      path: alphaPath,
+      section: 'Alpha',
+      content: 'Phase 1 launched. See [[Bravo]].',
+      skipWikilinks: true,
+    });
+
+    const { mcp, db } = await refreshAndSnapshot([alphaPath, bravoPath]);
+
+    // Bidirectional links
+    expect(mcp.backlinks[alphaPath]).toContain(bravoPath);
+    expect(mcp.forwardLinks[alphaPath].length).toBeGreaterThan(0);
+    // "phase 1" should be searchable in alpha
+    const phaseHits = await searchContent(client, '"phase 1"');
+    expect(phaseHits).toContain(alphaPath);
+    // DB should have both directions
+    expect(db.noteLinks.some(l => l.source === alphaPath && l.target === 'bravo')).toBe(true);
+    expect(db.noteLinks.some(l => l.source === bravoPath && l.target === 'alpha')).toBe(true);
+  }
+
+  async function tick4_updateAlphaFrontmatter() {
+    await callJsonTool(client, 'vault_update_frontmatter', {
+      path: alphaPath,
+      frontmatter: { status: 'active', priority: 'high' },
+    });
+
+    const { mcp } = await refreshAndSnapshot([alphaPath, bravoPath]);
+
+    // Metadata search
+    const statusHits = await callJsonTool(client, 'search', {
+      where: { status: 'active' },
+      limit: 10,
+    });
+    const statusPaths = (statusHits.notes ?? []).map((r: any) => r.path);
+    expect(statusPaths).toContain(alphaPath);
+    // Structure should show the new fields
+    expect(mcp.structures[alphaPath]?.frontmatter?.status).toBe('active');
+    expect(mcp.structures[alphaPath]?.frontmatter?.priority).toBe('high');
+    // Link graph unchanged from tick 3
+    expect(mcp.forwardLinks[alphaPath].length).toBeGreaterThan(0);
+    expect(mcp.backlinks[alphaPath]).toContain(bravoPath);
+  }
+
+  async function tick5_createOrphanCharlie() {
+    await callJsonTool(client, 'vault_create_note', {
+      path: charliePath,
+      content: '# Charlie\n\nUnrelated aerodynamics.',
+      skipWikilinks: true,
+    });
+
+    const { mcp } = await refreshAndSnapshot([alphaPath, bravoPath, charliePath]);
+
+    expect(mcp.inventory).toHaveLength(3);
+    expect(mcp.backlinks[charliePath]).toEqual([]);
+    expect(mcp.forwardLinks[charliePath]).toEqual([]);
+    // Alpha/Bravo graph unchanged
+    expect(mcp.backlinks[alphaPath]).toContain(bravoPath);
+  }
+
+  async function tick6_linkCharlieIntoGraph() {
+    await callJsonTool(client, 'vault_add_to_section', {
+      path: charliePath,
+      section: 'Charlie',
+      content: 'Collaborating with [[Alpha]] and [[Bravo]].',
+      skipWikilinks: true,
+    });
+
+    const { mcp, db } = await refreshAndSnapshot([alphaPath, bravoPath, charliePath]);
+
+    // Alpha backlinks = bravo + charlie
+    expect(mcp.backlinks[alphaPath].sort()).toEqual([bravoPath, charliePath].sort());
+    // Charlie forward links include alpha and bravo
+    expect(mcp.forwardLinks[charliePath].length).toBe(2);
+    // DB has Charlie rows
+    expect(db.noteLinks.some(l => l.source === charliePath)).toBe(true);
+  }
+
+  async function tick7_renameAlpha() {
+    await callJsonTool(client, 'vault_rename_note', {
+      path: 'test/alpha.md',
+      newTitle: 'alpha-prime',
+      updateBacklinks: true,
+    });
+
+    const newAlpha = 'test/alpha-prime.md';
+    alphaPath = newAlpha;
+
+    const { mcp, db } = await refreshAndSnapshot([alphaPath, bravoPath, charliePath]);
+
+    // Inventory has the new path, not the old one
+    expect(mcp.inventory).toContain(newAlpha);
+    expect(mcp.inventory).not.toContain('test/alpha.md');
+    // Old source path absent from DB
+    expect(db.noteLinks.some(l => l.source === 'test/alpha.md')).toBe(false);
+    expect(db.ftsPaths).not.toContain('test/alpha.md');
+    // Backlinks from bravo/charlie should now resolve to alpha-prime
+    expect(mcp.backlinks[newAlpha].sort()).toEqual([bravoPath, charliePath].sort());
+    // Content search for Alpha should still find the renamed note
+    const alphaHits = await searchContent(client, 'Alpha');
+    expect(alphaHits).toContain(newAlpha);
+  }
+
+  async function tick8_replaceBravoContent() {
+    await callJsonTool(client, 'vault_replace_in_section', {
+      path: bravoPath,
+      section: 'Bravo',
+      search: 'propulsion',
+      replacement: 'engine design',
+      skipWikilinks: true,
+    });
+
+    const { mcp } = await refreshAndSnapshot([alphaPath, bravoPath, charliePath]);
+
+    // Propulsion gone from search
+    const propHits = await searchContent(client, 'propulsion');
+    expect(propHits).not.toContain(bravoPath);
+    // Engine design now searchable
+    const engineHits = await searchContent(client, '"engine design"');
+    expect(engineHits).toContain(bravoPath);
+    // Bravo still links to alpha-prime
+    expect(mcp.forwardLinks[bravoPath].length).toBeGreaterThan(0);
+  }
+
+  async function tick9_deleteBravo() {
+    await callJsonTool(client, 'vault_delete_note', {
+      path: bravoPath,
+      confirm: true,
+    });
+
+    const { mcp, db } = await refreshAndSnapshot([alphaPath, charliePath]);
+
+    // 2-note inventory
+    expect(mcp.inventory).toHaveLength(2);
+    expect(mcp.inventory).not.toContain(bravoPath);
+    // No DB source rows for bravo
+    expect(db.noteLinks.some(l => l.source === bravoPath)).toBe(false);
+    expect(db.ftsPaths).not.toContain(bravoPath);
+    // Alpha-prime backlinks = charlie only
+    expect(mcp.backlinks[alphaPath]).toEqual([charliePath]);
+    // Charlie forward links: alpha-prime is live, bravo is dead
+    // Both still in source markdown (charlie's content still references bravo)
+    expect(mcp.forwardLinks[charliePath].length).toBe(2);
+  }
+
+  async function tick10_fullConsistencyCheck() {
+    // No mutation — just verify final state
+    const { mcp, db } = await refreshAndSnapshot([alphaPath, charliePath]);
+
+    // Final inventory = alpha-prime + charlie
+    expect(mcp.inventory.sort()).toEqual([alphaPath, charliePath].sort());
+    // Alpha-prime frontmatter intact
+    expect(mcp.structures[alphaPath]?.frontmatter?.type).toBe('project');
+    expect(mcp.structures[alphaPath]?.frontmatter?.status).toBe('active');
+    expect(mcp.structures[alphaPath]?.frontmatter?.priority).toBe('high');
+
+    // Validate links: should report dead links (bravo references in surviving notes)
+    const validation = await callJsonTool(client, 'validate_links', {
+      group_by_target: true,
+      limit: 20,
+    });
+    // Bravo should appear as a dead target
+    const deadTargets = (validation.targets ?? []).map((t: any) =>
+      (t.target ?? '').toLowerCase()
+    );
+    expect(deadTargets.length).toBeGreaterThan(0);
+
+    // Cross-layer consistency holds (already checked in refreshAndSnapshot)
+    assertCrossLayerConsistency(mcp, db);
+    assertInvariants(mcp);
+  }
+
+  // ── The clock ─────────────────────────────────────────────────
+
+  test('10-tick graph mutation sequence', async () => {
+    await tick1_createAlpha();
+    await tick2_createBravoLinkingAlpha();
+    await tick3_addLinkToAlpha();
+    await tick4_updateAlphaFrontmatter();
+    await tick5_createOrphanCharlie();
+    await tick6_linkCharlieIntoGraph();
+    await tick7_renameAlpha();
+    await tick8_replaceBravoContent();
+    await tick9_deleteBravo();
+    await tick10_fullConsistencyCheck();
+  }, 120_000);
+});

--- a/packages/mcp-server/test/read/helpers/createTestServer.ts
+++ b/packages/mcp-server/test/read/helpers/createTestServer.ts
@@ -97,7 +97,9 @@ export async function createTestServer(vaultPath: string): Promise<TestServerCon
     (newIndex) => {
       currentIndex = newIndex;
     },
-    () => vaultPath
+    () => vaultPath,
+    undefined,
+    () => stateDb
   );
 
   registerPrimitiveTools(


### PR DESCRIPTION
## Summary

- Add a 10-tick sequential clock test (`test/graph-quality/clock.test.ts`) that builds a graph one mutation at a time through MCP tools, refreshes after each step, and asserts the MCP surface and StateDb `note_links` agree at every tick
- Fix `refresh_index` to sync `note_links` from the rebuilt VaultIndex when StateDb is available — without this, DB-side graph assertions are false negatives
- Pass `() => stateDb` to `registerSystemTools` in the test server so `refresh_index` exercises the StateDb-backed path during tests

## Clock Sequence

1. Create note A → 2. Create note B linking A → 3. Add bidirectional link → 4. Update frontmatter → 5. Create orphan C → 6. Link C into graph → 7. Rename A → 8. Replace content in B → 9. Delete B → 10. Full consistency check with `validate_links`

## Test plan

- [x] `npx vitest run test/graph-quality/clock.test.ts` — all 10 ticks pass
- [x] `npx vitest run test/read/tools/system.test.ts` — no regressions
- [x] `npm run build` — builds clean
- [x] `npm run lint` — types check clean
- [ ] Full package test suite (`npm run test -w @velvetmonkey/flywheel-memory`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)