### PR TITLE
docs: T29 — repo truth pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Flywheel Memory - Claude Code Instructions
 
-**[[Flywheel]] Memory** — MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits. 75 [[TOOLS]] across 12 categories for search, graph analysis, schema intelligence, tasks, frontmatter, note mutations, temporal analysis, and memory — all local, all markdown. Hybrid search (BM25 + semantic via Reciprocal Rank Fusion) is available when embeddings are built via `init_semantic`.
+**[[Flywheel]] Memory** — MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits. 77 [[TOOLS]] across 12 categories for search, graph analysis, schema intelligence, tasks, frontmatter, note mutations, temporal analysis, and memory — all local, all markdown. Hybrid search (BM25 + semantic via Reciprocal Rank Fusion) is available when embeddings are built via `init_semantic`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ npm test
 ```
 packages/
   core/         # @velvetmonkey/vault-core -- shared utilities (entity scanning, wikilinks, SQLite)
-  mcp-server/   # @velvetmonkey/flywheel-memory -- the MCP server (75 tools)
+  mcp-server/   # @velvetmonkey/flywheel-memory -- the MCP server (77 tools)
   bench/        # @velvetmonkey/flywheel-bench -- benchmark infrastructure and vault generation
   demos/        # Demo vault fixtures (also used as test fixtures in CI)
 ```

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ E2E with Claude Sonnet (latest checked-in 695-question run): **97.4%** single-ho
 
 ## Testing
 
-2,760 defined tests across 142 test files and about 54.7k lines of test code. CI runs focused jobs on Ubuntu, plus a full matrix on Ubuntu and Windows across Node 22 and 24.
+3,025 defined tests across 156 test files and about 60.4k lines of test code. CI runs focused jobs on Ubuntu, plus a full matrix on Ubuntu and Windows across Node 22 and 24.
 
 - **Graph quality:** Latest generated report shows balanced-mode **40.2% precision / 71.7% recall / 51.5% F1** on the primary synthetic vault, along with multi-generation, archetype, chaos, and regression coverage. [Report ->](docs/QUALITY_REPORT.md)
 - **Live AI testing:** Real `claude -p` sessions verify tool adoption end to end, not just handler logic.

