### PR TITLE
chore: release v2.4.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v2.4.0

Bumps vault-core and flywheel-memory to 2.4.0.

### Changes since v2.3.3
- feat: three presets — full / auto / agent (#196)
- docs: three-preset updates + policy guide (#197)