### PR TITLE
chore: scrub hardcoded names from test fixtures

### DIFF
--- a/packages/core/src/wikilinks.ts
+++ b/packages/core/src/wikilinks.ts
@@ -293,13 +293,13 @@ function escapeRegex(str: string): string {
  * Check if an entity should be excluded from wikilikning
  */
 function shouldExcludeEntity(entity: string, isAlias = false): boolean {
-  // Skip single-char terms (e.g. alias "I" for Ben)
+  // Skip single-char terms (e.g. alias "I" for Max)
   if (entity.length < 2) return true;
   if (getMergedExcludeWords().has(entity.toLowerCase())) return true;
   // Skip lowercase hyphenated descriptors (e.g., self-improving, local-first, Claude-native)
   if (entity.includes('-') && entity === entity.toLowerCase()) return true;
   // Short aliases (≤3 chars) must be ALL-UPPERCASE to survive (e.g., "CI", "ML" ok, "api", "tF" blocked)
-  // Entity names like "Ben" (3 chars, mixed case) are unaffected since isAlias=false for names.
+  // Entity names like "Max" (3 chars, mixed case) are unaffected since isAlias=false for names.
   if (isAlias && entity.length <= 3 && entity !== entity.toUpperCase()) return true;
   return false;
 }

--- a/packages/core/test/wikilinks.test.ts
+++ b/packages/core/test/wikilinks.test.ts
@@ -1302,8 +1302,8 @@ Machine Learning is great outside the comment`;
 
 describe('noise reduction', () => {
   describe('T1: minimum alias length guard', () => {
-    it('should not match single-char aliases like "I" for Ben', () => {
-      const result = applyWikilinks('I went to the store', [{ name: 'Ben', aliases: ['I'] }]);
+    it('should not match single-char aliases like "I" for Max', () => {
+      const result = applyWikilinks('I went to the store', [{ name: 'Max', aliases: ['I'] }]);
       expect(result.content).toBe('I went to the store');
       expect(result.linksAdded).toBe(0);
     });
@@ -1311,7 +1311,7 @@ describe('noise reduction', () => {
     it('should not match two-char common-word aliases like "us" and "me"', () => {
       const result = applyWikilinks('Tell us about me', [
         { name: 'USA', aliases: ['us'] },
-        { name: 'Ben', aliases: ['me'] },
+        { name: 'Max', aliases: ['me'] },
       ]);
       expect(result.content).toBe('Tell us about me');
       expect(result.linksAdded).toBe(0);
@@ -1438,21 +1438,21 @@ describe('noise reduction', () => {
 
   describe('T4: sentence starter trimming', () => {
     it('should trim "So" from proper noun matches', () => {
-      const result = detectImplicitEntities('So Fartimus Venturi is here');
+      const result = detectImplicitEntities('So Nadia Kovalenko is here');
       const names = result.map(m => m.text);
-      expect(names).not.toContain('So Fartimus Venturi');
+      expect(names).not.toContain('So Nadia Kovalenko');
     });
 
     it('should trim "Hello" from proper noun matches', () => {
-      const result = detectImplicitEntities('Hello Ben Smith arrived');
+      const result = detectImplicitEntities('Hello Max Torres arrived');
       const names = result.map(m => m.text);
-      expect(names).not.toContain('Hello Ben Smith');
+      expect(names).not.toContain('Hello Max Torres');
     });
 
     it('should trim "Mr" from proper noun matches', () => {
-      const result = detectImplicitEntities('Mr Ben Cassie signed');
+      const result = detectImplicitEntities('Mr Max Torres signed');
       const names = result.map(m => m.text);
-      expect(names).not.toContain('Mr Ben Cassie');
+      expect(names).not.toContain('Mr Max Torres');
     });
 
     it('should trim "How" and keep multi-word remainder', () => {

--- a/packages/mcp-server/test/shared/entityRarity.test.ts
+++ b/packages/mcp-server/test/shared/entityRarity.test.ts
@@ -40,8 +40,8 @@ describe('entityRarity', () => {
 
   it('returns high multiplier (~1.8) for very rare entities', () => {
     // Entity appears in only 1 out of 1000 notes
-    const index = makeCoocIndex(new Map([['Fartimus', 1]]), 1000);
-    const rarity = entityRarity('Fartimus', index);
+    const index = makeCoocIndex(new Map([['Zorbatix', 1]]), 1000);
+    const rarity = entityRarity('Zorbatix', index);
     expect(rarity).toBeGreaterThan(1.5);
     expect(rarity).toBeLessThanOrEqual(1.8);
   });
@@ -64,8 +64,8 @@ describe('entityRarity', () => {
   });
 
   it('rare entity scores higher than common entity', () => {
-    const df = new Map([['API', 200], ['Fartimus', 3]]);
+    const df = new Map([['API', 200], ['Zorbatix', 3]]);
     const index = makeCoocIndex(df, 1000);
-    expect(entityRarity('Fartimus', index)).toBeGreaterThan(entityRarity('API', index));
+    expect(entityRarity('Zorbatix', index)).toBeGreaterThan(entityRarity('API', index));
   });
 });

--- a/packages/mcp-server/test/shared/levenshtein.test.ts
+++ b/packages/mcp-server/test/shared/levenshtein.test.ts
@@ -49,15 +49,15 @@ describe('fuzzySimilarity', () => {
   });
 
   it('returns correct similarity for close strings', () => {
-    // fartimus vs fartmus: distance=1, maxLen=8 → 1 - 1/8 = 0.875
-    const sim = fuzzySimilarity('fartimus', 'fartmus');
+    // zorbatix vs zorbatx: distance=1, maxLen=8 → 1 - 1/8 = 0.875
+    const sim = fuzzySimilarity('zorbatix', 'zorbatx');
     expect(sim).toBeCloseTo(0.875, 2);
   });
 });
 
 describe('fuzzyMatchScore', () => {
   it('returns similarity when above threshold', () => {
-    const score = fuzzyMatchScore('fartimus', 'fartmus', 0.80);
+    const score = fuzzyMatchScore('zorbatix', 'zorbatx', 0.80);
     expect(score).toBeCloseTo(0.875, 2);
   });
 
@@ -74,8 +74,8 @@ describe('fuzzyMatchScore', () => {
 
 describe('bestFuzzyMatch', () => {
   it('finds best match above threshold from candidates', () => {
-    const candidates = new Set(['fartmus', 'hello', 'world', 'fartimus']);
-    const best = bestFuzzyMatch('fartimus', candidates, 0.80);
+    const candidates = new Set(['zorbatx', 'hello', 'world', 'zorbatix']);
+    const best = bestFuzzyMatch('zorbatix', candidates, 0.80);
     expect(best).toBe(1); // exact match in candidates
   });
 
@@ -91,7 +91,7 @@ describe('bestFuzzyMatch', () => {
 
   it('returns 0 when no candidates match', () => {
     const candidates = new Set(['completely', 'different', 'words']);
-    expect(bestFuzzyMatch('fartimus', candidates, 0.80)).toBe(0);
+    expect(bestFuzzyMatch('zorbatix', candidates, 0.80)).toBe(0);
   });
 });
 
@@ -139,7 +139,7 @@ describe('scoreFuzzyMatch', () => {
   it('matches token-level typos for unmatched tokens', () => {
     const cache2 = new Map<string, number>();
     const result = scoreFuzzyMatch(
-      ['fartimus'], [0], new Set(['fartmus', 'hello', 'world']), new Set(), 'Fartimus', 4, idfFn, cache2,
+      ['zorbatix'], [0], new Set(['zorbatx', 'hello', 'world']), new Set(), 'Zorbatix', 4, idfFn, cache2,
     );
     expect(result.fuzzyScore).toBeGreaterThan(0);
     expect(result.fuzzyMatchedWords).toBe(1);
@@ -160,13 +160,13 @@ describe('scoreFuzzyMatch', () => {
 
   it('uses cache for repeated token lookups', () => {
     const cache2 = new Map<string, number>();
-    const contentTokens = new Set(['fartmus', 'hello']);
+    const contentTokens = new Set(['zorbatx', 'hello']);
 
-    scoreFuzzyMatch(['fartimus'], [0], contentTokens, new Set(), 'Fartimus', 4, idfFn, cache2);
-    expect(cache2.has('fartimus')).toBe(true);
+    scoreFuzzyMatch(['zorbatix'], [0], contentTokens, new Set(), 'Zorbatix', 4, idfFn, cache2);
+    expect(cache2.has('zorbatix')).toBe(true);
 
     // Second call should use cache
-    const result2 = scoreFuzzyMatch(['fartimus'], [0], contentTokens, new Set(), 'Fartimus', 4, idfFn, cache2);
+    const result2 = scoreFuzzyMatch(['zorbatix'], [0], contentTokens, new Set(), 'Zorbatix', 4, idfFn, cache2);
     expect(result2.fuzzyScore).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- Replace personal-sounding test data with generic alternatives across 4 files
- All 178 affected tests pass

## Test plan
- [x] vitest run on all 3 affected test suites (178 tests pass)