### PR TITLE
chore: move demo scripts to vault, add demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Every accepted link strengthens the graph. Every rejected link updates the score
 
 From the [carter-strategy](demos/carter-strategy/) demo: log a call by voice, watch wikilinks and suggestions appear, accept and reject a few, then log again — the suggestions improve immediately.
 
+https://github.com/user-attachments/assets/6da77945-ccea-405b-9995-30a07ab7c90e
+
 https://github.com/user-attachments/assets/bfdae034-6217-426e-bb1d-ff8e2f0d4bc3
 
 https://github.com/user-attachments/assets/4a0635ff-dd73-4fb1-933d-bf384822e2ce


### PR DESCRIPTION
## Summary
- Moved demo scripts (DEMO-OPENSCREEN-SCRIPT.md, DEMO-VIDEO-SCRIPT.md, DEMO-VOICE-PKM.md) out of the git repo and into the Obsidian vault
- Added new demo video as the first video in the README "Voice: The learning loop" section

## Test plan
- [ ] Verify README renders correctly on GitHub with all three videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)