--- a/docs/PROVE-IT.md
+++ b/docs/PROVE-IT.md
@@ -40,7 +40,7 @@ npm install
 npm test
 ```
 
-Your output will reflect the current Vitest totals in this checkout. As of **March 28, 2026**, the repo defines **2,760 tests across 142 test files**.
+Your output will reflect the current Vitest totals in this checkout. As of **March 30, 2026**, the repo defines **3,025 tests across 156 test files**.
 
 No mocks of external services -- these are real SQLite queries, real file parsing, real graph traversals against real vaults.
 
@@ -208,7 +208,7 @@ npm test
 
 - A successful `vitest` run across all three workspace packages
 - Totals that match the current checkout
-- As of **March 28, 2026**: **2,760 defined tests across 142 test files**
+- As of **March 30, 2026**: **3,025 defined tests across 156 test files**
 
 `npm test` runs `vitest run` across all three workspace packages (`vault-core`, `flywheel-memory`, `flywheel-bench`). The mcp-server package contains the vast majority of tests. No network access, no API keys, no Docker -- just Node and SQLite.
 
@@ -353,7 +353,7 @@ This runs 30 questions in ~15 minutes for ~$2.50.
 
 ## What You Just Proved
 
-1. **The test corpus is substantial** -- 2,760 defined tests in the current checkout, against real data
+1. **The test corpus is substantial** -- 3,025 defined tests in the current checkout, against real data
 2. **Graph queries work** -- backlinks + metadata, no file reads
 3. **Auto-wikilinks work** -- plain text in, linked text out
 4. **The algorithm is transparent** -- scores with explanations, not black boxes

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,7 @@ No. Flywheel runs entirely on your machine. No cloud services, no API keys (beyo
 CI benchmarks test 100,000-line file mutations and 2,500-entity indexes. The bench package can generate very large synthetic vaults. See [BENCHMARKS.md](BENCHMARKS.md) and [TESTING.md](TESTING.md) for the scoped measurements that are actually checked in.
 
 **Will it corrupt my vault?**
-The repo currently defines 2,760 tests across 142 test files. The suite includes 100 parallel write operations with zero corruption in the stress tests, property-based fuzzing, and dedicated security tests for injection attacks and path traversal. See [TESTING.md](TESTING.md).
+The repo currently defines 3,025 tests across 156 test files. The suite includes 100 parallel write operations with zero corruption in the stress tests, property-based fuzzing, and dedicated security tests for injection attacks and path traversal. See [TESTING.md](TESTING.md).
 
 **How much does it cost in tokens?**
 It depends on the dataset, model, and task. The checked-in benchmark artifacts currently show about **$0.074/question** for the latest HotpotQA 500-question run and **$0.122/question** for the latest 695-question LoCoMo E2E run. See [TESTING.md](TESTING.md) for the exact scope and dates.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,7 +4,7 @@
 
 Your vault is your second brain. You don't hand it to software you can't trust.
 
-**2,760 defined tests | 142 test files | 54,700+ lines of test code**
+**3,025 defined tests | 156 test files | 60,300+ lines of test code**
 
 - [Test Philosophy](#test-philosophy)
 - [CI Pipeline](#ci-pipeline)

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -111,7 +111,7 @@ The demo vaults in this repo cover these personas with production-realistic data
 
 ### Flywheel Memory
 
-The MCP server. tools across 12 categories give Claude structured access to Obsidian vaults: search, graph queries, schema intelligence, content mutations, task management, agent memory, and policy automation. Published as `@velvetmonkey/flywheel-memory`.
+The MCP server. Tools across 12 categories give Claude structured access to Obsidian vaults: search, graph queries, schema intelligence, content mutations, task management, agent memory, and policy automation. Published as `@velvetmonkey/flywheel-memory`.
 
 ### Vault-Core
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flywheel-memory-monorepo",
   "version": "2.0.154",
   "private": true,
-  "description": "Local-first memory for AI agents. Select from 75 tools. No cloud. Everything connects.",
+  "description": "Local-first memory for AI agents. Select from 77 tools. No cloud. Everything connects.",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -372,7 +372,7 @@ export const TOOL_TIER: Record<string, ToolTier> = {
   server_log: 2,
   flywheel_doctor: 2,
 
-  // Tier 3 — explicit or advanced operations (25 tools)
+  // Tier 3 — explicit or advanced operations (26 tools)
   vault_schema: 3,
   schema_conventions: 3,
   schema_validate: 3,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2,7 +2,7 @@
 /**
  * Flywheel Memory - MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.
  *
- * 76 tools across 12 categories
+ * 77 tools across 12 categories
  * - policy (unified: list, validate, preview, execute, author, revise)
  * - Temporal tools absorbed into search (modified_after/modified_before) + get_vault_stats (recent_activity)
  * - Dropped: policy_diff, policy_export, policy_import, get_contemporaneous_notes


### PR DESCRIPTION
## Summary

- Tool count 75/76 → 77 across package.json, CLAUDE.md, CONTRIBUTING.md, index.ts header
- Tier 3 comment 25 → 26 in config.ts
- Test counts 2,760 → 3,025, test files 142 → 156, lines 54.7k → 60.4k across README, PROVE-IT, TESTING, docs/README
- VISION.md: rephrased to avoid hardcoded tool count (passes `tool-counts.test.ts` prose scan)

## Test plan

- [x] `tool-counts.test.ts` passes (25/25) — no stale "N tools" in prose
- [x] `tool-routing.test.ts` passes (32/32) — 77 tools verified
- [x] Grepped for stale `75 tools`, `76 tools`, `2,760`, `142 test` — zero matches outside CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)