### PR TITLE
chore: bump flywheel-memory to 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,7 +5945,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.3.3",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5971,13 +5971,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.3.3",
+      "version": "2.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@velvetmonkey/vault-core": "^2.3.3",
+        "@velvetmonkey/vault-core": "^2.4.0",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -55,7 +55,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.3.3",
+    "@velvetmonkey/vault-core": "^2.4.0",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
Version bump for flywheel-memory + vault-core dependency update.