### PR TITLE
chore: release v2.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,7 +5945,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5971,13 +5971,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@velvetmonkey/vault-core": "^2.3.2",
+        "@velvetmonkey/vault-core": "^2.3.3",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -55,7 +55,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.3.2",
+    "@velvetmonkey/vault-core": "^2.3.3",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary
- Bump vault-core and flywheel-memory to 2.3.3

## Changes since v2.3.2
- feat: discover_tools meta-tool + derive tool counts (#194)

🤖 Generated with [Claude Code](https://claude.com/claude-code)