### PR TITLE
fix: commit video file and fix README video embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Every accepted link strengthens the graph. Every rejected link updates the score
 
 From the [carter-strategy](demos/carter-strategy/) demo: log a call by voice, watch wikilinks and suggestions appear, accept and reject a few, then log again — the suggestions improve immediately.
 
-![Voice: The learning loop](demos/carter-strategy/carter-strategy-demo.mp4)
+https://github.com/velvetmonkey/flywheel-memory/raw/main/demos/carter-strategy/carter-strategy-demo.mp4
 
 ### Write: Auto-wikilinks on mutation
 


### PR DESCRIPTION
## Summary
- Commit carter-strategy demo video directly to repo (7.4MB)
- Use raw GitHub URL for video embed — no more expired `user-attachments` links
- Remove broken "Read" demo video embed (no replacement file)

## Test plan
- [ ] Verify video renders inline on GitHub after merge (note: raw URL points to `main`, so it will work once merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)