### PR TITLE
feat: add daily note template and formatting rules for carter demo

### DIFF
--- a/demos/carter-strategy/.flywheel/policies/create-daily-note.yaml
+++ b/demos/carter-strategy/.flywheel/policies/create-daily-note.yaml
@@ -21,29 +21,9 @@ steps:
     when: "{{conditions.note_exists | negate}}"
     params:
       path: "daily-notes/{{variables.target_date}}.md"
+      template: "templates/daily-note.md"
       frontmatter:
-        type: daily
         date: "{{variables.target_date}}"
-        billable_hours: 0
-        clients_worked: []
-        tags:
-          - daily
-          - work-log
-      content: |
-        # {{variables.target_date}}
-
-        ## Log
-
-        ## Billable Summary
-
-        | Client | Hours | Rate | Amount |
-        |--------|-------|------|--------|
-
-        ## Tasks
-
-        ## Notes
-
-        ## Related
 
 output:
   summary: "Daily note for {{variables.target_date}} created"

--- a/demos/carter-strategy/daily-notes/CLAUDE.md
+++ b/demos/carter-strategy/daily-notes/CLAUDE.md
@@ -1,0 +1,21 @@
+# Daily Notes Rules
+
+## Creating daily notes
+
+Always use the `create-daily-note` policy: `policy action=execute name=create-daily-note variables={"target_date":"YYYY-MM-DD"}`
+
+This creates the note from the template with the correct sections.
+
+## Writing to daily notes
+
+- Always write new entries to the **Log** section using `vault_add_to_section`
+- Each entry is a timestamped bullet: `- HH:MM - content here`
+- Use 24-hour time format
+- Apply auto-wikilinks and suggest outgoing links (`suggestOutgoingLinks: true`)
+- Never write to the Notes section for logged activity — Notes is for standalone observations only
+
+### Example Log entry
+
+```
+- 18:00 - Call with [[Sarah Mitchell]] and [[James Rodriguez]] ([[Acme Corp]]) — [[UAT]] complete, [[Marcus Webb]]'s validation scripts passed, hitting 3x performance target. Cutover locked for March 28-29.
+```

--- a/demos/carter-strategy/templates/daily-note.md
+++ b/demos/carter-strategy/templates/daily-note.md
@@ -1,0 +1,23 @@
+---
+type: daily
+date: '{{date}}'
+billable_hours: 0
+clients_worked: []
+tags:
+  - daily
+  - work-log
+---
+# {{date}}
+
+## Log
+
+## Billable Summary
+
+| Client | Hours | Rate | Amount |
+|--------|-------|------|--------|
+
+## Tasks
+
+## Notes
+
+## Related


### PR DESCRIPTION
## Summary
- Added `templates/daily-note.md` with standard sections (Log, Billable Summary, Tasks, Notes, Related)
- Updated `create-daily-note` policy to use the template file
- Added `daily-notes/CLAUDE.md` rule: entries go to Log section with timestamped bullets (`- HH:MM - content`)

## Test plan
- [ ] Run Beat 1 of carter demo — daily note should be created from template with entry in Log section

🤖 Generated with [Claude Code](https://claude.com/claude-code)