### PR TITLE
chore: release v2.5.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,7 +5945,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.5.9",
+      "version": "2.5.10",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5971,13 +5971,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.5.9",
+      "version": "2.5.10",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@velvetmonkey/vault-core": "^2.5.9",
+        "@velvetmonkey/vault-core": "^2.5.10",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.5.9",
-  "description": "MCP tools that search, write, and auto-link your Obsidian vault \u2014 and learn from your edits.",
+  "version": "2.5.10",
+  "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -55,7 +55,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@velvetmonkey/vault-core": "^2.5.9",
+    "@velvetmonkey/vault-core": "^2.5.10",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary

- Bump vault-core and flywheel-memory to v2.5.10
- Update vault-core dependency pin

## Changes since v2.5.9

- **feat**: automatic index maintenance and deferred step execution (#252)
- **fix**: raise mutation benchmark threshold from 5x to 10x for CI (#251)

🤖 Generated with [Claude Code](https://claude.com/claude-code)