### PR TITLE
fix: restore graph tools and expand entity categories

### DIFF
--- a/demos/carter-strategy/DEMO-OPENSCREEN-SCRIPT.md
+++ b/demos/carter-strategy/DEMO-OPENSCREEN-SCRIPT.md
@@ -1,0 +1,347 @@
+# Carter Strategy Demo — OpenScreen Recording Script
+
+Single-take screen recording using [OpenScreen](https://github.com/siddharthvaddem/openscreen). Three-panel layout visible throughout; OpenScreen's zoom highlights the hero panel per beat. ~5 minutes final cut.
+
+**Tagline:** "Cognitive sovereignty for your Obsidian vault."
+
+**Core story:** Write notes, Flywheel suggests links, accept/reject feedback, graph improves, future suggestions get smarter. The viewer sees the learning loop close in real time.
+
+---
+
+## Screen Layout
+
+Arrange these three windows side-by-side before recording. Snap them so they fill the screen:
+
+```
++--------------+------------------+-------------+
+|   TELEGRAM   |   OBSIDIAN NOTE  |   CRANK     |
+|   + Wispr    |   (daily note)   |   GRAPH     |
+|              |                  |   PANEL     |
+|  Left ~30%  |   Centre ~40%    |  Right ~30% |
++--------------+------------------+-------------+
+```
+
+- **Left:** Telegram desktop, bot chat open, history cleared
+- **Centre:** Obsidian with carter-strategy vault, daily note open (empty)
+- **Right:** Crank graph panel in Obsidian sidebar
+
+---
+
+## Pre-Recording Setup
+
+### Vault
+
+1. Delete `daily-notes/` contents if any exist from previous runs
+2. **Do NOT delete `.flywheel/state.db`** — contains pre-seeded feedback (~30 records)
+3. Run `./run-demo-test.sh --seed-only` to ensure feedback is seeded
+4. Restart flywheel-demo service: `sudo systemctl restart flywheel-demo`
+
+### Pre-seeded feedback state
+
+The vault has been "in use for weeks." The state.db contains:
+
+| Entity | Feedback | Effect |
+|--------|----------|--------|
+| Sarah Mitchell | 90% accuracy (10 samples) | +10 boost — high-confidence suggestion |
+| Acme Data Migration | 85% accuracy (8 samples) | +10 boost |
+| Acme Corp | 95% accuracy (12 samples) | +10 boost |
+| Marcus Webb | 80% accuracy (6 samples) | +5 boost |
+| GlobalBank | 30% accuracy (25 samples) | **Suppressed** — won't appear |
+| Meridian Financial | 50% accuracy (4 samples) | Marginal — borderline |
+| Discovery Workshop Template | 55% accuracy (3 samples) | Marginal — borderline |
+
+Beat 1 suggestions already reflect prior learning. Live feedback in Beats 2-3 demonstrably improves Beat 4.
+
+### Apps
+
+- Obsidian open, carter-strategy vault, daily note visible, Crank graph panel on right
+- Telegram desktop open, bot chat, dark mode, history cleared
+- Wispr Flow active for voice input
+- All notifications silenced
+
+### OpenScreen
+
+1. Install from [GitHub Releases](https://github.com/siddharthvaddem/openscreen/releases) (Windows build)
+2. Set recording to **full screen**
+3. Audio: **microphone on**, system audio off
+4. Background: dark solid colour or gradient (for any padding around panels)
+5. Resolution: 1920x1080 or native
+6. Familiarise yourself with the zoom controls — you'll add zooms in post
+
+---
+
+## Recording
+
+**Record the entire session as one continuous take.** You'll add zooms, speed changes, annotations, and trims in OpenScreen's editor after recording.
+
+### Pre-roll (5 seconds)
+
+Sit on the empty 3-panel layout. Still frame. This gives you a clean opening to trim or add a title card.
+
+---
+
+### Beat 1: "Log a call" — suggestions appear (target: 0:00-1:00)
+
+**Voice (casual, post-call energy):**
+
+> "Log that I just wrapped a call with Sarah Mitchell and James Rodriguez at Acme. UAT is fully complete, Marcus Webb's validation scripts passed, and we're hitting the 3x performance target. Cutover locked for March 28-29."
+
+**What happens on screen:**
+
+| Panel | What the viewer sees |
+|-------|---------------------|
+| Left (Telegram) | Message appears in Telegram, bot confirms it's logging |
+| Centre (Obsidian) | Daily note entry appears with auto-wikilinks: [[Sarah Mitchell]], [[James Rodriguez]], [[UAT]], [[Marcus Webb]]. Suggested outgoing links: → [[Acme Corp]], [[Acme Analytics Add-on]], [[Beta Corp Dashboard]] |
+| Right (Crank) | Graph shows existing connections lighting up — Sarah, James, Marcus connected to Acme entities |
+
+**What this proves:** One voice command, four entities auto-linked. Three suggestions appeared based on co-occurrence patterns — the system already knows Acme Corp is the client, and surfaces related projects.
+
+**OpenScreen post-production:**
+
+| Edit | Detail |
+|------|--------|
+| Zoom | After voice input lands in Telegram, zoom to **centre panel** (~1.5x) as wikilinks appear. Hold 3-4 seconds on the rendered links + suggestions. |
+| Speed | If there's a processing delay between Telegram send and Obsidian update, speed that gap to 2-3x. |
+| Zoom | Pull back to full 3-panel view to show graph connections on the right. |
+
+---
+
+### Beat 2: "Accept and reject" — feedback captured (target: 1:00-1:45)
+
+**No voice. Hands on keyboard.**
+
+Manually edit the daily note entry:
+
+1. **Keep** the `→ [[Acme Corp]]` suggestion (obviously relevant — it's the client)
+2. **Remove** the `→ [[Beta Corp Dashboard]]` suggestion (not relevant to this Acme call)
+3. **Add** `→ [[Emily Chen]]` manually (she needs to sign off on production access — system didn't suggest her because she hasn't co-occurred with cutover conversations yet)
+
+**What happens on screen:**
+
+| Panel | What the viewer sees |
+|-------|---------------------|
+| Left (Telegram) | Static — not involved |
+| Centre (Obsidian) | Three edits visible: one suggestion kept, one removed, one manual link added |
+| Right (Crank) | Graph subtly updates — Acme Corp connection strengthens, Emily Chen gains new edge to the Acme cluster |
+
+**What this proves:** Every edit is feedback. Keep = boost. Remove = suppress. Manual add = teach. The graph responds in real time.
+
+**OpenScreen post-production:**
+
+| Edit | Detail |
+|------|--------|
+| Zoom | Zoom to **centre panel** (~1.8x) for the entire beat. This is the hero shot — the viewer needs to see each edit clearly. |
+| Speed | Slow to ~70% speed. Deliberate, quiet. |
+| Annotation | Add text overlay: **"Every edit teaches the system."** Position bottom-centre, hold for duration of beat. |
+| Annotation | Optional: checkmark (✓) on kept suggestion, X on removed suggestion as you edit each one. |
+
+---
+
+### Beat 3: "Write more, better suggestions" — the loop closes (target: 1:45-2:30)
+
+**Voice:**
+
+> "Sarah mentioned the Analytics Add-on proposal is circulating with their finance team. She wants to scope it with Emily after cutover. I said Priya Kapoor would be ideal."
+
+**What happens on screen:**
+
+| Panel | What the viewer sees |
+|-------|---------------------|
+| Left (Telegram) | Message in Telegram, bot logs it |
+| Centre (Obsidian) | New entry with auto-wikilinks: [[Sarah Mitchell]], [[Acme Analytics Add-on]], [[Emily Chen]], [[Priya Kapoor]]. Suggestions appear. **Notably ABSENT:** Beta Corp Dashboard (suppressed from Beat 2). **Notably PRESENT:** Emily Chen auto-linked (learned from Beat 2 manual add). |
+| Right (Crank) | Graph grows — Emily Chen now firmly in Acme cluster. Priya appears for the first time. |
+
+**What this proves:** The loop closed. Beta Corp Dashboard suppressed (you rejected it). Emily auto-linked (you taught the system). Suggestions got smarter from one interaction.
+
+**OpenScreen post-production:**
+
+| Edit | Detail |
+|------|--------|
+| Zoom | After wikilinks render, zoom to **centre panel** (~1.5x). |
+| Annotation | Add callout arrow or highlight on Emily Chen's auto-wikilink with text: **"Auto-linked — learned from Beat 2"** |
+| Annotation | Optional: ghost/strikethrough annotation where Beta Corp Dashboard would have appeared: **"Suppressed — rejected in Beat 2"** |
+| Zoom | Pull back to full view to show graph growth on the right. |
+| Speed | Real speed for voice. 2-3x for any processing gap. Slow/pause for the reveal. |
+
+---
+
+### Beat 4: "The voice dump" — showstopper (target: 2:30-3:45)
+
+**Voice (natural, stream-of-consciousness — consultant debriefing):**
+
+> "One more thing — James says the legacy Oracle decommission timeline hasn't been confirmed by IT. I've asked him to escalate. If we don't get a date by next Friday we might need to run parallel, which would push costs beyond the 75K budget, probably an extra 8 to 10K."
+
+*(Brief natural pause)*
+
+> "Oh, and update the [[Rate Card]] — Marcus is going up to 220 an hour from April. [[Leila Farouk|Leila]]'s rates need adding too for the [[Nexus Health]] engagement. [[Tom Huang]] confirmed Nexus wants to proceed with the Cloud Assessment once Leila's available."
+
+*(Slightly faster)*
+
+> "Last thing — Dan Oliveira pinged about the [[Beta Corp Dashboard]]. Pipeline module's done, wants to demo to Stacy Thompson before the client presentation Wednesday."
+
+**What happens on screen:**
+
+| Panel | What the viewer sees |
+|-------|---------------------|
+| Left (Telegram) | Long message appears via Wispr, bot processes |
+| Centre (Obsidian) | Massive entry with 12+ auto-wikilinks. Suggestions are sharply relevant — Emily Chen appears in suggestions for budget context (learned from Beats 2-3). Discovery Workshop Template appears where relevant (boosted from Beat 2). |
+| Right (Crank) | Graph **explodes** — Nexus Health cluster forms, Beta Corp connections multiply, Rate Card connects to multiple team members |
+
+**What this proves:** After 3 beats of feedback, suggestions are measurably better. Entities manually added earlier now auto-link. Suppressed entities stay gone.
+
+**Voice delivery tips:**
+- Natural pace, consultant-talking-to-assistant cadence
+- "Oh, and" before Rate Card — natural pause
+- "Last thing" — slightly faster, signals the close
+
+**OpenScreen post-production:**
+
+| Edit | Detail |
+|------|--------|
+| Speed | Voice input at real speed (~80-100%). Processing gaps at 2-3x. **Slow down** for the daily note filling up and graph expanding — hold 2-3 seconds after. |
+| Zoom | Start at full 3-panel view for the voice input. As the daily note populates, zoom to **centre panel** (~1.3x) to show density of wikilinks. Then pull back to full view for the graph explosion. |
+| Zoom | Optional: quick zoom to **right panel** (~1.5x) for the graph explosion moment, hold 2-3 seconds. |
+
+---
+
+### Beat 5: "Prove it improved" (target: 3:45-4:40)
+
+**Voice (relaxed):**
+
+> "Show me what's connected to Sarah Mitchell."
+
+**What happens on screen:**
+
+| Panel | What the viewer sees |
+|-------|---------------------|
+| Left (Telegram) | Agent response: Sarah's connections across the vault |
+| Centre (Obsidian) | Scroll the daily note — full audit trail of the session, 4 entries, dozens of wikilinks |
+| Right (Crank) | Click Sarah Mitchell in graph. Context cloud redraws showing her connections: Acme Corp, Emily Chen (learned this session!), Data Migration, Analytics Add-on, invoices. Weighted connections — thicker lines for stronger relationships. |
+
+**What this proves:** The graph is denser and smarter than when we started. Emily Chen is in Sarah's orbit — a connection that didn't exist 5 minutes ago, taught by one manual edit in Beat 2.
+
+**OpenScreen post-production:**
+
+| Edit | Detail |
+|------|--------|
+| Zoom | Start at full view. When Sarah's subgraph renders, zoom to **right panel** (~1.8x). This is the closing shot. |
+| Speed | Real speed throughout. Let the graph render. |
+| Hold | Hold on Sarah's subgraph for 3-4 seconds. No voiceover. Just the graph. |
+
+---
+
+### Closing (target: 4:40-5:00)
+
+**Voiceover (over the held graph shot):**
+
+> "Every edit taught the system. Links you kept got stronger. Links you removed got suppressed. After five minutes, the graph knows which connections matter — not because you configured anything, but because you just used it."
+
+**OpenScreen post-production:**
+
+| Edit | Detail |
+|------|--------|
+| Hold | Keep Sarah's subgraph visible throughout voiceover. |
+| Annotation | Fade in text: **"Cognitive sovereignty for your Obsidian vault."** Centre of screen. |
+| Annotation | Below tagline: repo URL. Hold 5 seconds. |
+| Trim | Cut any post-recording dead air. |
+
+---
+
+## OpenScreen Editor Checklist
+
+After recording, open the clip in OpenScreen's editor and apply these in order:
+
+### 1. Trim
+- [ ] Cut pre-roll to desired length (or replace with title card)
+- [ ] Cut any dead air or mistakes
+- [ ] Remove post-recording tail
+
+### 2. Speed adjustments
+- [ ] Beat 2 edits: slow to ~70%
+- [ ] All processing gaps (Telegram -> Obsidian delays): speed to 2-3x
+- [ ] Beat 4 voice input: keep at real speed
+- [ ] Beat 4 reveal (note filling + graph): real speed or slightly slow
+
+### 3. Zooms
+- [ ] Beat 1: Zoom centre panel after wikilinks appear. Pull back for graph.
+- [ ] Beat 2: Zoom centre panel for full beat (~1.8x). Hero shot.
+- [ ] Beat 3: Zoom centre panel for suggestion reveal. Pull back for graph.
+- [ ] Beat 4: Full view for voice. Zoom centre for note density. Pull back for graph explosion.
+- [ ] Beat 5: Zoom right panel for Sarah's subgraph. Hold for closing.
+
+### 4. Annotations
+- [ ] Beat 2: "Every edit teaches the system." text overlay
+- [ ] Beat 2 (optional): ✓ and ✗ on kept/removed suggestions
+- [ ] Beat 3: "Auto-linked — learned from Beat 2" callout on Emily Chen
+- [ ] Beat 3 (optional): "Suppressed — rejected in Beat 2" ghost text
+- [ ] Closing: "Cognitive sovereignty for your Obsidian vault." + repo URL
+
+### 5. Audio
+- [ ] Verify mic audio is clean across all beats
+- [ ] Beat 2 should be silent (just keyboard sounds if any)
+- [ ] Optional: add subtle ambient music under Beat 2 for contrast
+- [ ] Closing voiceover may need to be recorded separately and layered
+
+### 6. Export
+- [ ] Aspect ratio: 16:9
+- [ ] Resolution: 1920x1080 (or 4K if source supports it)
+- [ ] Format: MP4
+
+---
+
+## The Learning Loop (reference for on-screen annotation)
+
+```
+   Write a note
+       |
+       v
+  Auto-wikilinks fire
+  + suggestions appear
+       |
+       v
+  Accept / reject / add
+       |
+       v
+  Feedback shapes scoring
+  (boost / suppress / teach)
+       |
+       v
+  Next write: better suggestions
+       |
+       '---------> Graph gets denser
+```
+
+---
+
+## Entity Checklist
+
+Before recording, verify every entity mentioned exists in the vault:
+
+- [ ] Sarah Mitchell (Beats 1, 2, 3, 5) — VP Technology, Acme Corp
+- [ ] James Rodriguez (Beats 1, 4) — IT contact, Acme Corp
+- [ ] Marcus Webb (Beats 1, 4) — Senior Data Engineer
+- [ ] Emily Chen (Beats 2, 3, 4) — Acme Corp, production sign-off
+- [ ] Priya Kapoor (Beat 3) — financial modeling
+- [ ] Leila Farouk (Beat 4) — cloud/security
+- [ ] Tom Huang (Beat 4) — Nexus Health contact
+- [ ] Dan Oliveira (Beat 4) — Beta Corp Dashboard
+- [ ] Stacy Thompson (Beat 4) — demo reviewer
+- [ ] Acme Corp, [[TechStart Inc]], Nexus Health (clients)
+- [ ] [[Acme Data Migration]], Beta Corp Dashboard (projects)
+- [ ] Rate Card, Data Migration Playbook, Discovery Workshop Template (knowledge)
+- [ ] Acme Analytics Add-on, Nexus Health Cloud Assessment (proposals)
+
+---
+
+## Quick Reference: OpenScreen Features Used
+
+| Feature | Where used |
+|---------|-----------|
+| Full screen recording | Entire session — captures all 3 panels |
+| Manual zoom | Per-beat hero panel highlights (5-6 zooms total) |
+| Speed control | 70% for Beat 2 edits, 2-3x for processing gaps |
+| Annotations (text) | Beat 2 overlay, Beat 3 callouts, closing tagline + URL |
+| Annotations (arrows) | Beat 3 Emily Chen callout (optional) |
+| Trim | Pre-roll, post-roll, dead air |
+| Crop | Optional — hide taskbar or non-relevant screen edges |
+| Motion blur | Enable for zoom transitions (smoother pans between panels) |

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -248,49 +248,123 @@ const REGION_PATTERNS = ['eu', 'apac', 'emea', 'latam', 'amer'];
 const FRONTMATTER_TYPE_MAP: Record<string, EntityCategory> = {
   // animals
   animal: 'animals', pet: 'animals', horse: 'animals', dog: 'animals',
-  cat: 'animals', bird: 'animals', fish: 'animals',
+  cat: 'animals', bird: 'animals', fish: 'animals', insect: 'animals',
+  reptile: 'animals', species: 'animals', breed: 'animals',
+
   // people
   person: 'people', contact: 'people', friend: 'people',
-  colleague: 'people', family: 'people',
+  colleague: 'people', family: 'people', employee: 'people',
+  manager: 'people', author: 'people', speaker: 'people',
+  creator: 'people', stakeholder: 'people', contractor: 'people',
+  consultant: 'people', member: 'people', character: 'people',
+  prospect: 'people', lead: 'people', expert: 'people',
+
+  // organizations
+  company: 'organizations', organization: 'organizations', org: 'organizations',
+  team: 'organizations', client: 'organizations', customer: 'organizations',
+  vendor: 'organizations', partner: 'organizations', supplier: 'organizations',
+  agency: 'organizations', startup: 'organizations', enterprise: 'organizations',
+  business: 'organizations', department: 'organizations', division: 'organizations',
+  group: 'organizations', committee: 'organizations', institution: 'organizations',
+  school: 'organizations', university: 'organizations', studio: 'organizations',
+  account: 'organizations',
+
   // media
   movie: 'media', book: 'media', show: 'media', game: 'media',
-  music: 'media', album: 'media', film: 'media', podcast: 'media', series: 'media',
+  music: 'media', album: 'media', film: 'media', podcast: 'media',
+  series: 'media', episode: 'media', video: 'media', song: 'media',
+  playlist: 'media', artwork: 'media', photo: 'media', article: 'media',
+  post: 'media', blog: 'media', channel: 'media', publication: 'media',
+  newsletter: 'media',
+
   // events
   event: 'events', meeting: 'events', conference: 'events',
   trip: 'events', holiday: 'events', milestone: 'events',
+  interview: 'events', appointment: 'events', session: 'events',
+  workshop: 'events', webinar: 'events', call: 'events',
+  summit: 'events', meetup: 'events', vacation: 'events',
+  festival: 'events', ceremony: 'events',
+
   // documents
   document: 'documents', report: 'documents', guide: 'documents',
   reference: 'documents', template: 'documents', note: 'documents',
+  checklist: 'documents', playbook: 'documents', spec: 'documents',
+  specification: 'documents', roadmap: 'documents', review: 'documents',
+  decision: 'documents', manual: 'documents', contract: 'documents',
+  policy: 'documents', procedure: 'documents', log: 'documents',
+  journal: 'documents', transcript: 'documents', minutes: 'documents',
+  summary: 'documents', brief: 'documents', proposal: 'documents',
+  presentation: 'documents', deck: 'documents', memo: 'documents',
+  letter: 'documents', resource: 'documents', rfc: 'documents',
+  architecture: 'documents', draft: 'documents', manuscript: 'documents',
+  snippet: 'documents',
+
   // vehicles
   vehicle: 'vehicles', car: 'vehicles', bike: 'vehicles',
-  boat: 'vehicles', motorcycle: 'vehicles',
+  boat: 'vehicles', motorcycle: 'vehicles', truck: 'vehicles',
+  plane: 'vehicles', aircraft: 'vehicles', ship: 'vehicles',
+
   // health
   health: 'health', medical: 'health', fitness: 'health',
   condition: 'health', wellness: 'health', exercise: 'health',
+  treatment: 'health', medication: 'health', workout: 'health',
+  therapy: 'health', nutrition: 'health',
+
   // finance
-  finance: 'finance', account: 'finance', investment: 'finance',
+  finance: 'finance', investment: 'finance',
   budget: 'finance', transaction: 'finance', bank: 'finance',
+  expense: 'finance', income: 'finance', revenue: 'finance',
+  tax: 'finance', payment: 'finance', invoice: 'finance',
+  receipt: 'finance', portfolio: 'finance', equity: 'finance',
+
   // food
   food: 'food', recipe: 'food', restaurant: 'food',
   meal: 'food', ingredient: 'food', drink: 'food',
+  beverage: 'food', cuisine: 'food',
+
   // hobbies
   hobby: 'hobbies', sport: 'hobbies', craft: 'hobbies',
-  activity: 'hobbies', collection: 'hobbies',
-  // periodical notes (daily, weekly, monthly, etc.)
+  activity: 'hobbies', collection: 'hobbies', gaming: 'hobbies',
+  photography: 'hobbies',
+
+  // technologies
+  tool: 'technologies', technology: 'technologies', framework: 'technologies',
+  library: 'technologies', language: 'technologies', app: 'technologies',
+  software: 'technologies', hardware: 'technologies', device: 'technologies',
+  equipment: 'technologies', server: 'technologies', database: 'technologies',
+  platform: 'technologies', plugin: 'technologies', extension: 'technologies',
+  api: 'technologies', service: 'technologies', package: 'technologies',
+
+  // projects
+  project: 'projects', initiative: 'projects', campaign: 'projects',
+  program: 'projects', product: 'projects', release: 'projects',
+  sprint: 'projects', epic: 'projects', feature: 'projects',
+  goal: 'projects', objective: 'projects', deliverable: 'projects',
+  deal: 'projects', opportunity: 'projects',
+
+  // locations
+  place: 'locations', location: 'locations', city: 'locations',
+  country: 'locations', region: 'locations', state: 'locations',
+  town: 'locations', building: 'locations', office: 'locations',
+  venue: 'locations', facility: 'locations',
+
+  // concepts
+  concept: 'concepts', idea: 'concepts', topic: 'concepts',
+  theory: 'concepts', principle: 'concepts', model: 'concepts',
+  pattern: 'concepts', methodology: 'concepts', strategy: 'concepts',
+  technique: 'concepts', algorithm: 'concepts', definition: 'concepts',
+  knowledge: 'concepts', domain: 'concepts', discipline: 'concepts',
+  subject: 'concepts', course: 'concepts', lesson: 'concepts',
+  tutorial: 'concepts',
+
+  // periodical notes
   periodical: 'periodical', daily: 'periodical', weekly: 'periodical',
-  monthly: 'periodical', quarterly: 'periodical',
+  monthly: 'periodical', quarterly: 'periodical', yearly: 'periodical',
+
   // identity categories (for reverse-mapping)
   acronym: 'acronyms',
   media: 'media',
   other: 'other',
-  // existing categories
-  project: 'projects',
-  tool: 'technologies', technology: 'technologies', framework: 'technologies',
-  library: 'technologies', language: 'technologies',
-  company: 'organizations', organization: 'organizations', org: 'organizations', team: 'organizations',
-  place: 'locations', location: 'locations', city: 'locations',
-  country: 'locations', region: 'locations',
-  concept: 'concepts', idea: 'concepts', topic: 'concepts',
 };
 
 function mapFrontmatterType(
@@ -319,34 +393,67 @@ function mapFrontmatterType(
  */
 // Folder names that imply entity categories
 const FOLDER_CATEGORY_MAP: Record<string, EntityCategory> = {
-  'people': 'people',
-  'person': 'people',
-  'contacts': 'people',
-  'team': 'people',
-  'members': 'people',
-  'projects': 'projects',
-  'project': 'projects',
-  'locations': 'locations',
-  'places': 'locations',
-  'companies': 'organizations',
-  'organizations': 'organizations',
-  'orgs': 'organizations',
-  'concepts': 'concepts',
-  'topics': 'concepts',
-  'tools': 'technologies',
-  'software': 'technologies',
-  'media': 'media',
-  'books': 'media',
-  'films': 'media',
-  'movies': 'media',
-  'music': 'media',
+  // people
+  'people': 'people', 'person': 'people', 'contacts': 'people',
+  'team': 'people', 'members': 'people', 'employees': 'people',
+  'colleagues': 'people', 'contractors': 'people', 'consultants': 'people',
+
+  // organizations
+  'companies': 'organizations', 'organizations': 'organizations', 'orgs': 'organizations',
+  'clients': 'organizations', 'customers': 'organizations', 'vendors': 'organizations',
+  'partners': 'organizations', 'agencies': 'organizations', 'institutions': 'organizations',
+  'accounts': 'organizations',
+
+  // projects
+  'projects': 'projects', 'project': 'projects', 'initiatives': 'projects',
+  'campaigns': 'projects', 'products': 'projects', 'goals': 'projects',
+  'deliverables': 'projects', 'work': 'projects',
+
+  // locations
+  'locations': 'locations', 'places': 'locations',
+
+  // concepts
+  'concepts': 'concepts', 'topics': 'concepts', 'knowledge': 'concepts',
+  'research': 'concepts', 'learning': 'concepts',
+
+  // technologies
+  'tools': 'technologies', 'software': 'technologies', 'equipment': 'technologies',
+  'tech': 'technologies', 'apps': 'technologies', 'platforms': 'technologies',
+
+  // media
+  'media': 'media', 'books': 'media', 'films': 'media',
+  'movies': 'media', 'music': 'media', 'podcasts': 'media',
+  'reading': 'media', 'articles': 'media',
+
+  // events
+  'events': 'events', 'meetings': 'events', 'conferences': 'events',
+
+  // documents
+  'documents': 'documents', 'docs': 'documents', 'templates': 'documents',
+  'guides': 'documents', 'references': 'documents', 'proposals': 'documents',
+  'admin': 'documents', 'archive': 'documents', 'resources': 'documents',
+
+  // vehicles
   'vehicles': 'vehicles',
-  'equipment': 'technologies',
-  'food': 'food',
-  'recipes': 'food',
-  'health': 'health',
-  'finance': 'finance',
-  'hobbies': 'hobbies',
+
+  // health
+  'health': 'health', 'fitness': 'health', 'medical': 'health',
+
+  // finance
+  'finance': 'finance', 'invoices': 'finance', 'billing': 'finance',
+
+  // food
+  'food': 'food', 'recipes': 'food',
+
+  // hobbies
+  'hobbies': 'hobbies', 'sports': 'hobbies',
+
+  // animals
+  'animals': 'animals', 'pets': 'animals',
+
+  // periodical
+  'daily-notes': 'periodical', 'weekly-notes': 'periodical',
+  'monthly-notes': 'periodical',
 };
 
 function categorizeEntity(

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -252,13 +252,17 @@ export const TOOL_CATEGORY: Record<string, ToolCategory> = {
   vault_undo_last_mutation: 'write',
   policy: 'write',
 
-  // graph (6 tools) -- structural analysis + link detail
+  // graph (9 tools) -- structural analysis + link detail
   graph_analysis: 'graph',
   semantic_analysis: 'graph',
   get_connection_strength: 'graph',
   list_entities: 'graph',
   get_link_path: 'graph',
   get_common_neighbors: 'graph',
+  get_backlinks: 'graph',
+  get_forward_links: 'graph',
+  get_weighted_links: 'graph',
+  get_strong_connections: 'graph',
 
   // schema (7 tools) -- schema intelligence + migrations
   vault_schema: 'schema',
@@ -354,6 +358,10 @@ export const TOOL_TIER: Record<string, ToolTier> = {
   list_entities: 2,
   get_link_path: 2,
   get_common_neighbors: 2,
+  get_backlinks: 2,
+  get_forward_links: 2,
+  get_weighted_links: 2,
+  get_strong_connections: 2,
   suggest_wikilinks: 2,
   validate_links: 2,
   wikilink_feedback: 2,

--- a/packages/mcp-server/src/tool-registry.ts
+++ b/packages/mcp-server/src/tool-registry.ts
@@ -37,7 +37,7 @@ import { runInVaultScope, getActiveScopeOrNull, type VaultScope } from './vault-
 import { recordToolInvocation } from './core/shared/toolTracking.js';
 
 // Read tool registrations
-// graph.ts retired — get_backlinks, get_forward_links, get_weighted_links, get_strong_connections removed
+import { registerGraphTools } from './tools/read/graph.js';
 // graphExport.ts retired — export_graph removed
 import { registerWikilinkTools } from './tools/read/wikilinks.js';
 import { registerHealthTools } from './tools/read/health.js';
@@ -784,6 +784,7 @@ export function registerAllTools(
   registerWikilinkTools(targetServer, gvi, gvp, gsd);
   registerQueryTools(targetServer, gvi, gvp, gsd);
   registerPrimitiveTools(targetServer, gvi, gvp, gcf, gsd);
+  registerGraphTools(targetServer, gvi, gvp, gsd);
   registerGraphAnalysisTools(targetServer, gvi, gvp, gsd, gcf);
   registerSemanticAnalysisTools(targetServer, gvi, gvp);
   registerVaultSchemaTools(targetServer, gvi, gvp);

--- a/packages/mcp-server/src/tools/read/graph.ts
+++ b/packages/mcp-server/src/tools/read/graph.ts
@@ -1,0 +1,362 @@
+/**
+ * Graph intelligence tools
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { VaultIndex } from '../../core/read/types.js';
+import { MAX_LIMIT } from '../../core/read/constants.js';
+import {
+  getBacklinksForNote,
+  getForwardLinksForNote,
+  resolveTarget,
+} from '../../core/read/graph.js';
+import { getInboundTargetsForNote } from '../../core/read/identity.js';
+import { findBidirectionalLinks } from './graphAdvanced.js';
+import { requireIndex } from '../../core/read/indexGuard.js';
+
+/**
+ * Get surrounding context for a backlink
+ */
+async function getContext(
+  vaultPath: string,
+  sourcePath: string,
+  line: number,
+  contextLines: number = 1
+): Promise<string> {
+  try {
+    const fullPath = path.join(vaultPath, sourcePath);
+    const content = await fs.promises.readFile(fullPath, 'utf-8');
+    const allLines = content.split('\n');
+
+    // Line numbers from the parser are relative to the body (after frontmatter).
+    // Compute the frontmatter offset so we index into the full file correctly.
+    let fmLines = 0;
+    if (allLines[0]?.trimEnd() === '---') {
+      for (let i = 1; i < allLines.length; i++) {
+        if (allLines[i].trimEnd() === '---') {
+          fmLines = i + 1; // lines consumed by frontmatter (including both ---)
+          break;
+        }
+      }
+    }
+
+    const absLine = line + fmLines; // convert body-relative to absolute (1-indexed)
+    const startLine = Math.max(0, absLine - 1 - contextLines);
+    const endLine = Math.min(allLines.length, absLine + contextLines);
+
+    return allLines.slice(startLine, endLine).join('\n').trim();
+  } catch {
+    return '';
+  }
+}
+
+// Output schemas for structured content
+const BacklinkItemSchema = z.object({
+  source: z.string().describe('Path of the note containing the link'),
+  line: z.coerce.number().describe('Line number where the link appears'),
+  context: z.string().optional().describe('Surrounding text for context'),
+});
+
+const GetBacklinksOutputSchema = {
+  note: z.string().describe('The resolved note path'),
+  backlink_count: z.coerce.number().describe('Total number of backlinks found'),
+  returned_count: z.coerce.number().describe('Number of backlinks returned (may be limited)'),
+  backlinks: z.array(BacklinkItemSchema).describe('List of backlinks'),
+};
+
+// TypeScript type derived from schema
+type GetBacklinksOutput = {
+  note: string;
+  backlink_count: number;
+  returned_count: number;
+  backlinks: Array<{
+    source: string;
+    line: number;
+    context?: string;
+  }>;
+};
+
+/**
+ * Register graph intelligence tools with the MCP server
+ */
+export function registerGraphTools(
+  server: McpServer,
+  getIndex: () => VaultIndex,
+  getVaultPath: () => string,
+  getStateDb?: () => import('@velvetmonkey/vault-core').StateDb | null
+) {
+  // get_backlinks - What notes link TO this note?
+  server.registerTool(
+    'get_backlinks',
+    {
+      title: 'Get Backlinks',
+      description: 'Use when finding which notes reference a given note. Produces a list of incoming links with source file paths and surrounding line context. Returns backlink entries ranked by edge weight. Does not return outgoing links — use get_forward_links for that.',
+      inputSchema: {
+        path: z.string().describe('Path to the note (e.g., "daily/2024-01-15.md" or just "My Note")'),
+        include_context: z.boolean().default(true).describe('Include surrounding text for context'),
+        include_bidirectional: z.boolean().default(false).describe('Also return bidirectional (mutual) link pairs involving this note'),
+        limit: z.coerce.number().default(50).describe('Maximum number of results to return'),
+        offset: z.coerce.number().default(0).describe('Number of results to skip (for pagination)'),
+      },
+      outputSchema: GetBacklinksOutputSchema,
+    },
+    async ({ path: notePath, include_context, include_bidirectional, limit: requestedLimit, offset }): Promise<{
+      content: Array<{ type: 'text'; text: string }>;
+      structuredContent: GetBacklinksOutput;
+    }> => {
+      requireIndex();
+      const limit = Math.min(requestedLimit ?? 50, MAX_LIMIT);
+      const index = getIndex();
+      const vaultPath = getVaultPath();
+
+      // Try to resolve the path if it's just a title
+      let resolvedPath = notePath;
+      if (!notePath.endsWith('.md')) {
+        const resolved = resolveTarget(index, notePath);
+        if (resolved) {
+          resolvedPath = resolved;
+        } else {
+          resolvedPath = notePath + '.md';
+        }
+      }
+
+      // Get backlinks
+      const allBacklinks = getBacklinksForNote(index, resolvedPath);
+      const backlinks = allBacklinks.slice(offset, offset + limit);
+
+      // Enhance with context if requested
+      const results = await Promise.all(
+        backlinks.map(async (bl) => {
+          const result: {
+            source: string;
+            line: number;
+            context?: string;
+          } = {
+            source: bl.source,
+            line: bl.line,
+          };
+
+          if (include_context) {
+            result.context = await getContext(vaultPath, bl.source, bl.line);
+          }
+
+          return result;
+        })
+      );
+
+      // Format response with structured content
+      const output: GetBacklinksOutput = {
+        note: resolvedPath,
+        backlink_count: allBacklinks.length,
+        returned_count: results.length,
+        backlinks: results,
+      };
+
+      // Optionally include bidirectional pairs
+      if (include_bidirectional) {
+        const biPairs = findBidirectionalLinks(index, resolvedPath);
+        (output as any).bidirectional_pairs = biPairs;
+        (output as any).bidirectional_count = biPairs.length;
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(output, null, 2),
+          },
+        ],
+        structuredContent: output,
+      };
+    }
+  );
+
+  // get_forward_links - What notes does this note link TO?
+  const ForwardLinkItemSchema = z.object({
+    target: z.string().describe('The link target as written'),
+    alias: z.string().optional().describe('Display text if using [[target|alias]] syntax'),
+    line: z.coerce.number().describe('Line number where the link appears'),
+    resolved_path: z.string().optional().describe('Resolved path if target exists'),
+    exists: z.boolean().describe('Whether the target note exists'),
+  });
+
+  const GetForwardLinksOutputSchema = {
+    note: z.string().describe('The source note path'),
+    forward_link_count: z.coerce.number().describe('Total number of forward links'),
+    forward_links: z.array(ForwardLinkItemSchema).describe('List of forward links'),
+  };
+
+  type GetForwardLinksOutput = {
+    note: string;
+    forward_link_count: number;
+    forward_links: Array<{
+      target: string;
+      alias?: string;
+      line: number;
+      resolved_path?: string;
+      exists: boolean;
+    }>;
+  };
+
+  server.registerTool(
+    'get_forward_links',
+    {
+      title: 'Get Forward Links',
+      description: 'Use when listing which notes a given note links to. Produces outgoing wikilink targets with resolved paths and existence status. Returns forward link entries with alias text. Does not return incoming links — use get_backlinks for that.',
+      inputSchema: {
+        path: z.string().describe('Path to the note (e.g., "daily/2024-01-15.md" or just "My Note")'),
+      },
+      outputSchema: GetForwardLinksOutputSchema,
+    },
+    async ({ path: notePath }): Promise<{
+      content: Array<{ type: 'text'; text: string }>;
+      structuredContent: GetForwardLinksOutput;
+    }> => {
+      requireIndex();
+      const index = getIndex();
+
+      // Try to resolve the path if it's just a title
+      let resolvedPath = notePath;
+      if (!notePath.endsWith('.md')) {
+        const resolved = resolveTarget(index, notePath);
+        if (resolved) {
+          resolvedPath = resolved;
+        } else {
+          resolvedPath = notePath + '.md';
+        }
+      }
+
+      // Get forward links
+      const forwardLinks = getForwardLinksForNote(index, resolvedPath);
+
+      const output: GetForwardLinksOutput = {
+        note: resolvedPath,
+        forward_link_count: forwardLinks.length,
+        forward_links: forwardLinks.map((link) => ({
+          target: link.target,
+          alias: link.alias,
+          line: link.line,
+          resolved_path: link.resolvedPath,
+          exists: link.exists,
+        })),
+      };
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(output, null, 2),
+          },
+        ],
+        structuredContent: output,
+      };
+    }
+  );
+
+  // get_weighted_links - Get outgoing links with edge weights
+  server.tool(
+    'get_weighted_links',
+    'Use when ranking outgoing links from a note by relationship strength. Produces weighted link entries reflecting edge survival, co-session access, and source activity. Returns ranked outgoing links with weight scores. Does not include incoming links — use get_strong_connections for bidirectional.',
+    {
+      path: z.string().describe('Path to the note (e.g., "daily/2026-02-24.md")'),
+      min_weight: z.number().default(1.0).describe('Minimum weight threshold (default 1.0)'),
+      limit: z.number().default(20).describe('Maximum number of results to return'),
+    },
+    async ({ path: notePath, min_weight, limit: requestedLimit }) => {
+      const stateDb = getStateDb?.();
+      if (!stateDb) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'StateDb not initialized' }) }] };
+      }
+
+      const limit = Math.min(requestedLimit ?? 20, MAX_LIMIT);
+      const now = Date.now();
+
+      const rows = stateDb.db.prepare(`
+        SELECT target, weight, weight_updated_at
+        FROM note_links
+        WHERE note_path = ?
+        ORDER BY weight DESC
+      `).all(notePath) as Array<{ target: string; weight: number; weight_updated_at: number | null }>;
+
+      const results = rows
+        .map(row => {
+          const daysSinceUpdated = row.weight_updated_at
+            ? (now - row.weight_updated_at) / (1000 * 60 * 60 * 24)
+            : 0;
+          const decayFactor = Math.max(0.1, 1.0 - daysSinceUpdated / 180);
+          const effectiveWeight = Math.round(row.weight * decayFactor * 1000) / 1000;
+          return {
+            target: row.target,
+            weight: row.weight,
+            weight_effective: effectiveWeight,
+            last_updated: row.weight_updated_at,
+          };
+        })
+        .filter(r => r.weight_effective >= min_weight)
+        .slice(0, limit);
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            note: notePath,
+            count: results.length,
+            links: results,
+          }, null, 2),
+        }],
+      };
+    }
+  );
+
+  // get_strong_connections - Bidirectional connections ranked by combined weight
+  server.tool(
+    'get_strong_connections',
+    'Use when finding the most important relationships for a note in both directions. Produces bidirectional connections ranked by combined edge weight. Returns both incoming and outgoing links sorted by strength. Does not compute path distances — use get_link_path for shortest paths.',
+    {
+      path: z.string().describe('Path to the note (e.g., "daily/2026-02-24.md")'),
+      limit: z.number().default(20).describe('Maximum number of results to return'),
+    },
+    async ({ path: notePath, limit: requestedLimit }) => {
+      const stateDb = getStateDb?.();
+      if (!stateDb) {
+        return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'StateDb not initialized' }) }] };
+      }
+
+      const limit = Math.min(requestedLimit ?? 20, MAX_LIMIT);
+
+      // Resolve all inbound target identities (entity name, aliases, stem fallback)
+      const targets = getInboundTargetsForNote(stateDb, notePath);
+      const inPlaceholders = targets.map(() => '?').join(',');
+
+      const rows = stateDb.db.prepare(`
+        SELECT target AS node, weight, 'outgoing' AS direction
+        FROM note_links WHERE note_path = ?
+        UNION ALL
+        SELECT note_path AS node, MAX(weight) AS weight, 'incoming' AS direction
+        FROM note_links WHERE target IN (${inPlaceholders})
+        GROUP BY note_path
+        ORDER BY weight DESC
+        LIMIT ?
+      `).all(notePath, ...targets, limit) as Array<{ node: string; weight: number; direction: string }>;
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            note: notePath,
+            count: rows.length,
+            connections: rows.map(r => ({
+              node: r.node,
+              weight: r.weight,
+              direction: r.direction,
+            })),
+          }, null, 2),
+        }],
+      };
+    }
+  );
+
+}


### PR DESCRIPTION
## Summary
- Restored `get_backlinks`, `get_forward_links`, `get_weighted_links`, `get_strong_connections` from git history — Crank graph panel was showing only 1 connection because these tools were retired in T31 but Crank still calls them
- Expanded `FRONTMATTER_TYPE_MAP` from ~45 to ~170 entries (added client, knowledge, checklist, playbook, spec, roadmap, etc.)
- Expanded `FOLDER_CATEGORY_MAP` from ~28 to ~65 entries (added clients, knowledge, admin, invoices, etc.)
- Added OpenScreen demo recording script for Carter Strategy

## Test plan
- [x] Build passes
- [x] Startup validation tests pass (TOOL_CATEGORY/TOOL_TIER parity)
- [ ] Restart flywheel-demo, verify Crank graph shows multiple connections on daily note
- [ ] Verify Rate Card categorized as concepts, not people
- [ ] Run Carter Strategy demo Beat 1 through Beat 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)