### PR TITLE
feat: T19 — prospect ledger for persistent pre-entity memory

### DIFF
--- a/packages/core/src/migrations.ts
+++ b/packages/core/src/migrations.ts
@@ -29,6 +29,8 @@ export const SALVAGE_TABLES = [
   'session_summaries',
   'corrections',
   'tool_selection_feedback',
+  'prospect_ledger',
+  'prospect_summary',
 ] as const;
 
 // =============================================================================
@@ -410,6 +412,9 @@ export function initSchema(db: Database.Database): void {
 
       db.prepare('INSERT OR REPLACE INTO schema_version (version) VALUES (?)').run(36);
     }
+
+    // v37: prospect_ledger + prospect_summary tables (pre-entity pattern accumulation)
+    // (created by SCHEMA_SQL above via CREATE TABLE IF NOT EXISTS)
 
     db.prepare(
       'INSERT OR IGNORE INTO schema_version (version) VALUES (?)'

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -10,7 +10,7 @@
 // =============================================================================
 
 /** Current schema version - bump when schema changes */
-export const SCHEMA_VERSION = 36;
+export const SCHEMA_VERSION = 37;
 
 /** State database filename */
 export const STATE_DB_FILENAME = 'state.db';
@@ -488,4 +488,44 @@ CREATE TABLE IF NOT EXISTS tool_selection_feedback (
 );
 CREATE INDEX IF NOT EXISTS idx_tsf_tool ON tool_selection_feedback(tool_name);
 CREATE INDEX IF NOT EXISTS idx_tsf_ts ON tool_selection_feedback(timestamp);
+
+-- Prospect ledger (v37): day-grain sightings for pre-entity pattern accumulation
+CREATE TABLE IF NOT EXISTS prospect_ledger (
+  term TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  note_path TEXT NOT NULL,
+  seen_day TEXT NOT NULL,
+  source TEXT NOT NULL,
+  pattern TEXT,
+  confidence TEXT NOT NULL DEFAULT 'low',
+  backlink_count INTEGER DEFAULT 0,
+  score REAL DEFAULT 0,
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  sighting_count INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (term, note_path, seen_day)
+);
+CREATE INDEX IF NOT EXISTS idx_prospect_term ON prospect_ledger(term);
+CREATE INDEX IF NOT EXISTS idx_prospect_last_seen ON prospect_ledger(last_seen_at);
+
+-- Prospect summary (v37): materialized aggregate for fast scoring
+CREATE TABLE IF NOT EXISTS prospect_summary (
+  term TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  note_count INTEGER NOT NULL DEFAULT 0,
+  day_count INTEGER NOT NULL DEFAULT 0,
+  total_sightings INTEGER NOT NULL DEFAULT 0,
+  backlink_max INTEGER NOT NULL DEFAULT 0,
+  cooccurring_entities TEXT,
+  best_source TEXT NOT NULL DEFAULT 'implicit',
+  best_confidence TEXT NOT NULL DEFAULT 'low',
+  best_score REAL NOT NULL DEFAULT 0,
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  promotion_score REAL NOT NULL DEFAULT 0,
+  promoted_at INTEGER,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_prospect_summary_score ON prospect_summary(promotion_score DESC);
+
 `;

--- a/packages/core/test/backup.test.ts
+++ b/packages/core/test/backup.test.ts
@@ -337,7 +337,7 @@ describe('Backup & Recovery', () => {
   // Extended salvage scenarios
   // ===========================================================================
   describe('salvageFeedbackTables (extended)', () => {
-    it('salvages all 10 SALVAGE_TABLES when populated', () => {
+    it('salvages all 12 SALVAGE_TABLES when populated', () => {
       const sourceDb = openStateDb(testVaultPath);
       const now = Date.now();
 
@@ -372,6 +372,12 @@ describe('Backup & Recovery', () => {
       sourceDb.db.prepare(
         `INSERT INTO tool_selection_feedback (timestamp, tool_name, correct, source) VALUES (?, ?, ?, ?)`
       ).run(now, 'search', 1, 'explicit');
+      sourceDb.db.prepare(
+        `INSERT INTO prospect_ledger (term, display_name, note_path, seen_day, source, confidence, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run('test term', 'Test Term', 'n.md', '2026-03-30', 'implicit', 'low', now, now);
+      sourceDb.db.prepare(
+        `INSERT INTO prospect_summary (term, display_name, note_count, day_count, total_sightings, backlink_max, best_source, best_confidence, best_score, first_seen_at, last_seen_at, promotion_score, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run('test term', 'Test Term', 1, 1, 1, 0, 'implicit', 'low', 0, now, now, 5.0, now);
       sourceDb.close();
 
       const backupPath = `${dbPath}.full-salvage`;
@@ -385,7 +391,7 @@ describe('Backup & Recovery', () => {
 
       try {
         const results = salvageFeedbackTables(targetDb.db, backupPath);
-        // All 10 tables should have been salvaged
+        // All 12 tables should have been salvaged
         for (const table of SALVAGE_TABLES) {
           expect(results[table]).toBeGreaterThanOrEqual(1);
         }

--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -38,7 +38,8 @@ import { mineCooccurrences, saveCooccurrenceToStateDb } from '../../shared/coocc
 import { setCooccurrenceIndex, suggestRelatedLinks, applyProactiveSuggestions } from '../../write/wikilinks.js';
 import { enqueueProactiveSuggestions, drainProactiveQueue, type QueueEntry } from '../../write/proactiveQueue.js';
 import { mineRetrievalCooccurrence } from '../../shared/retrievalCooccurrence.js';
-import { updateFTS5Incremental } from '../fts5.js';
+import { updateFTS5Incremental, countFTS5Mentions } from '../fts5.js';
+import { recordProspectSightings, refreshProspectSummaries, cleanStaleProspects, type ProspectSighting } from '../../shared/prospects.js';
 
 // Read modules
 import { getForwardLinksForNote } from '../graph.js';
@@ -1040,6 +1041,40 @@ export class PipelineRunner {
       const implicitCount = prospectResults.reduce((s, p) => s + p.implicit.length, 0);
       const deadCount = prospectResults.reduce((s, p) => s + p.deadLinkMatches.length, 0);
       serverLog('watcher', `Prospect scan: ${implicitCount} implicit entities, ${deadCount} dead link matches across ${prospectResults.length} files`);
+
+      // Persist prospect sightings to ledger
+      const sightings: ProspectSighting[] = [];
+      for (const result of prospectResults) {
+        for (const name of result.implicit) {
+          sightings.push({
+            term: name.toLowerCase(),
+            displayName: name,
+            notePath: result.file,
+            source: 'implicit',
+            confidence: 'low',
+          });
+        }
+        for (const target of result.deadLinkMatches) {
+          const backlinkCount = vaultIndex.backlinks.get(target)?.length ?? 0;
+          const ftsCount = countFTS5Mentions(target);
+          const isHighScore = backlinkCount >= 3 && ftsCount >= 3;
+          sightings.push({
+            term: target.toLowerCase(),
+            displayName: target,
+            notePath: result.file,
+            source: isHighScore ? 'high_score' : 'dead_link',
+            confidence: backlinkCount >= 3 ? 'high' : 'medium',
+            backlinkCount,
+            score: isHighScore ? ftsCount : 0,
+          });
+        }
+      }
+      if (sightings.length > 0) {
+        recordProspectSightings(sightings);
+        const affectedTerms = [...new Set(sightings.map(s => s.term))];
+        refreshProspectSummaries(affectedTerms);
+      }
+      cleanStaleProspects();
     }
     return { prospects: prospectResults };
   }

--- a/packages/mcp-server/src/core/shared/prospects.ts
+++ b/packages/mcp-server/src/core/shared/prospects.ts
@@ -1,0 +1,565 @@
+/**
+ * Prospect Ledger — Persistent Pre-Entity Memory
+ *
+ * Accumulates evidence about terms that aren't yet full entities
+ * (no backing note) but keep appearing across sessions. Three
+ * persisted source classes feed the ledger:
+ *
+ * - **implicit** — Pattern-detected terms (proper nouns, CamelCase, etc.). score = 0.
+ * - **dead_link** — Unresolved backlink targets with backlink_count >= 2. score = 0.
+ * - **high_score** — Dead-link prospect with backlink_count >= 3 AND FTS mentions >= 3.
+ *                     score = countFTS5Mentions(term).
+ *
+ * The ledger stores day-grain sightings (one row per term + note_path + seen_day)
+ * and materializes a summary per term for fast scoring. A 60-day half-life decay
+ * ensures stale prospects fade naturally. Promotion scoring drives both wikilink
+ * suggestion boosting (Layer 14) and stub-candidate surfacing.
+ */
+
+import type { StateDb } from '@velvetmonkey/vault-core';
+import { getActiveScopeOrNull } from '../../vault-scope.js';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** 60-day half-life for prospect decay */
+export const PROSPECT_DECAY_HALF_LIFE_DAYS = 60;
+const PROSPECT_DECAY_LAMBDA = Math.LN2 / PROSPECT_DECAY_HALF_LIFE_DAYS;
+
+/** Age cutoff for stale cleanup (210 days — decay < 0.01) */
+const STALE_AGE_MS = 210 * 24 * 60 * 60 * 1000;
+
+/** Default promotion threshold (effective score after decay) */
+export const PROMOTION_THRESHOLD = 50;
+
+/** Source precedence: higher = stronger signal */
+const SOURCE_PRECEDENCE: Record<string, number> = {
+  implicit: 0,
+  dead_link: 1,
+  high_score: 2,
+};
+
+/** Source multipliers for promotion score */
+const SOURCE_MULTIPLIER: Record<string, number> = {
+  implicit: 1.0,
+  dead_link: 1.2,
+  high_score: 1.3,
+};
+
+/** Confidence precedence */
+const CONFIDENCE_PRECEDENCE: Record<string, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+};
+
+/** Cooldown for stale cleanup (1 hour) */
+const CLEANUP_COOLDOWN_MS = 60 * 60 * 1000;
+let lastCleanupAt = 0;
+
+// =============================================================================
+// Module-level StateDb (follows recency.ts pattern)
+// =============================================================================
+
+let moduleStateDb: StateDb | null = null;
+
+function getStateDb(): StateDb | null {
+  return getActiveScopeOrNull()?.stateDb ?? moduleStateDb;
+}
+
+/**
+ * Set the StateDb instance for this module.
+ * Called during MCP server initialization / activateVault().
+ */
+export function setProspectStateDb(stateDb: StateDb | null): void {
+  moduleStateDb = stateDb;
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type ProspectSource = 'implicit' | 'dead_link' | 'high_score';
+
+export interface ProspectSighting {
+  term: string;           // lowercased
+  displayName: string;    // original casing
+  notePath: string;       // vault-relative
+  source: ProspectSource;
+  pattern?: string;       // implicit pattern type
+  confidence: 'high' | 'medium' | 'low';
+  backlinkCount?: number;
+  score?: number;         // detector-specific: implicit=0, dead_link=0, high_score=FTS count
+}
+
+export interface ProspectCandidate {
+  term: string;
+  displayName: string;
+  promotionScore: number;     // raw un-decayed
+  effectiveScore: number;     // after decay
+  promotionReady: boolean;    // effectiveScore >= PROMOTION_THRESHOLD
+  noteCount: number;
+  dayCount: number;
+  backlinkMax: number;
+  cooccurringEntities: string[];
+  bestSource: string;
+  bestConfidence: string;
+  bestScore: number;
+  firstSeenAt: number;
+  lastSeenAt: number;
+}
+
+interface ProspectSummaryRow {
+  term: string;
+  display_name: string;
+  note_count: number;
+  day_count: number;
+  total_sightings: number;
+  backlink_max: number;
+  cooccurring_entities: string | null;
+  best_source: string;
+  best_confidence: string;
+  best_score: number;
+  first_seen_at: number;
+  last_seen_at: number;
+  promotion_score: number;
+  promoted_at: number | null;
+  updated_at: number;
+}
+
+// =============================================================================
+// Decay
+// =============================================================================
+
+/**
+ * Compute exponential decay weight for a prospect based on last seen time.
+ * Returns 1.0 for just-seen, 0.5 at 60 days, ~0.01 at 7 months.
+ */
+export function computeProspectDecay(lastSeenAt: number, now?: number): number {
+  const ref = now ?? Date.now();
+  const ageDays = (ref - lastSeenAt) / (24 * 60 * 60 * 1000);
+  if (ageDays < 0) return 1.0;
+  return Math.exp(-PROSPECT_DECAY_LAMBDA * ageDays);
+}
+
+// =============================================================================
+// Recording Sightings
+// =============================================================================
+
+/**
+ * Get today's date as ISO string (YYYY-MM-DD).
+ */
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Batch-record prospect sightings in a transaction.
+ * Same-day repeats for the same term+note_path upsert: keep earliest display_name,
+ * advance last_seen_at, increment sighting_count, take MAX backlink_count,
+ * upgrade source/confidence by precedence.
+ */
+export function recordProspectSightings(sightings: ProspectSighting[]): void {
+  const stateDb = getStateDb();
+  if (!stateDb || sightings.length === 0) return;
+
+  const now = Date.now();
+  const day = todayISO();
+
+  const upsert = stateDb.db.prepare(`
+    INSERT INTO prospect_ledger (term, display_name, note_path, seen_day, source, pattern, confidence, backlink_count, score, first_seen_at, last_seen_at, sighting_count)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+    ON CONFLICT(term, note_path, seen_day) DO UPDATE SET
+      last_seen_at = MAX(last_seen_at, excluded.last_seen_at),
+      sighting_count = sighting_count + 1,
+      backlink_count = MAX(backlink_count, excluded.backlink_count),
+      score = MAX(score, excluded.score),
+      source = CASE
+        WHEN (CASE excluded.source WHEN 'high_score' THEN 2 WHEN 'dead_link' THEN 1 ELSE 0 END)
+           > (CASE source WHEN 'high_score' THEN 2 WHEN 'dead_link' THEN 1 ELSE 0 END)
+        THEN excluded.source
+        ELSE source
+      END,
+      confidence = CASE
+        WHEN (CASE excluded.confidence WHEN 'high' THEN 2 WHEN 'medium' THEN 1 ELSE 0 END)
+           > (CASE confidence WHEN 'high' THEN 2 WHEN 'medium' THEN 1 ELSE 0 END)
+        THEN excluded.confidence
+        ELSE confidence
+      END
+  `);
+
+  const runBatch = stateDb.db.transaction(() => {
+    for (const s of sightings) {
+      upsert.run(
+        s.term.toLowerCase(),
+        s.displayName,
+        s.notePath,
+        day,
+        s.source,
+        s.pattern ?? null,
+        s.confidence,
+        s.backlinkCount ?? 0,
+        s.score ?? 0,
+        now,
+        now,
+      );
+    }
+  });
+
+  runBatch();
+}
+
+// =============================================================================
+// Summary Refresh
+// =============================================================================
+
+/**
+ * Refresh prospect summaries for the given terms.
+ * Aggregates from prospect_ledger into prospect_summary.
+ */
+export function refreshProspectSummaries(terms: string[]): void {
+  const stateDb = getStateDb();
+  if (!stateDb || terms.length === 0) return;
+
+  const now = Date.now();
+
+  // Aggregate query for a single term
+  const aggregate = stateDb.db.prepare(`
+    SELECT
+      term,
+      MIN(display_name) AS display_name,
+      COUNT(DISTINCT note_path) AS note_count,
+      COUNT(*) AS day_count,
+      SUM(sighting_count) AS total_sightings,
+      MAX(backlink_count) AS backlink_max,
+      MAX(score) AS best_score,
+      MIN(first_seen_at) AS first_seen_at,
+      MAX(last_seen_at) AS last_seen_at
+    FROM prospect_ledger
+    WHERE term = ?
+    GROUP BY term
+  `);
+
+  // Best source (highest precedence)
+  const bestSource = stateDb.db.prepare(`
+    SELECT source FROM prospect_ledger
+    WHERE term = ?
+    ORDER BY
+      CASE source WHEN 'high_score' THEN 2 WHEN 'dead_link' THEN 1 ELSE 0 END DESC
+    LIMIT 1
+  `);
+
+  // Best confidence (highest precedence)
+  const bestConfidence = stateDb.db.prepare(`
+    SELECT confidence FROM prospect_ledger
+    WHERE term = ?
+    ORDER BY
+      CASE confidence WHEN 'high' THEN 2 WHEN 'medium' THEN 1 ELSE 0 END DESC
+    LIMIT 1
+  `);
+
+  // Co-occurring entities from note_links
+  const cooccurring = stateDb.db.prepare(`
+    SELECT DISTINCT nl.target
+    FROM prospect_ledger pl
+    JOIN note_links nl ON pl.note_path = nl.note_path
+    WHERE pl.term = ? AND LOWER(nl.target) != ?
+    LIMIT 10
+  `);
+
+  // Check if entity exists (for promoted_at)
+  const entityExists = stateDb.db.prepare(`
+    SELECT 1 FROM entities
+    WHERE name_lower = ?
+    UNION
+    SELECT 1 FROM entities
+    WHERE EXISTS (
+      SELECT 1 FROM json_each(aliases_json) WHERE LOWER(value) = ?
+    )
+    LIMIT 1
+  `);
+
+  // Upsert summary
+  const upsertSummary = stateDb.db.prepare(`
+    INSERT INTO prospect_summary (term, display_name, note_count, day_count, total_sightings, backlink_max, cooccurring_entities, best_source, best_confidence, best_score, first_seen_at, last_seen_at, promotion_score, promoted_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(term) DO UPDATE SET
+      display_name = excluded.display_name,
+      note_count = excluded.note_count,
+      day_count = excluded.day_count,
+      total_sightings = excluded.total_sightings,
+      backlink_max = excluded.backlink_max,
+      cooccurring_entities = excluded.cooccurring_entities,
+      best_source = excluded.best_source,
+      best_confidence = excluded.best_confidence,
+      best_score = excluded.best_score,
+      first_seen_at = excluded.first_seen_at,
+      last_seen_at = excluded.last_seen_at,
+      promotion_score = excluded.promotion_score,
+      promoted_at = excluded.promoted_at,
+      updated_at = excluded.updated_at
+  `);
+
+  const runRefresh = stateDb.db.transaction(() => {
+    for (const rawTerm of terms) {
+      const term = rawTerm.toLowerCase();
+
+      const agg = aggregate.get(term) as {
+        term: string;
+        display_name: string;
+        note_count: number;
+        day_count: number;
+        total_sightings: number;
+        backlink_max: number;
+        best_score: number;
+        first_seen_at: number;
+        last_seen_at: number;
+      } | undefined;
+
+      if (!agg) continue;
+
+      const srcRow = bestSource.get(term) as { source: string } | undefined;
+      const confRow = bestConfidence.get(term) as { confidence: string } | undefined;
+      const coocRows = cooccurring.all(term, term) as Array<{ target: string }>;
+      const coocEntities = coocRows.map(r => r.target);
+
+      // Check entity existence for promoted_at
+      const exists = entityExists.get(term, term);
+      const promotedAt = exists ? now : null;
+
+      const promoScore = computePromotionScore({
+        noteCount: agg.note_count,
+        dayCount: agg.day_count,
+        backlinkMax: agg.backlink_max,
+        cooccurringCount: coocEntities.length,
+        bestScore: agg.best_score,
+        bestSource: srcRow?.source ?? 'implicit',
+      });
+
+      upsertSummary.run(
+        term,
+        agg.display_name,
+        agg.note_count,
+        agg.day_count,
+        agg.total_sightings,
+        agg.backlink_max,
+        coocEntities.length > 0 ? JSON.stringify(coocEntities) : null,
+        srcRow?.source ?? 'implicit',
+        confRow?.confidence ?? 'low',
+        agg.best_score,
+        agg.first_seen_at,
+        agg.last_seen_at,
+        promoScore,
+        promotedAt,
+        now,
+      );
+    }
+  });
+
+  runRefresh();
+}
+
+// =============================================================================
+// Promotion Score
+// =============================================================================
+
+interface PromotionInput {
+  noteCount: number;
+  dayCount: number;
+  backlinkMax: number;
+  cooccurringCount: number;
+  bestScore: number;
+  bestSource: string;
+}
+
+/**
+ * Compute raw promotion score (un-decayed).
+ *
+ * Formula:
+ *   raw = (noteSpread*3 + daySpread*2 + backlinkSig*2 + cooccurSig*1 + sourceScoreSig*0.5) * sourceMultiplier
+ *
+ * Each component normalized to [0, 10].
+ */
+export function computePromotionScore(input: PromotionInput): number {
+  const noteSpread = Math.min(input.noteCount, 10);
+  const daySpread = Math.min(input.dayCount, 10);
+  const backlinkSig = Math.min(input.backlinkMax, 10);
+  const cooccurSig = Math.min(input.cooccurringCount, 10);
+  const sourceScoreSig = Math.min(input.bestScore, 10);
+
+  const multiplier = SOURCE_MULTIPLIER[input.bestSource] ?? 1.0;
+
+  const raw = (
+    noteSpread * 3 +
+    daySpread * 2 +
+    backlinkSig * 2 +
+    cooccurSig * 1 +
+    sourceScoreSig * 0.5
+  ) * multiplier;
+
+  return Math.round(raw * 10) / 10;
+}
+
+// =============================================================================
+// Prospect Boost Map (for scoring pipeline)
+// =============================================================================
+
+/**
+ * Build a Map of prospect term -> boost value [0, 6] for the scoring pipeline.
+ * Entity existence is checked via DB query to exclude promoted prospects from
+ * candidate surfacing, but promoted terms still receive boost for decay-through.
+ */
+export function getProspectBoostMap(): Map<string, number> {
+  const stateDb = getStateDb();
+  if (!stateDb) return new Map();
+
+  try {
+    const rows = stateDb.db.prepare(`
+      SELECT term, promotion_score, last_seen_at
+      FROM prospect_summary
+      WHERE promotion_score > 0
+    `).all() as Array<Pick<ProspectSummaryRow, 'term' | 'promotion_score' | 'last_seen_at'>>;
+
+    const now = Date.now();
+    const map = new Map<string, number>();
+
+    for (const row of rows) {
+      const effective = row.promotion_score * computeProspectDecay(row.last_seen_at, now);
+      if (effective > 5) {
+        const boost = Math.min(6, effective / 10);
+        map.set(row.term, Math.round(boost * 10) / 10);
+      }
+    }
+
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+// =============================================================================
+// Promotion Candidates (for discover_stub_candidates)
+// =============================================================================
+
+/**
+ * Return all scored prospects sorted by effective score descending.
+ * Excludes terms that currently exist as entities (checked via DB lookup
+ * against entities.name_lower + json_each(aliases_json)).
+ * Each candidate includes promotion_ready annotation.
+ */
+export function getPromotionCandidates(limit = 50): ProspectCandidate[] {
+  const stateDb = getStateDb();
+  if (!stateDb) return [];
+
+  try {
+    const rows = stateDb.db.prepare(`
+      SELECT ps.*
+      FROM prospect_summary ps
+      WHERE ps.promotion_score > 0
+        AND NOT EXISTS (
+          SELECT 1 FROM entities WHERE name_lower = ps.term
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM entities e, json_each(e.aliases_json) j
+          WHERE LOWER(j.value) = ps.term
+        )
+      ORDER BY ps.promotion_score DESC
+    `).all() as ProspectSummaryRow[];
+
+    const now = Date.now();
+    const candidates: ProspectCandidate[] = [];
+
+    for (const row of rows) {
+      const effective = row.promotion_score * computeProspectDecay(row.last_seen_at, now);
+      if (effective < 1) continue; // filter near-zero
+
+      candidates.push({
+        term: row.term,
+        displayName: row.display_name,
+        promotionScore: row.promotion_score,
+        effectiveScore: Math.round(effective * 10) / 10,
+        promotionReady: effective >= PROMOTION_THRESHOLD,
+        noteCount: row.note_count,
+        dayCount: row.day_count,
+        backlinkMax: row.backlink_max,
+        cooccurringEntities: row.cooccurring_entities ? JSON.parse(row.cooccurring_entities) : [],
+        bestSource: row.best_source,
+        bestConfidence: row.best_confidence,
+        bestScore: row.best_score,
+        firstSeenAt: row.first_seen_at,
+        lastSeenAt: row.last_seen_at,
+      });
+
+      if (candidates.length >= limit) break;
+    }
+
+    return candidates;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get sample note paths for a prospect term (for discover_stub_candidates).
+ */
+export function getProspectSampleNotes(term: string, limit = 3): string[] {
+  const stateDb = getStateDb();
+  if (!stateDb) return [];
+
+  try {
+    const rows = stateDb.db.prepare(`
+      SELECT DISTINCT note_path FROM prospect_ledger
+      WHERE term = ?
+      ORDER BY last_seen_at DESC
+      LIMIT ?
+    `).all(term.toLowerCase(), limit) as Array<{ note_path: string }>;
+
+    return rows.map(r => r.note_path);
+  } catch {
+    return [];
+  }
+}
+
+// =============================================================================
+// Stale Cleanup
+// =============================================================================
+
+/**
+ * Delete prospect ledger rows older than 210 days and prune orphaned summaries.
+ * Gated behind a 1-hour in-process cooldown.
+ * Returns the number of ledger rows deleted.
+ */
+export function cleanStaleProspects(): number {
+  const now = Date.now();
+  if (now - lastCleanupAt < CLEANUP_COOLDOWN_MS) return 0;
+  lastCleanupAt = now;
+
+  const stateDb = getStateDb();
+  if (!stateDb) return 0;
+
+  try {
+    const cutoff = now - STALE_AGE_MS;
+
+    const result = stateDb.db.prepare(
+      'DELETE FROM prospect_ledger WHERE last_seen_at < ?'
+    ).run(cutoff);
+
+    // Prune orphaned summaries
+    stateDb.db.prepare(`
+      DELETE FROM prospect_summary
+      WHERE term NOT IN (SELECT DISTINCT term FROM prospect_ledger)
+    `).run();
+
+    return result.changes;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Reset the cleanup cooldown (for testing).
+ */
+export function resetCleanupCooldown(): void {
+  lastCleanupAt = 0;
+}

--- a/packages/mcp-server/src/core/shared/types.ts
+++ b/packages/mcp-server/src/core/shared/types.ts
@@ -191,6 +191,7 @@ export interface SuggestionConfig {
  * - 10: feedback (historical accuracy adjustment)
  * - 11: semantic (embedding similarity)
  * - 12: edge_weight (high-quality incoming link boost)
+ * - 14: prospect_boost (accumulated pre-entity evidence from prospect ledger)
  *
  * `fatigue` is included in this union so it can be disabled via `disabledLayers`
  * for ablation testing, but it is a per-file suffix-repetition guard, not a
@@ -204,6 +205,7 @@ export type ScoringLayer =
   | 'recency' | 'cross_folder'
   | 'hub_boost' | 'feedback' | 'semantic'
   | 'edge_weight'
+  | 'prospect_boost'
   | 'fatigue';
 
 export interface SuggestOptions {
@@ -229,6 +231,7 @@ export interface ScoreBreakdown {
   suppressionPenalty?: number; // Layer 0 (soft, proportional to Beta-Binomial posterior)
   semanticBoost?: number;      // Layer 11
   edgeWeightBoost?: number;    // Layer 12
+  prospectBoost?: number;       // Layer 14 (pre-entity prospect evidence)
 }
 
 export type ConfidenceLevel = 'high' | 'medium' | 'low';

--- a/packages/mcp-server/src/core/write/wikilinkFeedback.ts
+++ b/packages/mcp-server/src/core/write/wikilinkFeedback.ts
@@ -1143,6 +1143,8 @@ export interface SuggestionBreakdown {
   hubBoost: number;
   feedbackAdjustment: number;
   semanticBoost?: number;
+  edgeWeightBoost?: number;
+  prospectBoost?: number;
 }
 
 /** Recent suggestion event from suggestion_events table */

--- a/packages/mcp-server/src/core/write/wikilinks.ts
+++ b/packages/mcp-server/src/core/write/wikilinks.ts
@@ -54,6 +54,7 @@ import * as fs from 'fs/promises';
 import type { FlywheelConfig } from '../read/config.js';
 import type { SuggestOptions, SuggestResult, SuggestionConfig, StrictnessMode, NoteContext, ScoreBreakdown, ScoredSuggestion, ConfidenceLevel, ScoringLayer } from './types.js';
 import { stem, tokenize } from '../shared/stemmer.js';
+import { getProspectBoostMap } from '../shared/prospects.js';
 import {
   mineCooccurrences,
   getCooccurrenceBoost,
@@ -1484,6 +1485,9 @@ export async function suggestRelatedLinks(
   // Load edge weight map once (Layer 12)
   const edgeWeightMap = stateDb ? getEntityEdgeWeightMap(stateDb) : new Map<string, number>();
 
+  // Load prospect boost map (Layer 14)
+  const prospectBoosts = disabled.has('prospect_boost') ? new Map<string, number>() : getProspectBoostMap();
+
   // First pass: Score entities and track which ones matched directly
   interface ScoredEntry {
     name: string;
@@ -1578,6 +1582,10 @@ export async function suggestRelatedLinks(
     const layerEdgeWeightBoost = disabled.has('edge_weight') ? 0 : getEdgeWeightBoostScore(entityName, edgeWeightMap);
     score += layerEdgeWeightBoost;
 
+    // Layer 14: Prospect boost — accumulated pre-entity evidence (exact name/alias match only)
+    const layerProspectBoost = disabled.has('prospect_boost') ? 0 : (prospectBoosts.get(entityName.toLowerCase()) ?? 0);
+    score += layerProspectBoost;
+
     // Add to directlyMatchedEntities BEFORE suppression penalty
     // Only lexically-matched entities should seed co-occurrence lookups;
     // entities with only type/hub/recency boosts (no lexical evidence) are noise seeds.
@@ -1612,6 +1620,7 @@ export async function suggestRelatedLinks(
           feedbackAdjustment: layerFeedbackAdj,
           suppressionPenalty: layerSuppressionPenalty,
           edgeWeightBoost: layerEdgeWeightBoost,
+          prospectBoost: layerProspectBoost,
         },
       });
     }
@@ -1714,8 +1723,9 @@ export async function suggestRelatedLinks(
           const crossFolderBoost = hasContentOverlap ? rawCrossFolderBoost : Math.min(rawCrossFolderBoost, 2);
           const feedbackAdj = disabled.has('feedback') ? 0 : (feedbackBoosts.get(entityName) ?? 0);
           const edgeWeightBoost = disabled.has('edge_weight') ? 0 : getEdgeWeightBoostScore(entityName, edgeWeightMap);
+          const prospectBoost = disabled.has('prospect_boost') ? 0 : (prospectBoosts.get(entityName.toLowerCase()) ?? 0);
           const suppPenalty = disabled.has('feedback') ? 0 : (suppressionPenalties.get(entityName) ?? 0);
-          let totalBoost = boost + typeBoost + contextBoost + recencyBoostVal + crossFolderBoost + hubBoost + feedbackAdj + edgeWeightBoost + suppPenalty;
+          let totalBoost = boost + typeBoost + contextBoost + recencyBoostVal + crossFolderBoost + hubBoost + feedbackAdj + edgeWeightBoost + prospectBoost + suppPenalty;
           const coocContentRelevance = hasContentOverlap ? 5 : 0;
           totalBoost = capScoreWithoutContentRelevance(totalBoost, coocContentRelevance, config);
 
@@ -1744,6 +1754,7 @@ export async function suggestRelatedLinks(
                 feedbackAdjustment: feedbackAdj,
                 suppressionPenalty: suppPenalty,
                 edgeWeightBoost,
+                prospectBoost,
               },
             });
           }
@@ -1806,9 +1817,10 @@ export async function suggestRelatedLinks(
           const layerCrossFolderBoost = disabled.has('cross_folder') ? 0 : ((notePath && entity.path) ? getCrossFolderBoost(entity.path, notePath) : 0);
           const layerFeedbackAdj = disabled.has('feedback') ? 0 : (feedbackBoosts.get(match.entityName) ?? 0);
           const layerEdgeWeightBoost = disabled.has('edge_weight') ? 0 : getEdgeWeightBoostScore(match.entityName, edgeWeightMap);
+          const layerProspectBoost = disabled.has('prospect_boost') ? 0 : (prospectBoosts.get(match.entityName.toLowerCase()) ?? 0);
           const layerSuppPenalty = disabled.has('feedback') ? 0 : (suppressionPenalties.get(match.entityName) ?? 0);
 
-          const totalScore = boost + layerTypeBoost + layerContextBoost + layerHubBoost + layerCrossFolderBoost + layerFeedbackAdj + layerEdgeWeightBoost + layerSuppPenalty;
+          const totalScore = boost + layerTypeBoost + layerContextBoost + layerHubBoost + layerCrossFolderBoost + layerFeedbackAdj + layerEdgeWeightBoost + layerProspectBoost + layerSuppPenalty;
 
           if (totalScore >= adaptiveMinScore) {
             scoredEntities.push({
@@ -1830,6 +1842,7 @@ export async function suggestRelatedLinks(
                 suppressionPenalty: layerSuppPenalty,
                 semanticBoost: boost,
                 edgeWeightBoost: layerEdgeWeightBoost,
+                prospectBoost: layerProspectBoost,
               },
             });
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -116,6 +116,7 @@ import { updateSuppressionList } from './core/write/wikilinkFeedback.js';
 
 // Core imports - Recency
 import { setRecencyStateDb } from './core/shared/recency.js';
+import { setProspectStateDb } from './core/shared/prospects.js';
 
 // Core imports - Co-occurrence
 import { loadCooccurrenceFromStateDb } from './core/shared/cooccurrence.js';
@@ -450,6 +451,7 @@ function activateVault(ctx: VaultContext): void {
     setWriteStateDb(ctx.stateDb);
     setFTS5Database(ctx.stateDb.db);
     setRecencyStateDb(ctx.stateDb);
+    setProspectStateDb(ctx.stateDb);
     setTaskCacheDatabase(ctx.stateDb.db);
     setEmbeddingsDatabase(ctx.stateDb.db);
     loadEntityEmbeddingsToMemory();

--- a/packages/mcp-server/src/tools/read/wikilinks.ts
+++ b/packages/mcp-server/src/tools/read/wikilinks.ts
@@ -14,6 +14,7 @@ import { countFTS5Mentions } from '../../core/read/fts5.js';
 import { detectImplicitEntities, COMMON_ENGLISH_WORDS, isCommonWordEntity } from '@velvetmonkey/vault-core';
 import type { StateDb } from '@velvetmonkey/vault-core';
 import { getWeightedEntityStats, computePosteriorMean, PRIOR_ALPHA, PRIOR_BETA, SUPPRESSION_MIN_OBSERVATIONS, SUPPRESSION_POSTERIOR_THRESHOLD, isAiConfigEntity, AI_CONFIG_PRIOR_ALPHA } from '../../core/write/wikilinkFeedback.js';
+import { recordProspectSightings, refreshProspectSummaries, getPromotionCandidates, getProspectSampleNotes, PROMOTION_THRESHOLD, type ProspectSighting } from '../../core/shared/prospects.js';
 
 /**
  * Match entity in text, avoiding existing wikilinks and code blocks
@@ -35,6 +36,12 @@ interface ProspectMatch {
   source: 'dead_link' | 'implicit' | 'both';  // How it was detected
   confidence: 'high' | 'medium' | 'low';      // Confidence level
   backlink_count?: number;  // Number of backlinks (for dead link targets)
+  pattern?: string;         // Implicit pattern type
+  ledger_source?: 'implicit' | 'dead_link' | 'high_score';  // Best historical source
+  ledger_note_count?: number;   // Distinct notes from ledger
+  ledger_day_count?: number;    // Distinct days from ledger
+  effective_score?: number;     // Decay-adjusted promotion score
+  promotion_ready?: boolean;    // effective_score >= promotion threshold
 }
 
 /**
@@ -209,6 +216,12 @@ export function registerWikilinkTools(
     source: z.enum(['dead_link', 'implicit', 'both']).describe('How the prospect was detected'),
     confidence: z.enum(['high', 'medium', 'low']).describe('Confidence level'),
     backlink_count: z.coerce.number().optional().describe('Number of backlinks (for dead link targets)'),
+    pattern: z.string().optional().describe('Implicit pattern type (proper-nouns, camel-case, etc.)'),
+    ledger_source: z.enum(['implicit', 'dead_link', 'high_score']).optional().describe('Best historical source from the prospect ledger'),
+    ledger_note_count: z.coerce.number().optional().describe('Distinct notes from prospect ledger'),
+    ledger_day_count: z.coerce.number().optional().describe('Distinct days from prospect ledger'),
+    effective_score: z.coerce.number().optional().describe('Decay-adjusted promotion score'),
+    promotion_ready: z.boolean().optional().describe('True when effective_score >= promotion threshold'),
   });
 
   const ScoreBreakdownSchema = z.object({
@@ -225,6 +238,7 @@ export function registerWikilinkTools(
     suppressionPenalty: z.coerce.number().optional(),
     semanticBoost: z.coerce.number().optional(),
     edgeWeightBoost: z.coerce.number().optional(),
+    prospectBoost: z.coerce.number().optional(),
   });
 
   const ScoredSuggestionSchema = z.object({
@@ -269,13 +283,14 @@ export function registerWikilinkTools(
         'Analyze text and suggest where wikilinks could be added. Finds mentions of existing note titles and aliases.',
       inputSchema: {
         text: z.string().describe('The text to analyze for potential wikilinks'),
+        note_path: z.string().optional().describe('Vault-relative note path. When provided, prospect sightings are persisted to the ledger'),
         limit: z.coerce.number().default(50).describe('Maximum number of suggestions to return'),
         offset: z.coerce.number().default(0).describe('Number of suggestions to skip (for pagination)'),
         detail: z.boolean().default(false).describe('Include per-layer score breakdown for each suggestion'),
       },
       outputSchema: SuggestWikilinksOutputSchema,
     },
-    async ({ text, limit: requestedLimit, offset, detail }): Promise<{
+    async ({ text, note_path, limit: requestedLimit, offset, detail }): Promise<{
       content: Array<{ type: 'text'; text: string }>;
       structuredContent: SuggestWikilinksOutput;
     }> => {
@@ -366,6 +381,42 @@ export function registerWikilinkTools(
           source: 'implicit',
           confidence: 'low',
         });
+      }
+
+      // Persist prospect sightings to ledger when note_path is provided
+      if (note_path && prospects.length > 0) {
+        const sightings: ProspectSighting[] = prospects.map(p => ({
+          term: p.entity.toLowerCase(),
+          displayName: p.entity,
+          notePath: note_path,
+          source: p.source === 'both' ? 'dead_link' as const : (p.source === 'dead_link' ? 'dead_link' as const : 'implicit' as const),
+          confidence: p.confidence,
+          backlinkCount: p.backlink_count,
+        }));
+        recordProspectSightings(sightings);
+        const affectedTerms = [...new Set(sightings.map(s => s.term))];
+        refreshProspectSummaries(affectedTerms);
+      }
+
+      // Enrich prospects with ledger data when available
+      const stateDb = getStateDb();
+      if (stateDb && prospects.length > 0) {
+        try {
+          for (const prospect of prospects) {
+            const row = stateDb.db.prepare(
+              'SELECT note_count, day_count, best_source, best_score, promotion_score, last_seen_at FROM prospect_summary WHERE term = ?'
+            ).get(prospect.entity.toLowerCase()) as { note_count: number; day_count: number; best_source: string; best_score: number; promotion_score: number; last_seen_at: number } | undefined;
+            if (row) {
+              prospect.ledger_source = row.best_source as 'implicit' | 'dead_link' | 'high_score';
+              prospect.ledger_note_count = row.note_count;
+              prospect.ledger_day_count = row.day_count;
+              const decay = Math.exp(-(Math.LN2 / 60) * (Date.now() - row.last_seen_at) / (24 * 60 * 60 * 1000));
+              const effective = Math.round(row.promotion_score * decay * 10) / 10;
+              prospect.effective_score = effective;
+              prospect.promotion_ready = effective >= PROMOTION_THRESHOLD;
+            }
+          }
+        } catch { /* ledger enrichment unavailable */ }
       }
 
       const output: SuggestWikilinksOutput = {
@@ -651,7 +702,31 @@ export function registerWikilinkTools(
       const limit = Math.min(requestedLimit ?? 20, 100);
       const minFreq = min_frequency ?? 5;
 
-      // Collect all dead link targets with their sources
+      // Try prospect ledger first (richer data from accumulated sightings)
+      const prospectCandidates = getPromotionCandidates(limit * 2);
+      if (prospectCandidates.length > 0) {
+        const filtered = prospectCandidates
+          .filter(c => c.backlinkMax >= minFreq)
+          .slice(0, limit)
+          .map(c => ({
+            term: c.displayName,
+            wikilink_references: c.backlinkMax,
+            content_mentions: countFTS5Mentions(c.term),
+            sample_notes: getProspectSampleNotes(c.term, 3),
+            effective_score: c.effectiveScore,
+            promotion_ready: c.promotionReady,
+          }));
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify({
+            total_dead_targets: prospectCandidates.length,
+            candidates_above_threshold: filtered.length,
+            candidates: filtered,
+          }, null, 2) }],
+        };
+      }
+
+      // Fallback: compute from vault index (no prospect ledger data available)
       const targetMap = new Map<string, { count: number; sources: Set<string> }>();
       for (const note of index.notes.values()) {
         for (const link of note.outlinks) {
@@ -668,29 +743,23 @@ export function registerWikilinkTools(
         }
       }
 
-      // Also check FTS5 for additional plain-text mentions of each dead target
       const candidates = Array.from(targetMap.entries())
         .filter(([, data]) => data.count >= minFreq)
-        .map(([target, data]) => {
-          const fts5Mentions = countFTS5Mentions(target);
-          return {
-            term: target,
-            wikilink_references: data.count,
-            content_mentions: fts5Mentions,
-            sample_notes: Array.from(data.sources),
-          };
-        })
+        .map(([target, data]) => ({
+          term: target,
+          wikilink_references: data.count,
+          content_mentions: countFTS5Mentions(target),
+          sample_notes: Array.from(data.sources),
+        }))
         .sort((a, b) => b.wikilink_references - a.wikilink_references)
         .slice(0, limit);
 
-      const output = {
-        total_dead_targets: targetMap.size,
-        candidates_above_threshold: candidates.length,
-        candidates,
-      };
-
       return {
-        content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+        content: [{ type: 'text', text: JSON.stringify({
+          total_dead_targets: targetMap.size,
+          candidates_above_threshold: candidates.length,
+          candidates,
+        }, null, 2) }],
       };
     }
   );

--- a/packages/mcp-server/test/shared/prospects.test.ts
+++ b/packages/mcp-server/test/shared/prospects.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Tests for Prospect Ledger — Persistent Pre-Entity Memory
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { openStateDb, FLYWHEEL_DIR, SCHEMA_VERSION } from '@velvetmonkey/vault-core';
+import type { StateDb } from '@velvetmonkey/vault-core';
+import {
+  setProspectStateDb,
+  recordProspectSightings,
+  refreshProspectSummaries,
+  computePromotionScore,
+  computeProspectDecay,
+  getProspectBoostMap,
+  getPromotionCandidates,
+  getProspectSampleNotes,
+  cleanStaleProspects,
+  resetCleanupCooldown,
+  PROSPECT_DECAY_HALF_LIFE_DAYS,
+  PROMOTION_THRESHOLD,
+  type ProspectSighting,
+} from '../../src/core/shared/prospects.js';
+
+describe('Prospect Ledger', () => {
+  let testVaultPath: string;
+  let stateDb: StateDb;
+
+  beforeEach(() => {
+    testVaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'prospect-test-'));
+    stateDb = openStateDb(testVaultPath);
+    setProspectStateDb(stateDb);
+    resetCleanupCooldown();
+  });
+
+  afterEach(() => {
+    try { stateDb.db.close(); } catch { /* ignore */ }
+    fs.rmSync(testVaultPath, { recursive: true, force: true });
+    setProspectStateDb(null);
+  });
+
+  // ===========================================================================
+  // Schema / Migration
+  // ===========================================================================
+
+  describe('schema', () => {
+    it('creates prospect_ledger and prospect_summary tables at v37', () => {
+      const version = stateDb.db.prepare(
+        'SELECT MAX(version) as v FROM schema_version'
+      ).get() as { v: number };
+      expect(version.v).toBe(SCHEMA_VERSION);
+
+      const tables = stateDb.db.prepare(`
+        SELECT name FROM sqlite_master WHERE type='table'
+        AND name IN ('prospect_ledger', 'prospect_summary')
+        ORDER BY name
+      `).all() as Array<{ name: string }>;
+      expect(tables.map(t => t.name)).toEqual(['prospect_ledger', 'prospect_summary']);
+    });
+
+    it('prospect_ledger has correct PK (term, note_path, seen_day)', () => {
+      // Insert two rows with same term+note but different day
+      stateDb.db.exec(`
+        INSERT INTO prospect_ledger (term, display_name, note_path, seen_day, source, confidence, first_seen_at, last_seen_at)
+        VALUES ('test', 'Test', 'a.md', '2026-03-01', 'implicit', 'low', 1, 1);
+      `);
+      stateDb.db.exec(`
+        INSERT INTO prospect_ledger (term, display_name, note_path, seen_day, source, confidence, first_seen_at, last_seen_at)
+        VALUES ('test', 'Test', 'a.md', '2026-03-02', 'implicit', 'low', 1, 1);
+      `);
+      const count = stateDb.db.prepare(
+        'SELECT COUNT(*) as cnt FROM prospect_ledger WHERE term = ?'
+      ).get('test') as { cnt: number };
+      expect(count.cnt).toBe(2);
+    });
+  });
+
+  // ===========================================================================
+  // Decay
+  // ===========================================================================
+
+  describe('decay', () => {
+    it('returns 1.0 for just-seen prospects', () => {
+      expect(computeProspectDecay(Date.now())).toBeCloseTo(1.0, 2);
+    });
+
+    it('returns ~0.5 at 60 days (half-life)', () => {
+      const sixtyDaysAgo = Date.now() - 60 * 24 * 60 * 60 * 1000;
+      expect(computeProspectDecay(sixtyDaysAgo)).toBeCloseTo(0.5, 2);
+    });
+
+    it('returns ~0.25 at 120 days (two half-lives)', () => {
+      const hundredTwentyDaysAgo = Date.now() - 120 * 24 * 60 * 60 * 1000;
+      expect(computeProspectDecay(hundredTwentyDaysAgo)).toBeCloseTo(0.25, 2);
+    });
+
+    it('returns near-zero at 210+ days', () => {
+      const twoTenDaysAgo = Date.now() - 210 * 24 * 60 * 60 * 1000;
+      expect(computeProspectDecay(twoTenDaysAgo)).toBeLessThan(0.1);
+    });
+  });
+
+  // ===========================================================================
+  // Promotion Score
+  // ===========================================================================
+
+  describe('promotion score', () => {
+    it('computes correctly with known inputs', () => {
+      const score = computePromotionScore({
+        noteCount: 5,
+        dayCount: 4,
+        backlinkMax: 3,
+        cooccurringCount: 2,
+        bestScore: 0,
+        bestSource: 'implicit',
+      });
+      // (5*3 + 4*2 + 3*2 + 2*1 + 0*0.5) * 1.0 = (15+8+6+2+0) * 1.0 = 31
+      expect(score).toBe(31);
+    });
+
+    it('applies source multiplier for dead_link', () => {
+      const score = computePromotionScore({
+        noteCount: 5,
+        dayCount: 4,
+        backlinkMax: 3,
+        cooccurringCount: 2,
+        bestScore: 0,
+        bestSource: 'dead_link',
+      });
+      // 31 * 1.2 = 37.2
+      expect(score).toBe(37.2);
+    });
+
+    it('applies source multiplier for high_score', () => {
+      const score = computePromotionScore({
+        noteCount: 5,
+        dayCount: 4,
+        backlinkMax: 3,
+        cooccurringCount: 2,
+        bestScore: 5,
+        bestSource: 'high_score',
+      });
+      // (15+8+6+2+2.5) * 1.3 = 33.5 * 1.3 = 43.55
+      expect(score).toBe(43.6); // rounded to 1 decimal
+    });
+
+    it('caps each component at 10', () => {
+      const score = computePromotionScore({
+        noteCount: 100,  // capped at 10
+        dayCount: 100,   // capped at 10
+        backlinkMax: 100, // capped at 10
+        cooccurringCount: 100, // capped at 10
+        bestScore: 100,  // capped at 10
+        bestSource: 'implicit',
+      });
+      // (10*3 + 10*2 + 10*2 + 10*1 + 10*0.5) * 1.0 = 85
+      expect(score).toBe(85);
+    });
+  });
+
+  // ===========================================================================
+  // Recording Sightings
+  // ===========================================================================
+
+  describe('recordProspectSightings', () => {
+    it('inserts new sightings', () => {
+      recordProspectSightings([
+        { term: 'global equities api', displayName: 'Global Equities API', notePath: 'notes/a.md', source: 'implicit', confidence: 'low' },
+        { term: 'marcus johnson', displayName: 'Marcus Johnson', notePath: 'notes/b.md', source: 'dead_link', confidence: 'medium', backlinkCount: 3 },
+      ]);
+
+      const count = stateDb.db.prepare('SELECT COUNT(*) as cnt FROM prospect_ledger').get() as { cnt: number };
+      expect(count.cnt).toBe(2);
+    });
+
+    it('upserts same term+note+day: increments sighting_count', () => {
+      recordProspectSightings([
+        { term: 'test term', displayName: 'Test Term', notePath: 'a.md', source: 'implicit', confidence: 'low' },
+      ]);
+      recordProspectSightings([
+        { term: 'test term', displayName: 'Test Term', notePath: 'a.md', source: 'implicit', confidence: 'low' },
+      ]);
+
+      const row = stateDb.db.prepare(
+        'SELECT sighting_count FROM prospect_ledger WHERE term = ?'
+      ).get('test term') as { sighting_count: number };
+      expect(row.sighting_count).toBe(2);
+    });
+
+    it('keeps earliest display_name on upsert', () => {
+      recordProspectSightings([
+        { term: 'test', displayName: 'First Name', notePath: 'a.md', source: 'implicit', confidence: 'low' },
+      ]);
+      recordProspectSightings([
+        { term: 'test', displayName: 'Second Name', notePath: 'a.md', source: 'implicit', confidence: 'low' },
+      ]);
+
+      const row = stateDb.db.prepare(
+        'SELECT display_name FROM prospect_ledger WHERE term = ?'
+      ).get('test') as { display_name: string };
+      expect(row.display_name).toBe('First Name');
+    });
+
+    it('upgrades source by precedence (high_score > dead_link > implicit)', () => {
+      recordProspectSightings([
+        { term: 'test', displayName: 'Test', notePath: 'a.md', source: 'implicit', confidence: 'low' },
+      ]);
+      recordProspectSightings([
+        { term: 'test', displayName: 'Test', notePath: 'a.md', source: 'dead_link', confidence: 'medium' },
+      ]);
+
+      const row = stateDb.db.prepare(
+        'SELECT source, confidence FROM prospect_ledger WHERE term = ?'
+      ).get('test') as { source: string; confidence: string };
+      expect(row.source).toBe('dead_link');
+      expect(row.confidence).toBe('medium');
+    });
+
+    it('takes MAX of backlink_count and score', () => {
+      recordProspectSightings([
+        { term: 'test', displayName: 'Test', notePath: 'a.md', source: 'dead_link', confidence: 'medium', backlinkCount: 2, score: 1 },
+      ]);
+      recordProspectSightings([
+        { term: 'test', displayName: 'Test', notePath: 'a.md', source: 'dead_link', confidence: 'medium', backlinkCount: 5, score: 3 },
+      ]);
+
+      const row = stateDb.db.prepare(
+        'SELECT backlink_count, score FROM prospect_ledger WHERE term = ?'
+      ).get('test') as { backlink_count: number; score: number };
+      expect(row.backlink_count).toBe(5);
+      expect(row.score).toBe(3);
+    });
+
+    it('creates separate rows for different note_paths', () => {
+      recordProspectSightings([
+        { term: 'test', displayName: 'Test', notePath: 'a.md', source: 'implicit', confidence: 'low' },
+        { term: 'test', displayName: 'Test', notePath: 'b.md', source: 'implicit', confidence: 'low' },
+      ]);
+
+      const count = stateDb.db.prepare(
+        'SELECT COUNT(*) as cnt FROM prospect_ledger WHERE term = ?'
+      ).get('test') as { cnt: number };
+      expect(count.cnt).toBe(2);
+    });
+  });
+
+  // ===========================================================================
+  // Summary Refresh
+  // ===========================================================================
+
+  describe('refreshProspectSummaries', () => {
+    it('aggregates note_count and day_count correctly', () => {
+      // Insert raw day-grain rows directly for controlled test
+      const now = Date.now();
+      stateDb.db.exec(`
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'a.md', '2026-03-01', 'implicit', NULL, 'low', 0, 0, ${now}, ${now}, 1);
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'a.md', '2026-03-02', 'implicit', NULL, 'low', 0, 0, ${now}, ${now}, 1);
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'b.md', '2026-03-01', 'implicit', NULL, 'low', 0, 0, ${now}, ${now}, 1);
+      `);
+
+      refreshProspectSummaries(['test']);
+
+      const summary = stateDb.db.prepare(
+        'SELECT note_count, day_count, total_sightings FROM prospect_summary WHERE term = ?'
+      ).get('test') as { note_count: number; day_count: number; total_sightings: number };
+
+      expect(summary.note_count).toBe(2);  // a.md, b.md
+      expect(summary.day_count).toBe(3);   // 3 day-grain rows
+      expect(summary.total_sightings).toBe(3);
+    });
+
+    it('computes backlink_max as MAX across rows', () => {
+      const now = Date.now();
+      stateDb.db.exec(`
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'a.md', '2026-03-01', 'dead_link', NULL, 'medium', 2, 0, ${now}, ${now}, 1);
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'b.md', '2026-03-01', 'dead_link', NULL, 'high', 5, 0, ${now}, ${now}, 1);
+      `);
+
+      refreshProspectSummaries(['test']);
+
+      const summary = stateDb.db.prepare(
+        'SELECT backlink_max, best_source, best_confidence FROM prospect_summary WHERE term = ?'
+      ).get('test') as { backlink_max: number; best_source: string; best_confidence: string };
+
+      expect(summary.backlink_max).toBe(5);
+      expect(summary.best_source).toBe('dead_link');
+      expect(summary.best_confidence).toBe('high');
+    });
+
+    it('computes promotion_score from formula', () => {
+      const now = Date.now();
+      // 3 notes, 3 days, backlink_max=3
+      stateDb.db.exec(`
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'a.md', '2026-03-01', 'dead_link', NULL, 'medium', 3, 0, ${now}, ${now}, 1);
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'b.md', '2026-03-02', 'dead_link', NULL, 'medium', 2, 0, ${now}, ${now}, 1);
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'c.md', '2026-03-03', 'dead_link', NULL, 'medium', 1, 0, ${now}, ${now}, 1);
+      `);
+
+      refreshProspectSummaries(['test']);
+
+      const summary = stateDb.db.prepare(
+        'SELECT promotion_score FROM prospect_summary WHERE term = ?'
+      ).get('test') as { promotion_score: number };
+
+      // (3*3 + 3*2 + 3*2 + 0*1 + 0*0.5) * 1.2 = (9+6+6) * 1.2 = 25.2
+      expect(summary.promotion_score).toBe(25.2);
+    });
+  });
+
+  // ===========================================================================
+  // Boost Map
+  // ===========================================================================
+
+  describe('getProspectBoostMap', () => {
+    it('returns empty map when no summaries exist', () => {
+      const map = getProspectBoostMap();
+      expect(map.size).toBe(0);
+    });
+
+    it('scales effective score to [0, 6] range', () => {
+      const now = Date.now();
+      // Create a high-scoring prospect
+      stateDb.db.exec(`
+        INSERT INTO prospect_summary
+          (term, display_name, note_count, day_count, total_sightings, backlink_max, best_source, best_confidence, best_score, first_seen_at, last_seen_at, promotion_score, updated_at)
+        VALUES
+          ('test', 'Test', 10, 10, 50, 5, 'dead_link', 'high', 0, ${now}, ${now}, 60, ${now})
+      `);
+
+      const map = getProspectBoostMap();
+      // effective = 60 * ~1.0 (just seen) = 60, boost = min(6, 60/10) = 6
+      expect(map.get('test')).toBe(6);
+    });
+
+    it('filters out low effective scores', () => {
+      const longAgo = Date.now() - 180 * 24 * 60 * 60 * 1000;
+      stateDb.db.exec(`
+        INSERT INTO prospect_summary
+          (term, display_name, note_count, day_count, total_sightings, backlink_max, best_source, best_confidence, best_score, first_seen_at, last_seen_at, promotion_score, updated_at)
+        VALUES
+          ('stale', 'Stale', 2, 1, 2, 1, 'implicit', 'low', 0, ${longAgo}, ${longAgo}, 10, ${longAgo})
+      `);
+
+      const map = getProspectBoostMap();
+      expect(map.has('stale')).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Promotion Candidates
+  // ===========================================================================
+
+  describe('getPromotionCandidates', () => {
+    it('returns candidates sorted by effective score', () => {
+      const now = Date.now();
+      stateDb.db.exec(`
+        INSERT INTO prospect_summary VALUES ('low', 'Low', 2, 2, 2, 1, NULL, 'implicit', 'low', 0, ${now}, ${now}, 10, NULL, ${now});
+        INSERT INTO prospect_summary VALUES ('high', 'High', 8, 6, 20, 5, NULL, 'dead_link', 'high', 0, ${now}, ${now}, 60, NULL, ${now});
+      `);
+
+      const candidates = getPromotionCandidates(10);
+      expect(candidates.length).toBe(2);
+      expect(candidates[0].term).toBe('high');
+      expect(candidates[0].promotionReady).toBe(true);
+      expect(candidates[1].term).toBe('low');
+      expect(candidates[1].promotionReady).toBe(false);
+    });
+
+    it('excludes terms that exist as entities', () => {
+      const now = Date.now();
+      // Insert an entity
+      stateDb.db.exec(`
+        INSERT INTO entities (name, name_lower, path, category) VALUES ('Test Entity', 'test entity', 'test-entity.md', 'general');
+      `);
+      // Insert a prospect matching that entity
+      stateDb.db.exec(`
+        INSERT INTO prospect_summary VALUES ('test entity', 'Test Entity', 5, 5, 10, 3, NULL, 'dead_link', 'high', 0, ${now}, ${now}, 50, NULL, ${now});
+      `);
+
+      const candidates = getPromotionCandidates(10);
+      expect(candidates.length).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Sample Notes
+  // ===========================================================================
+
+  describe('getProspectSampleNotes', () => {
+    it('returns up to 3 distinct note paths', () => {
+      const now = Date.now();
+      stateDb.db.exec(`
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'a.md', '2026-03-01', 'implicit', NULL, 'low', 0, 0, ${now}, ${now}, 1);
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'b.md', '2026-03-01', 'implicit', NULL, 'low', 0, 0, ${now}, ${now}, 1);
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'c.md', '2026-03-01', 'implicit', NULL, 'low', 0, 0, ${now}, ${now}, 1);
+        INSERT INTO prospect_ledger VALUES ('test', 'Test', 'd.md', '2026-03-01', 'implicit', NULL, 'low', 0, 0, ${now}, ${now}, 1);
+      `);
+
+      const notes = getProspectSampleNotes('test', 3);
+      expect(notes.length).toBe(3);
+    });
+  });
+
+  // ===========================================================================
+  // Stale Cleanup
+  // ===========================================================================
+
+  describe('cleanStaleProspects', () => {
+    it('deletes rows older than 210 days', () => {
+      const now = Date.now();
+      const old = now - 220 * 24 * 60 * 60 * 1000;
+      stateDb.db.exec(`
+        INSERT INTO prospect_ledger VALUES ('fresh', 'Fresh', 'a.md', '2026-03-01', 'implicit', NULL, 'low', 0, 0, ${now}, ${now}, 1);
+        INSERT INTO prospect_ledger VALUES ('stale', 'Stale', 'b.md', '2025-08-01', 'implicit', NULL, 'low', 0, 0, ${old}, ${old}, 1);
+      `);
+      // Also add summary for stale
+      stateDb.db.exec(`
+        INSERT INTO prospect_summary VALUES ('stale', 'Stale', 1, 1, 1, 0, NULL, 'implicit', 'low', 0, ${old}, ${old}, 5, NULL, ${old});
+      `);
+
+      const deleted = cleanStaleProspects();
+      expect(deleted).toBe(1);
+
+      // Fresh row should remain
+      const count = stateDb.db.prepare('SELECT COUNT(*) as cnt FROM prospect_ledger').get() as { cnt: number };
+      expect(count.cnt).toBe(1);
+
+      // Orphaned summary should be pruned
+      const summaryCount = stateDb.db.prepare('SELECT COUNT(*) as cnt FROM prospect_summary').get() as { cnt: number };
+      expect(summaryCount.cnt).toBe(0);
+    });
+
+    it('respects cooldown (1 hour)', () => {
+      const now = Date.now();
+      const old = now - 220 * 24 * 60 * 60 * 1000;
+      stateDb.db.exec(`
+        INSERT INTO prospect_ledger VALUES ('stale', 'Stale', 'a.md', '2025-08-01', 'implicit', NULL, 'low', 0, 0, ${old}, ${old}, 1);
+      `);
+
+      // First call should work
+      const first = cleanStaleProspects();
+      expect(first).toBe(1);
+
+      // Add another stale row
+      stateDb.db.exec(`
+        INSERT INTO prospect_ledger VALUES ('stale2', 'Stale2', 'b.md', '2025-08-01', 'implicit', NULL, 'low', 0, 0, ${old}, ${old}, 1);
+      `);
+
+      // Second call within cooldown should skip
+      const second = cleanStaleProspects();
+      expect(second).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a persistent prospect ledger (prospect_ledger + prospect_summary tables, schema v37) so pre-entity patterns accumulate evidence across sessions instead of being rediscovered each run
- Three detection source classes (implicit, dead_link, high_score) feed day-grain sightings from the watcher pipeline and suggest_wikilinks
- Promotion scoring formula with 60-day half-life decay drives both Layer 14 wikilink suggestion boosting and stub-candidate surfacing
- suggest_wikilinks gains note_path param — persists sightings when provided, enriches prospect output with ledger metadata
- discover_stub_candidates ranks from prospect ledger when available (fallback to vault index)

## Test plan

- [x] npm run build — clean compile
- [x] 27 new prospect tests pass
- [x] Backup test updated and passing for 12 SALVAGE_TABLES
- [x] Full test suite: 3049 existing tests pass

Generated with [Claude Code](https://claude.com/claude-code)