### PR TITLE
docs: scrub remaining retired-tool references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,18 +29,16 @@ packages/mcp-server/src/
 │   ├── read/                   # Read-side tool registrations (20 files, helpers omitted)
 │   │   ├── query.ts            # search
 │   │   ├── primitives.ts       # get_note_structure, get_section_content, find_sections, tasks
-│   │   ├── graphAnalysis.ts    # graph_analysis (7 modes), list_entities, get_connection_strength,
+│   │   ├── graphAnalysis.ts    # graph_analysis (7 modes), get_connection_strength,
 │   │   │                       #   get_link_path, get_common_neighbors
-│   │   ├── semanticAnalysis.ts # semantic_analysis (clusters, bridges)
-│   │   ├── system.ts           # refresh_index, suggest_entity_aliases, unlinked_mentions_report
+│   │   ├── system.ts           # refresh_index, list_entities, suggest_entity_aliases
 │   │   ├── health.ts           # flywheel_doctor, pipeline_status, server_log
 │   │   ├── vaultSchema.ts      # vault_schema, schema_conventions, schema_validate
 │   │   ├── noteIntelligence.ts # note_intelligence
 │   │   ├── wikilinks.ts        # suggest_wikilinks, validate_links, discover_stub_candidates,
-│   │   │                       #   discover_cooccurrence_gaps, suggest_entity_aliases, unlinked_mentions_report
+│   │   │                       #   discover_cooccurrence_gaps
 │   │   ├── migrations.ts       # rename_field, migrate_field_values
 │   │   ├── metrics.ts          # vault_growth
-│   │   ├── merges.ts           # suggest_entity_merges, dismiss_merge_suggestion
 │   │   ├── similarity.ts       # find_similar
 │   │   ├── semantic.ts         # init_semantic
 │   │   └── brief.ts            # brief
@@ -53,11 +51,9 @@ packages/mcp-server/src/
 │       ├── merge.ts            # merge_entities, absorb_as_alias
 │       ├── corrections.ts      # vault_record_correction, vault_list_corrections, vault_resolve_correction
 │       ├── wikilinkFeedback.ts # wikilink_feedback
-│       ├── toolSelectionFeedback.ts # tool_selection_feedback
 │       ├── tags.ts             # rename_tag
 │       ├── memory.ts           # memory
 │       ├── config.ts           # flywheel_config
-│       ├── enrich.ts           # vault_init
 │       ├── system.ts           # vault_undo_last_mutation
 │       └── policy.ts           # policy
 ├── core/

--- a/demos/hotpotqa/run-benchmark.sh
+++ b/demos/hotpotqa/run-benchmark.sh
@@ -57,13 +57,12 @@ warmup_config=$(cat <<EOF
 EOF
 )
 
-echo "Pre-warming vault: index + auto-link + embeddings..."
+echo "Pre-warming vault: index + embeddings..."
 if claude -p "Bootstrap this vault for benchmarking. Run these steps in order:
-1. Call health_check — report entity_count and note_count.
-2. Call vault_init with mode='enrich' and dry_run=false to auto-link all notes with wikilinks.
-3. Call refresh_index to re-index with the new wikilinks.
-4. Call init_semantic to build embeddings. Wait for completion.
-5. Call health_check — confirm fts5_ready=true and embeddings_ready=true.
+1. Call flywheel_doctor — report entity_count and note_count.
+2. Call refresh_index to build the full-text index.
+3. Call init_semantic to build embeddings. Wait for completion.
+4. Call flywheel_doctor — confirm fts5_ready=true and embeddings_ready=true.
 Report final status with entity_count, note_count, and embeddings_ready." \
   --output-format stream-json \
   --no-session-persistence \
@@ -72,7 +71,7 @@ Report final status with entity_count, note_count, and embeddings_ready." \
   --strict-mcp-config \
   --model haiku \
   > "$RESULTS_DIR/warmup.jsonl" 2>"$RESULTS_DIR/warmup.stderr"; then
-  echo "Vault pre-warmed (index + auto-link + embeddings)"
+  echo "Vault pre-warmed (index + embeddings)"
 else
   echo "WARNING: Pre-warm failed (exit $?) — continuing anyway"
 fi

