### PR TITLE
docs: repo truth pass + README repositioning (T29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Flywheel Memory - Claude Code Instructions
 
-**[[Flywheel]] Memory** — MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits. 70+ [[TOOLS]] across 12 categories for search, graph analysis, schema intelligence, tasks, frontmatter, note mutations, temporal analysis, and memory — all local, all markdown. Hybrid search (BM25 + semantic via Reciprocal Rank Fusion) is available when embeddings are built via `init_semantic`.
+**[[Flywheel]] Memory** — MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits. 78 declared [[TOOLS]] across 12 categories for search, graph analysis, schema intelligence, tasks, frontmatter, note mutations, temporal analysis, and memory — all local, all markdown. Hybrid search (BM25 + semantic via Reciprocal Rank Fusion) is available when embeddings are built via `init_semantic`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ npm test
 ```
 packages/
   core/         # @velvetmonkey/vault-core -- shared utilities (entity scanning, wikilinks, SQLite)
-  mcp-server/   # @velvetmonkey/flywheel-memory -- the MCP server (70+ tools)
+  mcp-server/   # @velvetmonkey/flywheel-memory -- the MCP server
   bench/        # @velvetmonkey/flywheel-bench -- benchmark infrastructure and vault generation
   demos/        # Demo vault fixtures (also used as test fixtures in CI)
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <div align="center">
   <img src="header.png" alt="Flywheel" width="256"/>
   <h1>Flywheel</h1>
-  <p><strong>Local-first MCP server — AI search, safe writes, and auto-linking for Obsidian vaults.</strong><br/>
-  Every edit is auditable. Every link has a receipt.</p>
+  <p><strong>Flywheel turns an Obsidian vault into a graph-aware workspace for AI agents — fast to query, safe to write, and fully local.</strong></p>
 </div>
 
 [![npm version](https://img.shields.io/npm/v/@velvetmonkey/flywheel-memory.svg)](https://www.npmjs.com/package/@velvetmonkey/flywheel-memory)
@@ -11,11 +10,11 @@
 [![HotpotQA](https://img.shields.io/badge/HotpotQA-92.4%25%20recall%20(500q)-brightgreen.svg)](docs/TESTING.md#retrieval-benchmark-hotpotqa)
 [![LoCoMo](https://img.shields.io/badge/LoCoMo-84.3%25%20evidence%20recall%20(695q)-blue.svg)](docs/TESTING.md#retrieval-benchmark-locomo)
 
-**[What It Does](#what-it-does)** · **[See It Work](#see-it-work)** · **[Get Started](#get-started)** · **[Benchmarks](#benchmarks)** · **[Testing](#testing)** · **[Documentation](#documentation)** · **[License](#license)**
+**[What It Does](#what-it-does)** · **[See It Work](#see-it-work)** · **[Skills + Flywheel](#skills--flywheel)** · **[Get Started](#get-started)** · **[Benchmarks](#benchmarks)** · **[Testing](#testing)** · **[Documentation](#documentation)** · **[License](#license)**
 
-Flywheel is a local-first MCP server for Obsidian vaults. It indexes your markdown and gives AI clients 12 categories of tools for search, safe writes, tasks, graph traversal, and session memory. One server can serve multiple vaults with isolated state and cross-vault search.
+Flywheel is a local MCP server that gives AI agents structured access to an Obsidian vault. Search returns a *decision surface* — frontmatter, scored backlinks and outlinks, snippets with section context, dates, entity bridges, and confidence — so the model reasons from one call instead of opening file after file. Writes are git-committed, conflict-detected, and reversible. Auto-wikilinks resolve entities through a deterministic scoring algorithm where every suggestion has a traceable receipt. The graph compounds with use: links you keep get stronger, links you remove get suppressed, and every edit enriches the context for the next read.
 
-Search returns a *decision surface* — frontmatter, backlinks, outlinks, snippets, section context, extracted dates, entity bridges, and confidence scores — so the model can reason from one call instead of opening file after file. Every write auto-links entities through a deterministic 13-layer scoring algorithm. Links you keep get stronger; links you remove get suppressed. This is the *flywheel effect*: use compounds into structure, structure into intelligence, intelligence into more use.
+Everything runs on your machine. Nothing leaves your disk. Every action is bounded, inspectable, and reversible.
 
 ---
 
@@ -23,15 +22,15 @@ Search returns a *decision surface* — frontmatter, backlinks, outlinks, snippe
 
 ### Search your vault
 
-One call returns everything the model needs to answer: frontmatter, scored backlinks and outlinks, snippets with section context, dates, entity bridges, and confidence. Keyword search (BM25) finds what you said. Semantic search finds what you meant. Both fused via Reciprocal Rank Fusion, running locally. Nothing leaves your machine. [How search works ->](docs/ARCHITECTURE.md)
+One call returns everything the model needs to answer: frontmatter, scored backlinks and outlinks, snippets with section context, dates, entity bridges, and confidence. Keyword search (BM25) finds what you said. Semantic search finds what you meant. Both fused via Reciprocal Rank Fusion, running locally. [How search works ->](docs/ARCHITECTURE.md)
 
 ### Write safely
 
-Every mutation is git-committed, conflict-detected (SHA-256 content hash), and reversible with one undo. Auto-wikilinks resolve entities through a deterministic 13-layer scoring algorithm where every suggestion has a traceable receipt. For one-off edits, use the direct write tools. For repeatable workflows that need to search the vault and then act on the results, use **policies** — saved YAML workflows that can read vault state, branch on conditions, and drive multiple write steps as a single atomic operation. [How scoring works ->](docs/ALGORITHM.md) | [Policies guide ->](docs/POLICIES.md)
+Every mutation is git-committed, conflict-detected (SHA-256 content hash), and reversible with one undo. Writes preserve markdown structure — tables, callouts, code blocks, frontmatter, links, comments, and math are never corrupted by an edit to surrounding text. Auto-wikilinks resolve entities through a deterministic 13-layer scoring algorithm where every suggestion has a traceable receipt. For one-off edits, use the direct write tools. For repeatable workflows that search the vault and act on the results, use **policies** — saved YAML workflows that read vault state, branch on conditions, and drive multiple write steps as a single atomic operation. [How scoring works ->](docs/ALGORITHM.md) | [Policies guide ->](docs/POLICIES.md)
 
 ### Build context over time
 
-`brief` assembles a token-budgeted cold-start summary so the AI picks up where it left off. `memory` persists observations with confidence decay. The graph compounds with use. [Configuration ->](docs/CONFIGURATION.md)
+Every accepted link strengthens the graph. Every rejected link trains the scorer. Every write enriches the context for the next read. `brief` assembles a token-budgeted cold-start summary so the AI picks up where it left off. `memory` persists observations with confidence decay. This is the flywheel effect: use compounds into structure, structure into intelligence, intelligence into more use. [Configuration ->](docs/CONFIGURATION.md)
 
 ---
 
@@ -61,7 +60,17 @@ flywheel -> vault_add_to_section
 
 You type a normal sentence. Flywheel resolves known entities, detects prospective entities (proper nouns, acronyms, CamelCase terms), and adds wikilinks and suggests related links based on aliases, co-occurrence, graph structure, and semantic context. Suggested outgoing links are optional and off by default. Enable them where you want the graph to grow naturally, such as daily notes, meeting logs, or voice capture. [Configuration guide ->](docs/CONFIGURATION.md)
 
-### Policy: Search the vault, then act on it
+### Boundaries
+
+- Writes happen through visible tool calls.
+- Changes stay within the vault unless you explicitly point a tool somewhere else.
+- Git commits are opt-in.
+- Proactive linking can be disabled.
+
+> **Reproduce it yourself:** The carter-strategy demo includes a [`run-demo-test.sh`](demos/run-demo-test.sh) script that runs the full sequence end to end with `claude -p`, checking tool usage and vault state between steps.
+
+<details>
+<summary><strong>Policy example: Search the vault, then act on it</strong></summary>
 
 ```text
 > Create a policy that finds overdue invoices and logs follow-up tasks in today's daily note
@@ -85,16 +94,22 @@ flywheel -> policy action=execute name=overdue-invoice-chaser
 
 Policies search the vault, then write back. Author them in plain language, preview before running, and undo with one call if needed. [Policies guide ->](docs/POLICIES.md) | [Examples ->](docs/POLICY_EXAMPLES.md)
 
-### Boundaries
+</details>
 
-Flywheel is designed to be explicit about what it does.
+---
 
-- Writes happen through visible tool calls.
-- Changes stay within the vault unless you explicitly point a tool somewhere else.
-- Git commits are opt-in.
-- Proactive linking can be disabled.
+## Skills + Flywheel
 
-> **Reproduce it yourself:** The carter-strategy demo includes a [`run-demo-test.sh`](demos/run-demo-test.sh) script that runs the full sequence end to end with `claude -p`, checking tool usage and vault state between steps.
+Skills encode methodology — how to do something. Flywheel encodes knowledge — what you know. They are complementary layers:
+
+| Layer | What it provides | Example |
+|---|---|---|
+| Skills | Procedures, templates, reasoning frameworks | "How to write a client proposal" |
+| Flywheel | Entities, relationships, history, context | "Everything you know about this client" |
+
+An agent calling a proposal-writing skill works better when it can also search your vault for the client's history, past invoices, project notes, and team relationships. Skills tell agents how to work. Flywheel tells them what you know.
+
+[OpenClaw](https://github.com/openclaw) skills and Flywheel connect through MCP. OpenClaw routes intent and manages session flow; Flywheel provides the structured context and safe writes that make responses accurate. [Integration guide ->](docs/OPENCLAW.md)
 
 ---
 
@@ -203,17 +218,9 @@ If you use Cursor, Windsurf, VS Code, OpenClaw, or another client, see [docs/SET
 
 ---
 
-## Skills + Flywheel
-
-[OpenClaw](https://github.com/openclaw) skills and Flywheel serve complementary layers. Skills own the chat surface — channels, routing, session state, and safety. Flywheel owns the vault surface — indexing, retrieval, graph mutations, and persistent memory. Skills route conversations; Flywheel grounds them in your knowledge.
-
-Use both: OpenClaw routes intent and manages session flow, Flywheel provides the structured context and safe writes that make responses accurate. [Integration guide ->](docs/OPENCLAW.md)
-
----
-
 ## Benchmarks
 
-Latest checked-in benchmark artifacts:
+Agent-first tools should prove their claims. Flywheel ships with reproducible benchmarks against academic retrieval standards:
 
 - **HotpotQA full end to end:** **92.4% document recall** on **500 questions / 4,960 docs**. Latest artifact: **March 28, 2026**. Cost in that run: **$0.074/question**.
 - **LoCoMo full end to end:** **84.3% evidence recall** and **58.7% answer accuracy** on **695 scored questions / 272 sessions**. Latest artifact: **March 28, 2026**. Final token F1: **0.483**.
@@ -252,7 +259,7 @@ E2E with Claude Sonnet (latest checked-in 695-question run): **97.4%** single-ho
 
 ## Testing
 
-3,025 defined tests across 156 test files and about 60.4k lines of test code. CI runs focused jobs on Ubuntu, plus a full matrix on Ubuntu and Windows across Node 22 and 24.
+3,292 defined tests across 185 test files and about 64.4k lines of test code. CI runs focused jobs on Ubuntu, plus a full matrix on Ubuntu and Windows across Node 22 and 24.
 
 - **Graph quality:** Latest generated report shows balanced-mode **40.2% precision / 71.7% recall / 51.5% F1** on the primary synthetic vault, along with multi-generation, archetype, chaos, and regression coverage. [Report ->](docs/QUALITY_REPORT.md)
 - **Live AI testing:** Real `claude -p` sessions verify tool adoption end to end, not just handler logic.

--- a/demos/analyze-bundle-test.py
+++ b/demos/analyze-bundle-test.py
@@ -10,12 +10,14 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 
-# Full tool → category mapping mirroring packages/mcp-server/src/index.ts:345-438
+# Full tool → category mapping — canonical source is packages/mcp-server/src/config.ts (TOOL_CATEGORY).
+# Keep this dict in sync when tools are added or removed.
 TOOL_CATEGORY = {
-    # search (3 tools)
+    # search (4 tools)
     "search": "search",
     "init_semantic": "search",
     "find_similar": "search",
+    "discover_tools": "search",
     # read (3 tools)
     "get_note_structure": "read",
     "get_section_content": "read",
@@ -78,7 +80,7 @@ TOOL_CATEGORY = {
     "predict_stale_notes": "temporal",
     "track_concept_evolution": "temporal",
     "temporal_summary": "temporal",
-    # diagnostics (21 tools)
+    # diagnostics (22 tools)
     "health_check": "diagnostics",
     "get_vault_stats": "diagnostics",
     "get_folder_structure": "diagnostics",
@@ -100,6 +102,7 @@ TOOL_CATEGORY = {
     "vault_entity_history": "diagnostics",
     "flywheel_learning_report": "diagnostics",
     "flywheel_calibration_export": "diagnostics",
+    "tool_selection_feedback": "diagnostics",
 }
 
 # Reverse: category → list of tools

--- a/demos/analyze-coverage-test.py
+++ b/demos/analyze-coverage-test.py
@@ -9,9 +9,11 @@ import argparse
 from collections import defaultdict
 from datetime import datetime
 
-# Full tool -> category mapping mirroring packages/mcp-server/src/index.ts:345-438
+# Full tool -> category mapping — canonical source is packages/mcp-server/src/config.ts (TOOL_CATEGORY).
+# Keep this dict in sync when tools are added or removed.
 TOOL_CATEGORY = {
     "search": "search", "init_semantic": "search", "find_similar": "search",
+    "discover_tools": "search",
     "get_note_structure": "read", "get_section_content": "read", "find_sections": "read",
     "vault_add_to_section": "write", "vault_remove_from_section": "write",
     "vault_replace_in_section": "write", "vault_update_frontmatter": "write",
@@ -47,6 +49,7 @@ TOOL_CATEGORY = {
     "flywheel_trust_report": "diagnostics", "flywheel_benchmark": "diagnostics",
     "vault_session_history": "diagnostics", "vault_entity_history": "diagnostics",
     "flywheel_learning_report": "diagnostics", "flywheel_calibration_export": "diagnostics",
+    "tool_selection_feedback": "diagnostics",
 }
 
 # Category display order

--- a/demos/analyze-demo-test.py
+++ b/demos/analyze-demo-test.py
@@ -10,12 +10,14 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 
-# Full tool -> category mapping mirroring packages/mcp-server/src/index.ts:345-438
+# Full tool -> category mapping — canonical source is packages/mcp-server/src/config.ts (TOOL_CATEGORY).
+# Keep this dict in sync when tools are added or removed.
 TOOL_CATEGORY = {
-    # search (3 tools)
+    # search (4 tools)
     "search": "search",
     "init_semantic": "search",
     "find_similar": "search",
+    "discover_tools": "search",
     # read (3 tools)
     "get_note_structure": "read",
     "get_section_content": "read",

--- a/demos/run-coverage-test.sh
+++ b/demos/run-coverage-test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Full tool coverage test — one targeted prompt per flywheel tool (77 tools).
+# Full tool coverage test — one targeted prompt per default-visible flywheel tool (77 visible).
+# Canonical tool source: packages/mcp-server/src/config.ts (TOOL_CATEGORY).
+# discover_tools is disclosure-only and excluded from this coverage surface.
 #
 # Usage:
 #   demos/run-coverage-test.sh                        # default: 1 run, sonnet
@@ -19,7 +21,7 @@ TIMESTAMP=$(date +%Y%m%dT%H%M%S)
 RESULTS_DIR="$SCRIPT_DIR/test-results/coverage-$TIMESTAMP"
 
 # Tool definitions: tool_name|FLYWHEEL_TOOLS|prompt|resets(yes/no)
-# One entry per flywheel tool (69 total), organized by category.
+# One entry per default-visible flywheel tool, organized by category.
 TOOLS=(
   # --- search (3) ---
   'search|default|How much have I billed Acme Corp?|no'
@@ -40,7 +42,7 @@ TOOLS=(
   'vault_undo_last_mutation|default|Add a test line to the Notes section of Acme Corp, then immediately undo that last change|yes'
   'policy|default|Create and execute a policy that adds a Review Notes section to every client note in the clients folder|yes'
 
-  # --- graph (10) ---
+  # --- graph (11) ---
   'graph_analysis|default,graph|Analyze the overall graph structure of this vault and show me clusters, bridges, and hub nodes|no'
   'semantic_analysis|default,graph|Run a semantic analysis on this vault to find topic clusters and conceptual bridges between notes|no'
   'get_backlinks|default,graph|What notes link back to the Acme Corp note? Show me all backlinks.|no'
@@ -51,6 +53,7 @@ TOOLS=(
   'get_common_neighbors|default,graph|What are the common neighbors shared between Acme Corp and Data Migration in the vault graph?|no'
   'get_weighted_links|default,graph|Show me the weighted links for the Acme Corp entity with their weights|no'
   'get_strong_connections|default,graph|What are the strongest entity connections in this vault? Rank them by weight.|no'
+  'export_graph|default,graph|Export the full vault graph as JSON so I can visualize it externally|no'
 
   # --- schema (7) ---
   'vault_schema|default,schema|Show me the frontmatter schema used across this vault - what fields exist and their types|no'
@@ -98,7 +101,7 @@ TOOLS=(
   'track_concept_evolution|default,temporal|How has the concept of Data Migration evolved over time in this vault?|no'
   'temporal_summary|default,temporal|Give me a temporal summary of recent changes and activity in this vault|no'
 
-  # --- diagnostics (14) ---
+  # --- diagnostics (22) ---
   'health_check|default,diagnostics|Run a health check on this vault and report any issues|no'
   'get_vault_stats|default,diagnostics|Show me detailed statistics about this vault - note counts, link density, entity counts|no'
   'get_folder_structure|default,diagnostics|Show me the complete folder structure of this vault|no'
@@ -113,6 +116,14 @@ TOOLS=(
   'dismiss_merge_suggestion|default,diagnostics|Check for entity merge suggestions, then dismiss any that are not relevant|no'
   'vault_init|default,diagnostics|Initialize this vault with flywheel enrichment and wikilinks|yes'
   'flywheel_doctor|default,diagnostics|Run the flywheel doctor diagnostic to check for any issues with this vault|no'
+  'pipeline_status|default,diagnostics|Show me the current pipeline status for this vault|no'
+  'flywheel_trust_report|default,diagnostics|Generate a trust report for this vault showing scoring reliability and safety metrics|no'
+  'flywheel_benchmark|default,diagnostics|Run a benchmark test on this vault to measure search and scoring performance|no'
+  'vault_session_history|default,diagnostics|Show me the session history for this vault - what queries and operations have been run|no'
+  'vault_entity_history|default,diagnostics|Show me the history of the Acme Corp entity - how it has changed over time|no'
+  'flywheel_learning_report|default,diagnostics|Generate a learning report showing how the scoring system has improved over time|no'
+  'flywheel_calibration_export|default,diagnostics|Export the calibration data for this vault so I can analyze scoring patterns|no'
+  'tool_selection_feedback|default,diagnostics|Record feedback that the search tool was the right choice for a billing lookup query|no'
 )
 
 # Pre-flight checks

--- a/docs/PROVE-IT.md
+++ b/docs/PROVE-IT.md
@@ -40,7 +40,7 @@ npm install
 npm test
 ```
 
-Your output will reflect the current Vitest totals in this checkout. As of **March 30, 2026**, the repo defines **3,025 tests across 156 test files**.
+Your output will reflect the current Vitest totals in this checkout. The repo currently defines **3,292 tests across 185 test files**.
 
 No mocks of external services -- these are real SQLite queries, real file parsing, real graph traversals against real vaults.
 
@@ -208,7 +208,7 @@ npm test
 
 - A successful `vitest` run across all three workspace packages
 - Totals that match the current checkout
-- As of **March 30, 2026**: **3,025 defined tests across 156 test files**
+- Current checkout: **3,292 defined tests across 185 test files**
 
 `npm test` runs `vitest run` across all three workspace packages (`vault-core`, `flywheel-memory`, `flywheel-bench`). The mcp-server package contains the vast majority of tests. No network access, no API keys, no Docker -- just Node and SQLite.
 
@@ -353,7 +353,7 @@ This runs 30 questions in ~15 minutes for ~$2.50.
 
 ## What You Just Proved
 
-1. **The test corpus is substantial** -- 3,025 defined tests in the current checkout, against real data
+1. **The test corpus is substantial** -- 3,292 defined tests in the current checkout, against real data
 2. **Graph queries work** -- backlinks + metadata, no file reads
 3. **Auto-wikilinks work** -- plain text in, linked text out
 4. **The algorithm is transparent** -- scores with explanations, not black boxes

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@
 
 ## Getting Started
 
-- **Install** — see [Try It](../README.md#try-it) in the main README
+- **Install** — see [Get Started](../README.md#get-started) in the main README
 - **First query** — see [See It Work](../README.md#see-it-work) for a walkthrough
 - **Demo vaults** — jump to [Demo Vaults](#demo-vaults) below
 
@@ -96,7 +96,7 @@ No. Flywheel runs entirely on your machine. No cloud services, no API keys (beyo
 CI benchmarks test 100,000-line file mutations and 2,500-entity indexes. The bench package can generate very large synthetic vaults. See [BENCHMARKS.md](BENCHMARKS.md) and [TESTING.md](TESTING.md) for the scoped measurements that are actually checked in.
 
 **Will it corrupt my vault?**
-The repo currently defines 3,025 tests across 156 test files. The suite includes 100 parallel write operations with zero corruption in the stress tests, property-based fuzzing, and dedicated security tests for injection attacks and path traversal. See [TESTING.md](TESTING.md).
+The repo currently defines 3,292 tests across 185 test files. The suite includes 100 parallel write operations with zero corruption in the stress tests, property-based fuzzing, and dedicated security tests for injection attacks and path traversal. See [TESTING.md](TESTING.md).
 
 **How much does it cost in tokens?**
 It depends on the dataset, model, and task. The checked-in benchmark artifacts currently show about **$0.074/question** for the latest HotpotQA 500-question run and **$0.122/question** for the latest 695-question LoCoMo E2E run. See [TESTING.md](TESTING.md) for the exact scope and dates.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,7 +4,7 @@
 
 Your vault is your second brain. You don't hand it to software you can't trust.
 
-**3,025 defined tests | 156 test files | 60,300+ lines of test code**
+**3,292 defined tests | 185 test files | 64,400+ lines of test code**
 
 - [Test Philosophy](#test-philosophy)
 - [CI Pipeline](#ci-pipeline)
@@ -456,7 +456,7 @@ This kind of test is valuable because it measures actual tool selection and comp
 
 | Test Suite | What it proves | Sessions | Result | Script |
 |---|---|---|---|---|
-| **Per-tool coverage** | Claude discovers and uses each of 69 individual tools | 69 | **100% adoption** | [`run-coverage-test.sh`](../demos/run-coverage-test.sh) |
+| **Per-tool coverage** | Claude discovers and uses each default-visible tool | 77 | See [latest results](#per-tool-coverage) | [`run-coverage-test.sh`](../demos/run-coverage-test.sh) |
 | **Bundle adoption** | Claude finds the right tools for each of 12 bundles | 36 (12 × 3 runs) | 11/12 at 100% | [`run-bundle-test.sh`](../demos/run-bundle-test.sh) |
 | **Sequential workflow** | 9-beat workflow (retrieval + learning loop + operational) where each beat builds on previous vault state | 9 beats | — | [`run-demo-test.sh`](../demos/run-demo-test.sh) |
 | **HotpotQA benchmark** | End-to-end retrieval quality on HotpotQA multi-hop questions | 500 questions | 92.4% recall | [`hotpotqa/run-benchmark.sh`](../demos/hotpotqa/run-benchmark.sh) |
@@ -627,13 +627,13 @@ Each of 12 tool bundles tested with a targeted prompt against carter-strategy va
 ## Overall
 
 - **Bundles adopted:** 12/12
-- **Distinct flywheel tools used:** 20/69
+- **Distinct flywheel tools used:** 20/77
 
 <!-- END BUNDLE TEST RESULTS -->
 
 ### Per-Tool Coverage
 
-Each of 69 tools tested with a targeted prompt against carter-strategy vault.
+Each default-visible tool tested with a targeted prompt against the carter-strategy vault. The coverage surface is the 77 tools visible in the `full` preset (`discover_tools` is disclosure-only and excluded). Results below are from the last coverage run — rerun `demos/run-coverage-test.sh` to regenerate.
 
 <!-- BEGIN COVERAGE TEST RESULTS -->
 # Tool Coverage Test Report
@@ -776,7 +776,7 @@ Each of 69 tools tested with a targeted prompt against carter-strategy vault.
 
 ## Summary
 
-**Coverage: 64/69 tools adopted (92%)**
+**Coverage: 64/69 tools adopted (92%)** — from a 69-tool run prior to diagnostics expansion. The current coverage surface is 77 default-visible tools; rerun to get updated numbers.
 
 ### Tools Never Adopted
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flywheel-memory-monorepo",
   "version": "2.0.154",
   "private": true,
-  "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits. 70+ tools, local-first, no cloud.",
+  "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits. Local-first, no cloud.",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2,7 +2,7 @@
 /**
  * Flywheel Memory - MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.
  *
- * 70+ tools across 12 categories (see TOTAL_TOOL_COUNT in config.ts)
+ * 78 declared tools across 12 categories (see TOTAL_TOOL_COUNT in config.ts)
  * - policy (unified: list, validate, preview, execute, author, revise)
  * - Temporal tools absorbed into search (modified_after/modified_before) + get_vault_stats (recent_activity)
  * - Dropped: policy_diff, policy_export, policy_import, get_contemporaneous_notes


### PR DESCRIPTION
## Summary
- Rewrite README around three jobs (search, write safely, compound context) with outcome-led positioning
- Remove stale tool counts from marketing copy; update internal references to 78 declared tools
- Sync coverage tooling (4 Python/bash files) with config.ts as canonical source
- Update test counts to 3,292/185/64.4k across README, PROVE-IT, TESTING, docs/README
- Fix broken docs/README.md anchor, add structure-aware writes proof line

## Test plan
- [x] Doc-contract tests pass (25/25)
- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] Grep sweep confirms no stale "70+", "3,025", or "156 test" phrases remain
- [x] README 3-second scan: line 4 answers what/who/why

🤖 Generated with [Claude Code](https://claude.com/claude-code)