### PR TITLE
docs: remove hardcoded tool counts and fix TOOLS.md TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ Flywheel watches the vault, maintains local indexes, and serves the graph to MCP
 
 ### Tool presets
 
-The `full` preset (default) shows the 65-tool default-visible surface immediately. Use `auto` for progressive disclosure if you want the full 66-tool surface, including `discover_tools`, to appear as the conversation needs it.
+The `full` preset (default) shows the default-visible surface immediately. Use `auto` for progressive disclosure if you want the full surface, including `discover_tools`, to appear as the conversation needs it.
 
 | Preset | Behaviour |
 |--------|-----------|
-| `full` (default) | 65 tools visible at startup |
-| `auto` | Progressive disclosure across the full 66-tool surface |
-| `agent` | Fixed set of 18 tools: search, read, write, tasks, memory |
+| `full` (default) | All tools visible at startup |
+| `auto` | Progressive disclosure across the full surface |
+| `agent` | Fixed set: search, read, write, tasks, memory |
 
 Compose bundles for custom configurations:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -143,9 +143,9 @@ Vault root detection order:
 
 | Preset | Behaviour |
 |--------|-----------|
-| `full` (default) | 65 tools visible at startup |
-| `auto` | Progressive disclosure across the full 66-tool surface via `discover_tools` |
-| `agent` | Fixed reduced set of 18 tools — search, read, write, tasks, memory |
+| `full` (default) | All tools visible at startup |
+| `auto` | Progressive disclosure across the full surface via `discover_tools` |
+| `agent` | Fixed reduced set — search, read, write, tasks, memory |
 
 #### Composable Bundles
 
@@ -153,15 +153,15 @@ Start with `agent`, then add what you need:
 
 | Bundle | What it adds |
 |--------|--------------|
-| `graph` | 6 tools: structural analysis, semantic analysis, entity lists, paths, neighbor overlap, connection strength |
+| `graph` | Structural analysis, semantic analysis, entity lists, paths, neighbor overlap, connection strength |
 | `schema` | Schema inspection, conventions, validation, note intelligence, migrations, tag rename |
 | `wikilinks` | Link suggestions, validation, feedback, discovery |
 | `corrections` | Correction recording + resolution |
 | `tasks` | Task queries and mutations (already included in `agent`) |
 | `memory` | Session memory + brief |
 | `note-ops` | Delete, move, rename notes, merge entities |
-| `temporal` | 3 tools: get_context_around_date, predict_stale_notes, track_concept_evolution |
-| `diagnostics` | 16 tools: vault health, config, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status |
+| `temporal` | get_context_around_date, predict_stale_notes, track_concept_evolution |
+| `diagnostics` | Vault health, config, merges, doctor, trust, benchmark, session/entity history, learning report, calibration export, pipeline status |
 
 #### Recipes
 
@@ -170,7 +170,7 @@ Start with `agent`, then add what you need:
 | `agent` | search, read, write, tasks, memory |
 | `agent,graph` | agent + graph analysis, semantic analysis, paths, hubs |
 | `agent,graph,wikilinks` | + link suggestions, validation |
-| `full` | All categories, 65 tools visible immediately |
+| `full` | All categories, all tools visible immediately |
 | `auto` | All categories, progressive disclosure |
 
 #### How It Works
@@ -185,7 +185,7 @@ Set `FLYWHEEL_TOOLS` to a preset, one or more bundles, individual categories, or
 - **Tier 2** unlocks when the conversation shifts into graph, wikilink, correction, temporal, or diagnostics work
 - **Tier 3** stays on-demand for schema operations, note operations, and deep diagnostics
 
-`agent` is a fixed reduced set of 18 tools — search, read, write, tasks, memory. No progressive disclosure.
+`agent` is a fixed reduced set — search, read, write, tasks, memory. No progressive disclosure.
 
 `default` is a deprecated alias for `full`, retained for backward compatibility.
 