--- a/demos/locomo/run-benchmark.sh
+++ b/demos/locomo/run-benchmark.sh
@@ -127,7 +127,7 @@ EOF
 )
 
 # Pre-warm: ensure vault is fully indexed + embeddings built before questions start
-# Uses full preset (health_check, refresh_index, init_semantic) for bootstrap
+# Uses full,memory preset (flywheel_doctor, refresh_index, init_semantic) for bootstrap
 warmup_config=$(cat <<EOF
 {"mcpServers":{"flywheel":{"command":"node","args":["$MCP_SERVER"],"env":{"PROJECT_PATH":"$VAULT_DIR","FLYWHEEL_TOOLS":"full,memory"}}}}
 EOF
@@ -136,13 +136,12 @@ EOF
 if [[ -n "${RESUME:-}" ]] && [[ -f "$RESULTS_DIR/warmup.jsonl" ]]; then
   echo "Resuming — skipping warmup (already done)"
 else
-echo "Pre-warming vault: index + auto-link + embeddings..."
+echo "Pre-warming vault: index + embeddings..."
 if claude -p "Bootstrap this vault for benchmarking. Run these steps in order:
-1. Call health_check — report entity_count and note_count.
-2. Call vault_init with mode='enrich' and dry_run=false to auto-link all notes with wikilinks.
-3. Call refresh_index to re-index with the new wikilinks.
-4. Call init_semantic to build embeddings. Wait for completion.
-5. Call health_check — confirm fts5_ready=true and embeddings_ready=true.
+1. Call flywheel_doctor — report entity_count and note_count.
+2. Call refresh_index to build the full-text index.
+3. Call init_semantic to build embeddings. Wait for completion.
+4. Call flywheel_doctor — confirm fts5_ready=true and embeddings_ready=true.
 Report final status with entity_count, note_count, and embeddings_ready." \
   --output-format stream-json \
   --no-session-persistence \
@@ -151,7 +150,7 @@ Report final status with entity_count, note_count, and embeddings_ready." \
   --strict-mcp-config \
   --model haiku \
   > "$RESULTS_DIR/warmup.jsonl" 2>"$RESULTS_DIR/warmup.stderr"; then
-  echo "Vault pre-warmed (index + auto-link + embeddings)"
+  echo "Vault pre-warmed (index + embeddings)"
 else
   echo "WARNING: Pre-warm failed (exit $?) — continuing anyway"
 fi

--- a/docs/ALGORITHM.md
+++ b/docs/ALGORITHM.md
@@ -572,7 +572,7 @@ Flywheel uses embeddings in two complementary ways:
 
 **Inside the scoring pipeline (Layer 12)** -- Entity-level embeddings participate directly in wikilink scoring. When you write about "deployment automation", Layer 12 finds `[[CI/CD]]` at similarity 0.72 even though those words don't appear in the content. This is the same deterministic pipeline -- the semantic boost is just another number in the sum.
 
-**Alongside the scoring pipeline** -- Note-level embeddings power `search` (hybrid mode) and `find_similar` via Reciprocal Rank Fusion. The `semantic_analysis` tool provides `clusters` and `bridges` modes. These serve different purposes: discovery and exploration rather than wikilink suggestions.
+**Alongside the scoring pipeline** -- Note-level embeddings power `search` (hybrid mode) and `find_similar` via Reciprocal Rank Fusion. These serve a different purpose from wikilink scoring: broad discovery and exploration across the vault rather than per-entity suggestion.
 
 Five properties of the scoring pipeline remain unchanged:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,7 +74,6 @@ packages/
 │       │   │   ├── query.ts     # search (unified: metadata + content + entities)
 │       │   │   ├── graphAdvanced.ts  # get_link_path, get_common_neighbors, get_connection_strength
 │       │   │   ├── graphAnalysis.ts  # graph_analysis (7 modes + centrality + cycles)
-│       │   │   ├── semanticAnalysis.ts # semantic_analysis (clusters, bridges)
 │       │   │   ├── vaultSchema.ts    # vault_schema (unified: overview, field_values, inconsistencies, validate, conventions, incomplete)
 │       │   │   ├── noteIntelligence.ts # note_intelligence (unified: prose_patterns, suggest_frontmatter, suggest_wikilinks, compute, semantic_links)
 │       │   │   ├── primitives.ts     # get_note_structure, get_section_content, find_sections, tasks
@@ -93,8 +92,7 @@ packages/
 │       │       ├── system.ts    # vault_undo_last_mutation
 │       │       ├── policy.ts    # policy (unified: list, validate, preview, execute, author, revise)
 │       │       ├── memory.ts    # memory (agent working memory)
-│       │       ├── config.ts    # flywheel_config (runtime configuration)
-│       │       └── toolSelectionFeedback.ts # tool_selection_feedback
+│       │       └── config.ts    # flywheel_config (runtime configuration)
 │       ├── core/
 │       │   ├── read/            # Read-side core logic
 │       │   │   ├── graph.ts     # Index building, backlinks, hubs, orphans, path finding
@@ -272,7 +270,7 @@ In addition to note-level embeddings, Flywheel builds entity-level embeddings fo
 
 **Integration points:**
 - **Layer 9 scoring** in `suggestRelatedLinks()`  --  cosine similarity against in-memory entity embeddings
-- **Semantic analysis**  --  `semantic_analysis` tool (clusters, bridges)
+- **Hybrid search**  --  note embeddings power `search` (BM25 + semantic via RRF) and `find_similar`
 - **Semantic note intelligence**  --  `semantic_links` mode in `note_intelligence`
 - **Preflight duplicate detection**  --  `vault_create_note` checks semantic similarity before creation
 - **Broken link fallback**  --  `validate_links` uses embedding similarity to suggest corrections

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -65,9 +65,9 @@ Typical latency for common tool calls (1,500-note vault, index warm):
 | `suggest_wikilinks` (detail) | 20–50ms | With 13-layer scoring |
 | `get_note_structure` | 1–3ms | Single file read + parse |
 | `get_backlinks` | 1–5ms | Index lookup |
-| `health_check` | 10–30ms | Aggregates multiple subsystems |
+| `flywheel_doctor` | 10–30ms | Aggregates subsystem health (FTS5, embeddings, indexes) |
 | `vault_add_to_section` | 5–20ms | Read + parse + write + hash check |
-| `temporal_summary` | 50–200ms | Composes 3 tools |
+| `track_concept_evolution` | 50–200ms | Composes temporal + graph queries |
 
 ## StateDb Disk Usage
 

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -27,8 +27,7 @@ All examples assume Flywheel is connected to your vault. See [SETUP.md](SETUP.md
   - [Enable hybrid search](#enable-hybrid-search)
   - [Search by concept](#search-by-concept)
   - [Find similar notes](#find-similar-notes)
-  - [Discover semantic bridges](#discover-semantic-bridges)
-  - [Cluster by meaning](#cluster-by-meaning)
+  - [Find missing connections](#find-missing-connections)
   - [Find semantic links for a note](#find-semantic-links-for-a-note)
   - [Inspect semantic scoring](#inspect-semantic-scoring)
 - [Maintenance](#maintenance)
@@ -209,17 +208,11 @@ When embeddings exist, search automatically uses hybrid ranking (keyword + seman
 
 `find_similar` combines keyword and semantic matching when the semantic index is built, surfacing conceptually related notes even if they don't share keywords.
 
-### Discover semantic bridges
+### Find missing connections
 
-> "Find notes that are conceptually related but have no link between them"
+> "Find pairs of entities I write about together that don't have a link between them"
 
-Uses `semantic_analysis({ type: "bridges" })` to discover high-value missing connections. Great for finding notes that *should* be linked but aren't.
-
-### Cluster by meaning
-
-> "Group my notes by semantic similarity instead of folder structure"
-
-Uses `semantic_analysis({ type: "clusters" })` to organize notes by what they're about, not where they live.
+Uses `graph({ action: "cooccurrence_gaps" })` to surface entity pairs that co-occur in notes but lack a direct link — concrete candidates for new connections, backed by the evidence notes.
 
 ### Find semantic links for a note
 
@@ -388,4 +381,4 @@ Manage vault-wide changes.
 - **Let auto-wikilinks work.** When writing through Flywheel, entity mentions are linked automatically. Write naturally -- don't add `[[brackets]]` yourself.
 - **Check before deleting.** `vault_delete_note` shows backlink warnings before deletion. If a note has backlinks, consider moving or renaming instead.
 - **Dry-run any write.** All write tools accept `dry_run: true` to preview changes without modifying files. Bulk tools (`rename_field`, `migrate_field_values`) default to dry-run mode.
-- **Build the semantic index once** — `init_semantic` now builds both note embeddings (for hybrid search) and entity embeddings (for semantic wikilink scoring). Takes ~2-3 minutes for 500 entities. After that, wikilink suggestions gain semantic understanding, and new analyses unlock: `semantic_analysis` (clusters, bridges), `semantic_links`.
+- **Build the semantic index once** — `init_semantic` builds both note embeddings (for hybrid search via `search` and `find_similar`) and entity embeddings (for semantic wikilink scoring). Takes ~2-3 minutes for 500 entities. After that, wikilink suggestions gain semantic understanding and the `semantic_links` mode in `note_intelligence` becomes available.

--- a/docs/PROVE-IT.md
+++ b/docs/PROVE-IT.md
@@ -246,7 +246,7 @@ COUNT=500 demos/hotpotqa/run-benchmark.sh
 
 What happens under the hood:
 
-1. **Pre-warm** (1 Claude Haiku session): `health_check` -> `vault_init` (auto-link) -> `refresh_index` -> `init_semantic` (embeddings) -> `health_check`. This matches production usage -- Flywheel indexes and links the vault before questions start.
+1. **Pre-warm** (1 Claude Haiku session): `flywheel_doctor` -> `refresh_index` -> `init_semantic` (embeddings) -> `flywheel_doctor`. This matches production usage -- Flywheel indexes and embeds the vault before questions start. (Auto-wikilinks are applied on write, so they accrue naturally as the vault is populated.)
 2. **500 questions** (500 individual Claude Sonnet sessions): Each question gets its own `claude -p` session with `--strict-mcp-config` (no filesystem access, vault tools only). Claude decides which tools to call. Non-MCP tools (Bash, Grep, Read, etc.) are stripped via `--disallowedTools`.
 3. **Analysis**: Python script parses JSONL output, computes document recall against ground truth.
 
@@ -312,7 +312,7 @@ demos/locomo/run-benchmark.sh
 
 What happens under the hood:
 
-1. **Pre-warm** (1 Claude Haiku session with `full,memory` preset): `health_check` -> `vault_init` (auto-link) -> `refresh_index` -> `init_semantic` (embeddings) -> `health_check`.
+1. **Pre-warm** (1 Claude Haiku session with `full,memory` preset): `flywheel_doctor` -> `refresh_index` -> `init_semantic` (embeddings) -> `flywheel_doctor`.
 2. **Stratified sampling**: Python selects 695 questions balanced across all 5 categories (commonsense, single-hop, multi-hop, temporal, adversarial) and all 10 conversations (seed 42).
 3. **695 questions** (695 individual Claude Sonnet sessions): Each question gets its own `claude -p` session with `--strict-mcp-config`. Claude is told notes are conversation sessions and uses search + read tools to find evidence and answer.
 4. **Analysis**: Python script computes evidence recall and token F1 per category.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -598,7 +598,7 @@ This runs `init_semantic`, which builds **two** indexes:
 ### Entity Embeddings (Semantic Wikilinks + Graph Analysis)
 - Embeds all vault entities (note titles, aliases, categories)
 - After build: wikilink suggestions gain **semantic scoring** — content about "deployment automation" can suggest `[[CI/CD]]` without keyword matches
-- Unlocks `semantic_analysis` tool (clusters, bridges) and `semantic_links` in `note_intelligence`
+- Unlocks `semantic_links` in `note_intelligence` for per-note missing-entity suggestions
 
 ### Build Details
 
@@ -614,9 +614,8 @@ This runs `init_semantic`, which builds **two** indexes:
 
 After building semantic embeddings:
 
+- **Hybrid search**: `search` and `find_similar` combine BM25 + semantic matching via Reciprocal Rank Fusion — concept queries surface notes that don't share keywords
 - **Wikilink suggestions**: Semantic scoring finds conceptual links that keyword matching misses
-- **Semantic bridges**: `semantic_analysis({ type: "bridges" })` — find notes that should be connected but aren't
-- **Semantic clusters**: `semantic_analysis({ type: "clusters" })` — group notes by meaning, not folder
 - **Semantic links**: `note_intelligence({ analysis: "semantic_links" })` — find missing entity links for a specific note
 - **Preflight checks**: `vault_create_note` warns when a semantically similar note already exists
 - **Broken link recovery**: `validate_links` suggests fixes via semantic similarity when exact matches fail


### PR DESCRIPTION
## Summary

Follow-up to #287. That PR used codegen to fix drift in the four highest-leverage files (`README.md`, `CLAUDE.md`, `docs/CONFIGURATION.md`, `docs/TOOLS.md` TOC/At-a-Glance). This PR hand-edits the remaining prose / architecture descriptions that can't be mechanically derived, plus two benchmark scripts that were silently broken.

A roundtable review (Codex + Gemini) on the initial 4-file audit flagged two high-impact files I'd missed: `docs/COOKBOOK.md` (broken user-facing tutorial examples) and `docs/ALGORITHM.md` (stale feature description). Both are now in scope.

## Changes

- **`CLAUDE.md`, `docs/ARCHITECTURE.md`** — drop stub source files from the architecture tree (`semanticAnalysis.ts`, `merges.ts`, `toolSelectionFeedback.ts`, `enrich.ts`), fix stale registration listings for `system.ts` (now correctly lists `refresh_index`, `list_entities`, `suggest_entity_aliases`) and `wikilinks.ts` (drops nonexistent entries).
- **`docs/COOKBOOK.md`** — the "Discover semantic bridges" and "Cluster by meaning" sections were literal broken examples calling `semantic_analysis({ type: "bridges" })` — a retired tool. Replaced with a single "Find missing connections" section backed by `graph({ action: "cooccurrence_gaps" })`, the real current path. TOC updated.
- **`docs/SETUP.md`** — the embedding-unlock list promised `semantic_analysis` (retired). Rewrote to highlight hybrid search via `search` + `find_similar` + RRF, which is the actual payoff users get from running `init_semantic`.
- **`docs/BENCHMARKS.md`** — latency table replaced `health_check` row with `flywheel_doctor` and `temporal_summary` row with `track_concept_evolution`.
- **`docs/ALGORITHM.md`** — struck the `semantic_analysis` mention from the "Vectors + Structure" section; note-level embeddings now correctly described as powering `search` (hybrid) and `find_similar` only.
- **`docs/PROVE-IT.md`** — pre-warm recipe at lines 249, 315 now matches what the benchmark scripts actually do: `flywheel_doctor` → `refresh_index` → `init_semantic` → `flywheel_doctor`.
- **`demos/hotpotqa/run-benchmark.sh`, `demos/locomo/run-benchmark.sh`** — the pre-warm prompts literally told Claude to call `health_check` and `vault_init`, both retired. The `|| continuing anyway` branch masked this as a silent failure. Replaced with `flywheel_doctor`; dropped the `vault_init enrich` step because auto-wikilinks apply on write (no bulk-enrichment MCP tool is currently exposed). This means the pre-warm has likely been partly non-functional since T43 — worth re-running the benchmarks after this lands.

## Intentionally NOT touched

- **`docs/ARCHITECTURE.md` line 623** — describes the `tool_selection_feedback` database table. The MCP _tool_ was retired, but the _table_ is still actively written by `core/shared/misrouteDetection.ts` for heuristic misroute detection. Schema description is still accurate.
- **`docs/ARCHITECTURE.md` line 471** — schema migration history entry (`v36 | Added tool_selection_feedback table`). Historical fact, not current-state drift.
- **`docs/TESTING.md`** — contains retired tool names inside captured benchmark-run tables (rows 523–781). Those are frozen historical snapshots; rewriting them would corrupt the record. If we ever want to refresh the benchmarks, regenerate the tables wholesale.

## Test plan

- [x] Underscore-form retired-tool grep across all 9 edited files — zero hits
- [x] Spaced-variant grep (`semantic bridges`, `temporal summary`, etc.) — only natural-language user queries remain ("Run a health check on my vault"), which still work via `flywheel_doctor`
- [x] `npx vitest run test/docs/doc-fragments.test.ts test/write/docs/tool-counts.test.ts` — 28/28 passing
- [ ] Full CI green on this branch
- [ ] After merge: consider re-running the hotpotqa/locomo benchmarks with the fixed pre-warm to confirm the numbers haven't regressed (or improved — if the pre-warm was silently failing, the embeddings may not have been fully built during recent runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)