### PR TITLE
fix: Windows path casing mismatch in watcher

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -55,7 +55,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.5.4",
+    "@velvetmonkey/vault-core": "^2.5.5",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/mcp-server/src/core/read/watch/pathFilter.ts
+++ b/packages/mcp-server/src/core/read/watch/pathFilter.ts
@@ -106,8 +106,12 @@ export function normalizePath(filePath: string): string {
  * Get relative path from vault root
  */
 export function getRelativePath(vaultPath: string, filePath: string): string {
-  const relative = path.relative(vaultPath, filePath);
-  return normalizePath(relative);
+  // Normalize both paths before computing relative — on Windows, path.relative
+  // fails when casing differs (e.g. C:\Users vs c:/users from chokidar)
+  const normalizedVault = normalizePath(vaultPath);
+  const normalizedFile = normalizePath(filePath);
+  const relative = path.posix.relative(normalizedVault, normalizedFile);
+  return relative;
 }
 
 /**


### PR DESCRIPTION
Chokidar lowercases paths, vault path retains original case. path.relative fails, upsertNote double-joins. Fixes graph not populating on Windows.