### PR TITLE
chore: release v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,7 +5945,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v2.3.0

Bumps vault-core and flywheel-memory to 2.3.0.

### vault-core changes
- feat: T19 — prospect ledger for persistent pre-entity memory (#169)
- chore: scrub hardcoded names from test fixtures (#170)

### flywheel-memory changes
- feat: T21 — agent-first tool description rewrite (#173)
- feat: T19 — prospect ledger for persistent pre-entity memory (#169)
- refactor: move policy storage from .claude/policies/ to .flywheel/policies/ (#174)
- fix: normalize CRLF in structure.ts to fix Windows CI section parsing (#186)
- fix: full preset listTools() visibility + session behaviour tests (#168)
- test: clock phase 2, mutation traces, tool set composition, prospect ledger coverage
- docs: repo truth pass, README rewrite, TOOLS.md consolidation