### PR TITLE
fix: normalize CRLF in structure.ts for Windows CI

### DIFF
--- a/packages/mcp-server/src/tools/read/structure.ts
+++ b/packages/mcp-server/src/tools/read/structure.ts
@@ -39,7 +39,7 @@ const HEADING_REGEX = /^(#{1,6})\s+(.+)$/;
  * Extract all headings from markdown content
  */
 function extractHeadings(content: string): Heading[] {
-  const lines = content.split('\n');
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
   const headings: Heading[] = [];
 
   let inCodeBlock = false;
@@ -126,6 +126,7 @@ export async function getNoteStructure(
     return null;
   }
 
+  content = content.replace(/\r\n/g, '\n');
   const lines = content.split('\n');
   const headings = extractHeadings(content);
   const sections = buildSections(headings, lines.length);
@@ -194,6 +195,7 @@ export async function getSectionContent(
     return null;
   }
 
+  content = content.replace(/\r\n/g, '\n');
   const lines = content.split('\n');
   const headings = extractHeadings(content);
 


### PR DESCRIPTION
## Summary

- Normalizes CRLF→LF in `extractHeadings()`, `getNoteStructure()`, and `getSectionContent()` before splitting on `\n`
- Fixes the heading regex (`/^(#{1,6})\s+(.+)$/`) failing to match lines with trailing `\r` on Windows
- Root cause: Git's default `autocrlf=true` on Windows converts LF→CRLF on checkout; after `git reset --hard` in the undo flow, files have CRLF endings

## Test plan

- [x] `undo-traces.trace.test.ts` passes locally (all 3 tests)
- [x] Full test suite: 3274 passed, 3 pre-existing failures (docs/count assertions unrelated to this change)
- [ ] Windows CI should now pass the `undo removes added section content` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)