### PR TITLE
Fix demos dual-tracking: reset via outer repo

### DIFF
--- a/demos/run-action-coverage-test.sh
+++ b/demos/run-action-coverage-test.sh
@@ -31,11 +31,14 @@ mkdir -p "$RESULTS_DIR/raw"
 # auto-memory entries that shadow fresh tool calls. Without this, tests like
 # memory_store and entity_dismiss_merge silently pass against stale state from
 # previous runs instead of exercising the MCP tool surface.
+#
+# Reset via the outer flywheel-memory repo (not a nested .git inside the demo
+# dir). A nested repo caused dual-tracking pollution where the inner HEAD
+# diverged from the outer repo's tracked snapshot and phantom diffs leaked
+# into unrelated PRs.
 echo "Resetting demo vault and Claude auto-memory to clean state..."
-if [[ -d "$DEMO_DIR/.git" ]]; then
-  git -C "$DEMO_DIR" checkout -- . 2>/dev/null || true
-  git -C "$DEMO_DIR" clean -fd 2>/dev/null || true
-fi
+git -C "$REPO_ROOT" checkout -- demos/carter-strategy/ 2>/dev/null || true
+git -C "$REPO_ROOT" clean -fd demos/carter-strategy/ 2>/dev/null || true
 rm -rf "$HOME/.claude/projects/-home-ben-src-flywheel-memory-demos-carter-strategy"
 
 # Parse prompts


### PR DESCRIPTION
## Summary
- Remove nested \`.git\` inside \`demos/carter-strategy/\` that had accumulated Flywheel test-run auto-commits and diverged from the outer repo's tracked snapshot
- Update \`demos/run-action-coverage-test.sh\` to reset via the outer flywheel-memory repo instead of the inner nested repo

## Why
The action-coverage harness was calling \`git -C "\$DEMO_DIR" checkout -- .\` against a nested \`.git\` whose HEAD had drifted (e.g. \`[Flywheel:Replace] Update Acme Data Migration.md\` commits from test runs). From the outer repo's perspective, that left phantom diffs — 30+ modified or deleted files leaking into unrelated PRs (caught on #285).

Removing the nested repo makes \`demos/carter-strategy/\` a plain tracked directory. The harness now resets through the outer repo, which is the snapshot humans actually review.

## Test plan
- [ ] CI green on the one-file harness change
- [ ] Next action-coverage run reports a clean working tree before execution