### PR TITLE
docs: full mcpServers config in README snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,17 @@ Flywheel watches the vault, maintains local indexes, and serves the graph to MCP
 Out of the box, Flywheel progressively surfaces specialised tools as the conversation needs them. For a fixed reduced set, use `agent`. Compose bundles for custom configurations.
 
 ```json
-{ "env": { "FLYWHEEL_TOOLS": "agent,graph" } }
+{
+  "mcpServers": {
+    "flywheel": {
+      "command": "npx",
+      "args": ["-y", "@velvetmonkey/flywheel-memory"],
+      "env": {
+        "FLYWHEEL_TOOLS": "agent,graph"
+      }
+    }
+  }
+}
 ```
 
 [Browse all tools ->](docs/TOOLS.md) | [Preset recipes ->](docs/CONFIGURATION.md)
@@ -118,8 +128,14 @@ Serve more than one vault from a single Flywheel instance with `FLYWHEEL_VAULTS`
 
 ```json
 {
-  "env": {
-    "FLYWHEEL_VAULTS": "personal:/home/you/obsidian/Personal,work:/home/you/obsidian/Work"
+  "mcpServers": {
+    "flywheel": {
+      "command": "npx",
+      "args": ["-y", "@velvetmonkey/flywheel-memory"],
+      "env": {
+        "FLYWHEEL_VAULTS": "personal:/home/you/obsidian/Personal,work:/home/you/obsidian/Work"
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Preset and multi-vault JSON examples in the README showed bare `{ "env": { ... } }` fragments with no surrounding `mcpServers` wrapper
- Readers couldn't tell where the `env` block belongs — now both snippets match the install example directly above them

## Test plan
- [ ] Visual check: both snippets render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)