### PR TITLE
docs: soften quality claims + improve onboarding (T37, T38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Everything runs on your machine. Nothing leaves your disk. Every action is bound
 
 ### Search your vault
 
-One call returns everything the model needs to answer: frontmatter, scored backlinks and outlinks, snippets with section context, dates, entity bridges, and confidence. Under the hood, entities give the system stable identity, the graph gives it load-bearing structure, and semantic search bridges the gaps when meaning exists without an explicit link. Keyword search (BM25) finds what you said. Semantic search finds what you meant. Both are fused via Reciprocal Rank Fusion, running locally. [How search works ->](docs/ARCHITECTURE.md)
+One call returns everything the model needs to answer: frontmatter, scored backlinks and outlinks, snippets with section context, dates, entity bridges, and confidence. Under the hood, entities give the system stable identity, the graph gives it load-bearing structure, and semantic search surfaces related notes when no explicit link exists yet. Keyword search (BM25) finds what you said. Semantic search finds what you meant. Both are fused via Reciprocal Rank Fusion, running locally. [How search works ->](docs/ARCHITECTURE.md)
 
 ### Write safely
 
@@ -135,7 +135,7 @@ Then ask: *"How much have I billed Acme Corp?"*
 | [nexus-lab](demos/nexus-lab/) | PhD researcher | "How does AlphaFold connect to my experiment?" |
 | [zettelkasten](demos/zettelkasten/) | Zettelkasten student | "How does spaced repetition connect to active recall?" |
 
-### Install on your own vault
+### Your Vault in 2 Minutes
 
 Add `.mcp.json` to your vault root:
 
@@ -156,7 +156,7 @@ cd /path/to/your/vault && claude
 
 Flywheel watches the vault, maintains local indexes, and serves the graph to MCP clients. Your source of truth stays in markdown. If you delete `.flywheel/state.db`, Flywheel rebuilds from the vault.
 
-### Tool presets
+### Optional: Tool presets
 
 The `agent` preset (default) provides a focused set of core tools. Use `full` to expose the entire tool surface immediately, or `auto` for progressive disclosure via `discover_tools`.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,6 +4,8 @@
 
 Two layers of configuration: **environment variables** set in your MCP config (startup-time), and **runtime config** adjustable via the `flywheel_config` tool (persisted in StateDb). No config files to manage.
 
+> **First time?** You only need the [MCP Config](#mcp-config) section — one JSON block, zero environment variables. Everything else is optional.
+
 - [MCP Config](#mcp-config)
   - [Claude Code (`.mcp.json` in vault root)](#claude-code-mcpjson-in-vault-root)
   - [Claude Desktop (`claude_desktop_config.json`)](#claude-desktop-claude_desktop_configjson)


### PR DESCRIPTION
## Summary

- **T37:** Replace "bridges the gaps" with "surfaces related notes" — more accurate framing for semantic search
- **T38:** Rename install section to "Your Vault in 2 Minutes", prefix "Tool Presets" with "Optional:", add first-time callout to CONFIGURATION.md

## Test plan

- [x] README reads naturally with softened language
- [x] New user path is clearer: MCP Config → done, everything else optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)