### PR TITLE
fix: Windows CI — gitignore .flywheel/ in undo trace test vaults

### DIFF
--- a/packages/mcp-server/test/write/traces/undo-traces.trace.test.ts
+++ b/packages/mcp-server/test/write/traces/undo-traces.trace.test.ts
@@ -16,6 +16,8 @@ import { createWriteTestServer, type WriteTestServerContext } from '../../helper
 import { connectTestClient, type TestClient } from '../../read/helpers/createTestServer.js';
 import { createTestNote } from '../helpers/testUtils.js';
 import { snap } from './helpers/snapshotTools.js';
+import { writeFile } from 'fs/promises';
+import path from 'path';
 
 /**
  * After vault_undo_last_mutation (soft reset), restore working tree
@@ -42,6 +44,7 @@ describe('undo traces', () => {
       await git.init();
       await git.addConfig('user.email', 'test@test.com');
       await git.addConfig('user.name', 'Test');
+      await writeFile(path.join(ctx.vaultPath, '.gitignore'), '.flywheel/\n');
 
       // Seed vault with one note
       await createTestNote(ctx.vaultPath, 'notes/existing.md', [
@@ -106,6 +109,7 @@ describe('undo traces', () => {
       await git.init();
       await git.addConfig('user.email', 'test@test.com');
       await git.addConfig('user.name', 'Test');
+      await writeFile(path.join(ctx.vaultPath, '.gitignore'), '.flywheel/\n');
 
       // Seed vault
       await createTestNote(ctx.vaultPath, 'notes/sectioned.md', [
@@ -176,6 +180,7 @@ describe('undo traces', () => {
       await git.init();
       await git.addConfig('user.email', 'test@test.com');
       await git.addConfig('user.name', 'Test');
+      await writeFile(path.join(ctx.vaultPath, '.gitignore'), '.flywheel/\n');
 
       // Seed vault with a person note
       await createTestNote(ctx.vaultPath, 'people/robo.md', [


### PR DESCRIPTION
## Summary

- Fixes 3 Windows CI failures in `undo-traces.trace.test.ts` from PR #176
- Temp test vaults lacked a `.gitignore`, so `.flywheel/state.db*` files got tracked by git
- On Windows, `git reset --hard` fails because SQLite holds WAL/SHM files open and Windows can't unlink open files
- Adds `.gitignore` with `.flywheel/` to each test vault's `beforeAll`, matching production behavior

## Test plan
- [x] 3 undo trace tests pass locally on Linux
- [ ] Windows CI passes (the only platform affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)