### PR TITLE
docs: consolidate contradictory intro in TOOLS.md

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,8 +1,6 @@
 # Tools
 
-Start with `search`. Specialised tools surface automatically when the query calls for them.
-
-> **Start here:** `full` (the default) progressively discloses tools as needed. Use `agent` for a fixed reduced set. See [CONFIGURATION.md](CONFIGURATION.md) for presets.
+The `full` preset (default) starts with `search` and progressively discloses specialised tools as the query calls for them. Use `agent` for a fixed reduced set. See [CONFIGURATION.md](CONFIGURATION.md) for presets.
 
 - [At a Glance](#at-a-glance)
 - [Find Anything](#find-anything)


### PR DESCRIPTION
## Summary
- Merged the two competing "start here" statements at the top of TOOLS.md into a single sentence that covers both which tool to start with and which preset is active.

## Test plan
- [ ] Verify the intro reads clearly and no information was lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)