### PR TITLE
fix: repair CI test drift across four test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="header.png" alt="Flywheel" width="256"/>
   <h1>Flywheel</h1>
   <p><strong>Local-first MCP server — AI search, safe writes, and auto-linking for Obsidian vaults.</strong><br/>
-  77 tools. Every edit is auditable. Every link has a receipt.</p>
+  Every edit is auditable. Every link has a receipt.</p>
 </div>
 
 [![npm version](https://img.shields.io/npm/v/@velvetmonkey/flywheel-memory.svg)](https://www.npmjs.com/package/@velvetmonkey/flywheel-memory)

--- a/packages/core/test/backup.test.ts
+++ b/packages/core/test/backup.test.ts
@@ -577,7 +577,7 @@ describe('Backup & Recovery', () => {
   // attemptSalvage (extended)
   // ===========================================================================
   describe('attemptSalvage (extended)', () => {
-    it('merges .backup and .backup.1, getting unique rows from each', () => {
+    it('merges .backup and .backup.1, getting unique rows from each', { timeout: 15_000 }, () => {
       // .backup.1 has OldBackup (unique to this source)
       const db1 = openStateDb(testVaultPath);
       db1.db.prepare(


### PR DESCRIPTION
## Summary

- **README**: remove hardcoded "77 tools" from hero subtitle — the stale-copy detector (`tool-counts.test.ts`) flags any `N tools` phrasing in prose
- **backup (vault-core)**: raise timeout 5s→15s for the salvage merge test — Windows CI hits ~8s, per WSL2 timing policy (raise ceiling 2x)

Note: graph-export and demo-vault-assertions failures were from local dirty working tree state, not from committed code. Those tests pass on clean checkout.

## Test plan

- [x] `tool-counts.test.ts` passes (no stale "N tools" in prose)
- [x] `backup.test.ts` passes locally (timeout only affects Windows CI)
- [x] `graph-export.test.ts` passes on clean checkout
- [x] `demo-vault-assertions.test.ts` passes on clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)