--- a/docs/OPENCLAW.md
+++ b/docs/OPENCLAW.md
@@ -146,7 +146,7 @@ OpenClaw's `bindings[]` model is the right place to decide which conversations g
 | Preset | When to use it | What you get |
 |--------|----------------|--------------|
 | `agent` | Best starting point for most OpenClaw bots | search, read, write, tasks, memory |
-| `full` | When the bot should be able to use the default full vault surface immediately | 65 tools visible up front |
+| `full` | When the bot should be able to use the default full vault surface immediately | All tools visible up front |
 | `agent,graph,wikilinks` | Good middle ground for assistant-style bots that need richer graph context | agent plus graph and linking tools |
 
 Recommended starting point:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -440,7 +440,7 @@ Flywheel auto-links any mentions of existing notes. If your vault has `Stacy Tho
 
 ## Step 3: Choose a Tool Preset
 
-Flywheel defaults to the `full` preset (65 tools visible at startup).
+Flywheel defaults to the `full` preset (all tools visible at startup).
 Use `"auto"` for progressive disclosure, `"agent"` for a fixed reduced set (search, read, write, tasks, memory). Add bundles for graph analysis, wikilinks, or other capabilities:
 
 ```json

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,12 +1,12 @@
 # Tools
 
-The `full` preset (default) shows the 65-tool default-visible surface immediately. Use `auto` for progressive disclosure, which activates the full 66-tool surface via `discover_tools`. Use `agent` for a fixed reduced set of 18 tools. See [CONFIGURATION.md](CONFIGURATION.md) for presets.
+The `full` preset (default) shows the default-visible surface immediately. Use `auto` for progressive disclosure, which activates the full surface including `discover_tools`. Use `agent` for a fixed reduced set covering search, read, write, tasks, and memory. See [CONFIGURATION.md](CONFIGURATION.md) for presets.
 
 - [At a Glance](#at-a-glance)
 - [Find Anything](#find-anything)
   - [`search`](#search)
-  - [`discover_tools`](#discover_tools)
   - [`find_similar`](#find_similar)
+  - [`discover_tools`](#discover_tools)
   - [`init_semantic`](#init_semantic)
 - [Read Deeper](#read-deeper)
 - [Write & Edit](#write--edit)
@@ -16,7 +16,6 @@ The `full` preset (default) shows the 65-tool default-visible surface immediatel
 - [Explore Connections](#explore-connections)
   - [`graph_analysis`](#graph_analysis)
   - [`semantic_analysis`](#semantic_analysis)
-  - [Link detail tools](#link-detail-tools)
   - [Other graph tools](#other-graph-tools)
 - [Wikilinks & Linking](#wikilinks--linking)
 - [Schema & Consistency](#schema--consistency)
@@ -427,7 +426,7 @@ Monitor, configure, and maintain your vault.
 
 ## Tool Selection Intelligence
 
-Under `full` (the default), the 65-tool default-visible surface is shown at startup. Under `agent`, only the fixed reduced surface is shown (18 tools across search, read, write, tasks, memory).
+Under `full` (the default), the default-visible surface is shown at startup. Under `agent`, only the fixed reduced surface is shown (search, read, write, tasks, memory).
 
 Under `auto`, Flywheel progressively discloses tools across three tiers via `discover_tools`:
 


### PR DESCRIPTION
## Summary
- Replace all hardcoded "N tools" phrasing in prose across 5 doc files with descriptive text (e.g. "all tools", "fixed reduced set") so counts never go stale when tools are added or removed
- Fix TOOLS.md TOC: swap `find_similar`/`discover_tools` entries to match actual heading order in the document
- Remove orphaned `#link-detail-tools` TOC anchor that pointed to a nonexistent heading

## Test plan
- [x] `tool-counts.test.ts` passes (25/25) — no "N tools" phrasing in scanned docs
- [x] `toc-completeness.test.ts` passes — TOC anchors exist and are in heading order

🤖 Generated with [Claude Code](https://claude.com/claude-code)