### PR TITLE
docs: use Acme subgraph image, mention graph export

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Every mutation is git-committed, conflict-detected with a SHA-256 content hash, 
 
 ### Build context over time
 
-Every accepted link strengthens the graph. Every rejected link updates the scorer. Every write adds more context for the next read. `brief` assembles a token-budgeted summary of recent activity, and `memory` persists observations with confidence decay. [Configuration ->](docs/CONFIGURATION.md)
+Every accepted link strengthens the graph. Every rejected link updates the scorer. Every write adds more context for the next read. `brief` assembles a token-budgeted summary of recent activity, and `memory` persists observations with confidence decay. The graph can be exported as GraphML for visualization in tools like [Gephi](https://gephi.org) or NetworkX — see the [carter-strategy demo](demos/carter-strategy/) for an example. [Configuration ->](docs/CONFIGURATION.md)
 
 ---
 

--- a/demos/carter-strategy/README.md
+++ b/demos/carter-strategy/README.md
@@ -163,11 +163,11 @@ Zero file reads needed.
 
 ### Knowledge Graph Export
 
-The vault's knowledge graph, exported via `export_graph` and visualized with NetworkX + matplotlib:
+The vault's knowledge graph, exported as GraphML via `graph_analysis` and visualized with NetworkX + matplotlib:
 
-![Carter Strategy Knowledge Graph](carter-strategy-graph.png)
+![Acme Corp Knowledge Graph](carter-strategy-acme-graph.png)
 
-**88 nodes** (40 entities + 48 notes) and **434 edges** (wikilinks + weighted connections). People in blue, projects in green, documents in orange, invoices at the periphery. The hub structure shows Acme Corp's central role across the practice.
+Acme Corp subgraph — the largest client hub with its surrounding team members, invoices, projects, and daily notes. Node size reflects connection count; edge colors distinguish link types. The full vault graph and GraphML files are also included in this directory.
 
 **Download and explore yourself:**
 - [carter-strategy.graphml](carter-strategy.graphml) — open in [Gephi](https://gephi.org), [yEd](https://www.yworks.com/products/yed), or [Cytoscape](https://cytoscape.org)


### PR DESCRIPTION
## Summary
- Swap carter-strategy README graph image from full vault graph to Acme Corp subgraph — clearer visual of hub structure
- Fix reference to nonexistent `export_graph` tool (now references `graph_analysis` + GraphML)
- Add graph export/visualization mention to main README "Build context over time" section

## Test plan
- [ ] Verify image renders on GitHub
- [ ] Verify no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)