### PR TITLE
fix: normalize vault prefixes for Windows path casing in watcher

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -55,7 +55,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.5.6",
+    "@velvetmonkey/vault-core": "^2.5.7",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -126,6 +126,7 @@ import * as fs from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import type { CoalescedEvent, RenameEvent } from './core/read/watch/types.js';
 import type { BatchHandler } from './core/read/watch/index.js';
+import { normalizePath } from './core/read/watch/pathFilter.js';
 
 // Multi-vault
 import { VaultRegistry, parseVaultConfig, type VaultContext } from './vault-registry.js';
@@ -1186,12 +1187,12 @@ async function runPostIndexWork(ctx: VaultContext) {
         // Convert event paths from absolute to vault-relative
         // Handles symlink mismatches (e.g., WSL /mnt/c/ vs /home/user/ mounts)
         const vaultPrefixes = new Set([
-          vp.replace(/\\/g, '/'),
-          rvp,
+          normalizePath(vp),
+          normalizePath(rvp),
         ]);
         /** Normalize a single path from absolute to vault-relative */
         const normalizeEventPath = (rawPath: string): string => {
-          const normalized = rawPath.replace(/\\/g, '/');
+          const normalized = normalizePath(rawPath);
           for (const prefix of vaultPrefixes) {
             if (normalized.startsWith(prefix + '/')) {
               return normalized.slice(prefix.length + 1);


### PR DESCRIPTION
Event queue lowercases, vault prefix didn't. startsWith failed, paths stayed absolute, upsertNote double-joined. Reviewed with Gemini — confirmed correct approach.