### PR TITLE
fix: wire progressive disclosure to listTools (T30)

### DIFF
--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -46,6 +46,14 @@ export type ToolCategory =
   | 'temporal' | 'diagnostics';
 
 export type ToolTier = 1 | 2 | 3;
+export type ToolTierOverride = 'auto' | 'full' | 'minimal';
+
+/**
+ * Default tier override for fresh sessions.
+ * 'auto' enables progressive disclosure (tier-1 visible, tier-2/3 activated by context).
+ * Users can override to 'full' via flywheel_config at runtime.
+ */
+export const INITIAL_TIER_OVERRIDE: ToolTierOverride = 'auto';
 
 export const ALL_CATEGORIES: ToolCategory[] = [
   'search', 'read', 'write',

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -138,6 +138,7 @@ import {
   parseEnabledCategories,
   resolveToolConfig,
   generateInstructions,
+  INITIAL_TIER_OVERRIDE,
   type ToolCategory,
   type ToolTier,
 } from './config.js';
@@ -197,7 +198,7 @@ export function getWatcherStatus(): WatcherStatus | null {
 const toolConfig = resolveToolConfig();
 const enabledCategories = toolConfig.categories;
 const toolTierMode: ToolTierMode = toolConfig.isFullToolset ? 'tiered' : 'off';
-let runtimeToolTierOverride: ToolTierOverride = toolConfig.preset === 'full' ? 'full' : 'auto';
+let runtimeToolTierOverride: ToolTierOverride = INITIAL_TIER_OVERRIDE;
 let runtimeActiveCategoryTiers = new Map<ToolCategory, ToolTier>();
 let primaryToolTierController: ToolTierController | null = null;
 

--- a/packages/mcp-server/src/tool-registry.ts
+++ b/packages/mcp-server/src/tool-registry.ts
@@ -27,7 +27,7 @@ import type { PipelineActivity } from './core/read/watch/pipeline.js';
 import type { StateDb } from '@velvetmonkey/vault-core';
 import { getSessionId } from '@velvetmonkey/vault-core';
 
-import { PRESETS, TOOL_CATEGORY, TOOL_TIER, type ToolCategory, type ToolTier } from './config.js';
+import { PRESETS, TOOL_CATEGORY, TOOL_TIER, type ToolCategory, type ToolTier, type ToolTierOverride } from './config.js';
 import { getSemanticActivations, getToolRoutingMode, hasToolRouting, type SemanticActivation } from './core/read/toolRouting.js';
 import { applySandwichOrdering } from './tools/read/query.js';
 import { VaultRegistry, type VaultContext } from './vault-registry.js';
@@ -109,7 +109,8 @@ export interface VaultActivationCallbacks {
 }
 
 export type ToolTierMode = 'off' | 'tiered';
-export type ToolTierOverride = 'auto' | 'full' | 'minimal';
+// ToolTierOverride re-exported from config.ts (side-effect-free for testing)
+export type { ToolTierOverride } from './config.js';
 
 export interface ToolTierController {
   readonly mode: ToolTierMode;
@@ -306,14 +307,19 @@ export function applyToolGating(
   }
 
   function refreshToolVisibility(): void {
+    let changed = false;
     for (const [name, handle] of toolHandles) {
       const enabled = shouldEnableTool(name);
-      if (enabled && !handle.enabled) {
-        handle.enable();
-      } else if (!enabled && handle.enabled) {
-        handle.disable();
+      if (enabled !== handle.enabled) {
+        // Set directly to avoid per-tool sendToolListChanged() notifications
+        handle.enabled = enabled;
+        changed = true;
       }
     }
+    if (changed) {
+      targetServer.sendToolListChanged();
+    }
+    // Always fire callback — override state may have changed even if no tools flipped
     if (controllerRef) {
       onTierStateChange?.(controllerRef);
     }

--- a/packages/mcp-server/test/tool-tiering.test.ts
+++ b/packages/mcp-server/test/tool-tiering.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import { ALL_CATEGORIES, TOOL_CATEGORY, TOOL_TIER, generateInstructions } from '../src/config.js';
+import { ALL_CATEGORIES, INITIAL_TIER_OVERRIDE, TOOL_CATEGORY, TOOL_TIER, generateInstructions } from '../src/config.js';
 import { applyToolGating } from '../src/tool-registry.js';
 import type { ToolTierController } from '../src/tool-registry.js';
 
@@ -1391,5 +1391,57 @@ describe('concurrent activation and finalization', () => {
     const result = await callTool(server, 'graph_analysis');
     expect(result.isError).not.toBe(true);
     expect(tools.graph_analysis.enabled).toBe(true);
+  });
+});
+
+// ============================================================================
+// T30 — Startup tier override policy
+// ============================================================================
+
+describe('startup tier override policy', () => {
+  it('INITIAL_TIER_OVERRIDE is auto, not full', () => {
+    // Regression guard: the bug was `preset === 'full' ? 'full' : 'auto'`
+    // which bypassed all tier filtering for the default preset.
+    expect(INITIAL_TIER_OVERRIDE).toBe('auto');
+  });
+});
+
+// ============================================================================
+// T30 — Notification batching
+// ============================================================================
+
+describe('notification batching in refreshToolVisibility', () => {
+  it('emits exactly one sendToolListChanged when activating a multi-tool category', () => {
+    const { server, controller } = createFullPresetServer();
+
+    // Attach spy AFTER createFullPresetServer() returns (registration-time notifications already fired)
+    const spy = vi.spyOn(server, 'sendToolListChanged');
+
+    controller.enableTierCategory('graph');
+
+    // Multiple graph tools should now be enabled
+    const graphTools = Object.entries(TOOL_TIER)
+      .filter(([name, tier]) => tier === 2 && TOOL_CATEGORY[name] === 'graph')
+      .map(([name]) => name);
+    expect(graphTools.length).toBeGreaterThan(1);
+    for (const name of graphTools) {
+      expect((server as any)._registeredTools[name]?.enabled).toBe(true);
+    }
+
+    // But only one notification should have been sent
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit sendToolListChanged when no tools change state', () => {
+    const { server, controller } = createFullPresetServer();
+
+    // Activate graph first
+    controller.enableTierCategory('graph');
+
+    const spy = vi.spyOn(server, 'sendToolListChanged');
+
+    // Activating graph again should not change any tool state
+    controller.enableTierCategory('graph');
+    expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause:** `index.ts:200` defaulted `runtimeToolTierOverride` to `'full'` for the default `full` preset, bypassing all tier filtering — every session exposed 77 tools instead of ~18 tier-1 tools
- **Fix:** Export `INITIAL_TIER_OVERRIDE = 'auto'` from `config.ts` (side-effect-free), import and use it in `index.ts`. Fixes both stdio and HTTP transport paths
- **Notification batching:** `refreshToolVisibility()` now sets `handle.enabled` directly (no per-tool notification), sends one `sendToolListChanged()` at the end. `onTierStateChange` callback still fires unconditionally for override sync + HTTP pool invalidation

## Test plan

- [x] 91/91 tool-tiering tests pass (88 existing + 3 new)
- [x] Full suite: 3276 pass, 4 pre-existing failures (demo vault counts, stale README tool count — T29 scope)
- [ ] Manual: start server with default config → `tools/list` returns tier-1 tool count
- [ ] Manual: `flywheel_config({ mode: "set", key: "tool_tier_override", value: "full" })` → all tools visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)