### PR TITLE
fix: eliminate path round-trip causing Windows watcher failure

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -55,7 +55,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.5.5",
+    "@velvetmonkey/vault-core": "^2.5.6",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/mcp-server/src/core/read/watch/batchProcessor.ts
+++ b/packages/mcp-server/src/core/read/watch/batchProcessor.ts
@@ -98,7 +98,8 @@ export async function processBatch(
     // Process chunk concurrently
     const chunkResults = await Promise.allSettled(
       chunk.map(async (event) => {
-        const relativePath = getRelativePath(vaultPath, event.path);
+        // event.path is already vault-relative from the pipeline
+        const relativePath = event.path;
 
         if (event.type === 'delete') {
           return deleteNote(index, relativePath);
@@ -126,7 +127,6 @@ export async function processBatch(
       } else {
         failed++;
         const event = chunk[j];
-        const relativePath = getRelativePath(vaultPath, event.path);
         const error = result.reason instanceof Error
           ? result.reason
           : new Error(String(result.reason));
@@ -134,11 +134,11 @@ export async function processBatch(
         results.push({
           success: false,
           action: 'unchanged',
-          path: relativePath,
+          path: event.path,
           error,
         });
 
-        onError?.(relativePath, error);
+        onError?.(event.path, error);
       }
     }
 

--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -333,11 +333,12 @@ export class PipelineRunner {
       this.hasEntityRelevantChanges = true; // full rebuild — entity state unknown
       serverLog('watcher', `Index rebuilt (full): ${rebuilt.notes.size} notes, ${rebuilt.entities.size} entities`);
     } else {
-      const absoluteBatch = {
+      // Pass events with relative paths directly — batchProcessor handles joining with vaultPath
+      const relativeBatch = {
         ...p.batch,
-        events: p.events.map(e => ({ ...e, path: path.join(p.vp, e.path) })),
+        events: p.events,
       };
-      const batchResult = await processBatch(vaultIndex, p.vp, absoluteBatch, {
+      const batchResult = await processBatch(vaultIndex, p.vp, relativeBatch, {
         onError: (filePath, error) => {
           serverLog('watcher', `File processing error: ${filePath}: ${error.message}`, 'error');
         },


### PR DESCRIPTION
Paths were relative→absolute→relative, breaking on Windows casing. Now stays relative.