### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,28 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@1c30734416d9b05948ccd7f4b3cf60baada87e9e
+        with:
+          mode: validate


### PR DESCRIPTION
Adding a lightweight CI workflow to validate structured metadata for this project, since the tool-call interface and layered scoring already produce a well-defined surface that's worth describing cleanly.

- Knowledge graph over Obsidian vaults with a 13-layer scoring model that learns over time
- Local-first, zero cloud — all writes go through visible tool calls
- Layered structure (| Layer | What it provides | Example |) makes the tool interface machine-readable

This PR adds a single GitHub Actions workflow at `.github/workflows/hol-skill-validate.yml` that runs the HOL skill validator in validate mode against the repo root. It checks schema and trust signals only, stays validate-only with no publishing step, and doesn't touch any runtime code.

Happy to adjust the workflow filename or skill directory if you'd prefer a different path.