### PR TITLE
fix(proactive): surface rejection reasons in queue drain (P42 Issue 2)

### DIFF
--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -17,6 +17,7 @@ import {
   rangeOverlapsProtectedZone,
   detectImplicitEntities,
   recordEntityMention,
+  setWriteState,
   type EntitySearchResult,
 } from '@velvetmonkey/vault-core';
 
@@ -1286,6 +1287,28 @@ export class PipelineRunner {
     if (totalApplied > 0) {
       serverLog('watcher', `Proactive drain: applied ${totalApplied} links in ${result.applied.length} files`);
     }
+    if (result.rejections.length > 0) {
+      const byReason: Record<string, number> = {};
+      for (const r of result.rejections) byReason[r.reason] = (byReason[r.reason] ?? 0) + 1;
+      const summary = Object.entries(byReason).map(([k, v]) => `${k}=${v}`).join(' ');
+      serverLog('watcher', `Proactive drain rejections: ${result.rejections.length} (${summary})`);
+    }
+
+    // Persist last-drain snapshot for doctor diagnostics. Cap rejection sample
+    // to avoid bloat — diagnostic surface, not durable audit log.
+    try {
+      setWriteState(p.sd, 'last_proactive_drain', {
+        at: Date.now(),
+        total_applied: totalApplied,
+        applied_files: result.applied.length,
+        expired: result.expired,
+        skipped_active: result.skippedActiveEdit,
+        skipped_mtime: result.skippedMtimeGuard,
+        skipped_daily_cap: result.skippedDailyCap,
+        rejection_count: result.rejections.length,
+        rejection_sample: result.rejections.slice(0, 25),
+      });
+    } catch { /* non-critical */ }
 
     return {
       applied: result.applied,
@@ -1294,6 +1317,7 @@ export class PipelineRunner {
       skipped_active: result.skippedActiveEdit,
       skipped_mtime: result.skippedMtimeGuard,
       skipped_daily_cap: result.skippedDailyCap,
+      rejections: result.rejections.length,
     };
   }
 

--- a/packages/mcp-server/src/core/write/proactiveQueue.ts
+++ b/packages/mcp-server/src/core/write/proactiveQueue.ts
@@ -24,12 +24,29 @@ export interface QueueEntry {
   confidence: string;
 }
 
+export type RejectionReason =
+  | 'active_edit'
+  | 'stat_failed'
+  | 'daily_cap'
+  | 'apply_empty'
+  | 'apply_error';
+
+export interface Rejection {
+  note_path: string;
+  entity: string;
+  score: number;
+  confidence: string;
+  reason: RejectionReason;
+  detail?: string;
+}
+
 export interface DrainResult {
   applied: Array<{ file: string; entities: string[] }>;
   expired: number;
   skippedActiveEdit: number;
   skippedMtimeGuard: number;
   skippedDailyCap: number;
+  rejections: Rejection[];
 }
 
 type ApplyFn = (
@@ -89,6 +106,25 @@ export async function drainProactiveQueue(
     skippedActiveEdit: 0,
     skippedMtimeGuard: 0,
     skippedDailyCap: 0,
+    rejections: [],
+  };
+
+  const pushRejections = (
+    filePath: string,
+    items: Array<{ entity: string; score: number; confidence: string }>,
+    reason: RejectionReason,
+    detail?: string,
+  ): void => {
+    for (const s of items) {
+      result.rejections.push({
+        note_path: filePath,
+        entity: s.entity,
+        score: s.score,
+        confidence: s.confidence,
+        reason,
+        ...(detail ? { detail } : {}),
+      });
+    }
   };
 
   // 1. Expire stale entries
@@ -134,10 +170,12 @@ export async function drainProactiveQueue(
       const mtime = statSync(fullPath).mtimeMs;
       if (Date.now() - mtime < MTIME_GUARD_MS) {
         result.skippedActiveEdit += suggestions.length;
+        pushRejections(filePath, suggestions, 'active_edit', `mtime age ${Date.now() - mtime}ms < ${MTIME_GUARD_MS}ms`);
         continue;
       }
-    } catch {
+    } catch (e) {
       result.skippedActiveEdit += suggestions.length;
+      pushRejections(filePath, suggestions, 'stat_failed', String(e));
       continue;
     }
 
@@ -145,6 +183,7 @@ export async function drainProactiveQueue(
     const todayCount = (countTodayApplied.get(filePath, todayStr) as { cnt: number }).cnt;
     if (todayCount >= config.maxPerDay) {
       result.skippedDailyCap += suggestions.length;
+      pushRejections(filePath, suggestions, 'daily_cap', `today=${todayCount} cap=${config.maxPerDay}`);
       // Mark these as expired since we won't apply them today
       for (const s of suggestions) {
         try {
@@ -171,12 +210,18 @@ export async function drainProactiveQueue(
         }
       }
 
-      // If all were skipped (mtime guard), leave as pending for next drain
-      if (applyResult.applied.length === 0 && applyResult.skipped.length > 0) {
-        result.skippedMtimeGuard += applyResult.skipped.length;
+      // Anything not in applied but in capped was rejected by applyFn
+      // (suppressed, common-word FP, apply produced 0 links, stat/read/write fail).
+      // Leave as pending — next drain retries. Record rejection reason.
+      const appliedSet = new Set(applyResult.applied);
+      const notApplied = capped.filter(s => !appliedSet.has(s.entity));
+      if (notApplied.length > 0) {
+        result.skippedMtimeGuard += notApplied.length;
+        pushRejections(filePath, notApplied, 'apply_empty', 'applyFn returned empty (suppressed, common-word, write failed, or 0 links added)');
       }
     } catch (e) {
       serverLog('watcher', `Proactive drain: error applying to ${filePath}: ${e}`, 'error');
+      pushRejections(filePath, capped, 'apply_error', String(e));
     }
   }
 

--- a/packages/mcp-server/src/tools/read/health.ts
+++ b/packages/mcp-server/src/tools/read/health.ts
@@ -10,7 +10,7 @@ import { resolveTarget, getBacklinksForNote, findSimilarEntity, getIndexState, g
 import { detectPeriodicNotes } from './periodic.js';
 import { getActivitySummary } from './temporal.js';
 import type { FlywheelConfig } from '../../core/read/config.js';
-import { SCHEMA_VERSION, type StateDb } from '@velvetmonkey/vault-core';
+import { SCHEMA_VERSION, getWriteState, type StateDb } from '@velvetmonkey/vault-core';
 import { getRecentIndexEvents, getRecentPipelineEvent, getLastSuccessfulEvent, getLastEventByTrigger, compactPipelineRun, compactStep, type PipelineStep, type CompactStep, type CompactPipelineRun } from '../../core/shared/indexActivity.js';
 import type { PipelineActivity } from '../../core/read/watch/pipeline.js';
 import { getFTS5State } from '../../core/read/fts5.js';
@@ -618,19 +618,81 @@ export function registerHealthTools(
       proactive_linking: isFull && stateDb ? (() => {
         const config = getConfig();
         const enabled = config.proactive_linking !== false;
+        const minScore = config.proactive_min_score ?? 20;
+        const maxPerDay = config.proactive_max_per_day ?? 10;
         const queuePending = stateDb.db.prepare(
           `SELECT COUNT(*) as cnt FROM proactive_queue WHERE status = 'pending'`,
         ).get() as { cnt: number };
         const summary = getProactiveLinkingSummary(stateDb, 1);
         const oneLiner = getProactiveLinkingOneLiner(stateDb, 1);
+
+        // Per-row pending breakdown: why each queued item hasn't applied yet.
+        const pendingRows = stateDb.db.prepare(
+          `SELECT note_path, entity, score, confidence, queued_at, expires_at
+           FROM proactive_queue
+           WHERE status = 'pending'
+           ORDER BY queued_at DESC
+           LIMIT 25`,
+        ).all() as Array<{
+          note_path: string;
+          entity: string;
+          score: number;
+          confidence: string;
+          queued_at: number;
+          expires_at: number;
+        }>;
+
+        const now = Date.now();
+        const pendingBreakdown = pendingRows.map(r => {
+          const reasons: string[] = [];
+          if (r.score < minScore) reasons.push(`score ${r.score} < min ${minScore}`);
+          if (r.confidence !== 'high') reasons.push(`confidence=${r.confidence} (need high)`);
+          if (r.expires_at <= now) reasons.push('expired');
+          return {
+            note_path: r.note_path,
+            entity: r.entity,
+            score: r.score,
+            confidence: r.confidence,
+            age_hours: Math.round((now - r.queued_at) / 3_600_000 * 10) / 10,
+            likely_reasons: reasons.length > 0 ? reasons : ['passes filters — likely active_edit, daily_cap, or apply_empty (see last_drain)'],
+          };
+        });
+
+        const lastDrain = getWriteState<{
+          at: number;
+          total_applied: number;
+          applied_files: number;
+          expired: number;
+          skipped_active: number;
+          skipped_mtime: number;
+          skipped_daily_cap: number;
+          rejection_count: number;
+          rejection_sample: Array<Record<string, unknown>>;
+        }>(stateDb, 'last_proactive_drain');
+
         return {
           enabled,
           queue_pending: queuePending.cnt,
+          min_score: minScore,
+          max_per_day: maxPerDay,
           summary: oneLiner,
           total_applied_24h: summary.total_applied,
           survived_24h: summary.survived,
           removed_24h: summary.removed,
           files_24h: summary.files_touched,
+          pending_breakdown: pendingBreakdown,
+          last_drain: lastDrain ? {
+            at: lastDrain.at,
+            age_minutes: Math.round((now - lastDrain.at) / 60_000),
+            total_applied: lastDrain.total_applied,
+            applied_files: lastDrain.applied_files,
+            expired: lastDrain.expired,
+            skipped_active: lastDrain.skipped_active,
+            skipped_mtime: lastDrain.skipped_mtime,
+            skipped_daily_cap: lastDrain.skipped_daily_cap,
+            rejection_count: lastDrain.rejection_count,
+            rejection_sample: lastDrain.rejection_sample,
+          } : null,
         };
       })() : undefined,
       recommendations,

--- a/packages/mcp-server/test/shared/proactiveQueueDrain.test.ts
+++ b/packages/mcp-server/test/shared/proactiveQueueDrain.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Proactive Queue Drain — Rejection Diagnostics (P42 Issue 2)
+ *
+ * Verifies drainProactiveQueue populates rejection reasons for every
+ * candidate that was dropped, so flywheel_doctor can surface why items
+ * stay pending forever.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { openStateDb, type StateDb } from '@velvetmonkey/vault-core';
+import {
+  enqueueProactiveSuggestions,
+  drainProactiveQueue,
+} from '../../src/core/write/proactiveQueue.js';
+
+describe('Proactive Queue Drain — rejection diagnostics', () => {
+  let vaultPath: string;
+  let stateDb: StateDb;
+
+  beforeEach(() => {
+    vaultPath = mkdtempSync(join(tmpdir(), 'pq-drain-'));
+    stateDb = openStateDb(vaultPath);
+  });
+
+  afterEach(() => {
+    stateDb?.close();
+    rmSync(vaultPath, { recursive: true, force: true });
+  });
+
+  const writeNote = (rel: string, ageMs = 5 * 60_000): void => {
+    const full = join(vaultPath, rel);
+    writeFileSync(full, '# Note\n\nSome content about TypeScript.\n');
+    const mtime = new Date(Date.now() - ageMs);
+    utimesSync(full, mtime, mtime);
+  };
+
+  it('records apply_empty rejection when applyFn returns nothing', async () => {
+    writeNote('note-a.md');
+    enqueueProactiveSuggestions(stateDb, [
+      { notePath: 'note-a.md', entity: 'TypeScript', score: 30, confidence: 'high' },
+      { notePath: 'note-a.md', entity: 'React', score: 25, confidence: 'high' },
+    ]);
+
+    const result = await drainProactiveQueue(
+      stateDb,
+      vaultPath,
+      { minScore: 20, maxPerFile: 5, maxPerDay: 10 },
+      async () => ({ applied: [], skipped: ['TypeScript', 'React'] }),
+    );
+
+    expect(result.applied).toHaveLength(0);
+    expect(result.rejections).toHaveLength(2);
+    expect(result.rejections.every(r => r.reason === 'apply_empty')).toBe(true);
+    expect(result.rejections.map(r => r.entity).sort()).toEqual(['React', 'TypeScript']);
+    expect(result.rejections[0].score).toBeGreaterThanOrEqual(20);
+  });
+
+  it('records active_edit rejection for files modified within mtime guard', async () => {
+    writeNote('hot-note.md', 1000); // 1 second old — inside 60s guard
+    enqueueProactiveSuggestions(stateDb, [
+      { notePath: 'hot-note.md', entity: 'TypeScript', score: 30, confidence: 'high' },
+    ]);
+
+    const result = await drainProactiveQueue(
+      stateDb,
+      vaultPath,
+      { minScore: 20, maxPerFile: 5, maxPerDay: 10 },
+      async () => ({ applied: ['TypeScript'], skipped: [] }),
+    );
+
+    expect(result.skippedActiveEdit).toBe(1);
+    expect(result.rejections).toHaveLength(1);
+    expect(result.rejections[0].reason).toBe('active_edit');
+    expect(result.rejections[0].detail).toMatch(/mtime age/);
+  });
+
+  it('records stat_failed when the note file is missing', async () => {
+    enqueueProactiveSuggestions(stateDb, [
+      { notePath: 'ghost.md', entity: 'Ghost', score: 30, confidence: 'high' },
+    ]);
+
+    const result = await drainProactiveQueue(
+      stateDb,
+      vaultPath,
+      { minScore: 20, maxPerFile: 5, maxPerDay: 10 },
+      async () => ({ applied: [], skipped: [] }),
+    );
+
+    expect(result.rejections).toHaveLength(1);
+    expect(result.rejections[0].reason).toBe('stat_failed');
+  });
+
+  it('records daily_cap rejection and marks rows expired', async () => {
+    writeNote('capped.md');
+
+    // Seed today's applications up to the cap
+    const now = new Date().toISOString();
+    const insert = stateDb.db.prepare(
+      `INSERT INTO wikilink_applications (entity, note_path, applied_at, source) VALUES (?, ?, ?, 'proactive')`,
+    );
+    for (let i = 0; i < 10; i++) insert.run(`seed${i}`, 'capped.md', now);
+
+    enqueueProactiveSuggestions(stateDb, [
+      { notePath: 'capped.md', entity: 'Overflow', score: 30, confidence: 'high' },
+    ]);
+
+    const result = await drainProactiveQueue(
+      stateDb,
+      vaultPath,
+      { minScore: 20, maxPerFile: 5, maxPerDay: 10 },
+      async () => ({ applied: ['Overflow'], skipped: [] }),
+    );
+
+    expect(result.skippedDailyCap).toBe(1);
+    expect(result.rejections).toHaveLength(1);
+    expect(result.rejections[0].reason).toBe('daily_cap');
+    expect(result.rejections[0].detail).toMatch(/today=10/);
+
+    const row = stateDb.db.prepare(
+      `SELECT status FROM proactive_queue WHERE note_path = 'capped.md' AND entity = 'Overflow'`,
+    ).get() as { status: string };
+    expect(row.status).toBe('expired');
+  });
+
+  it('partial apply — marks only unapplied entities as rejected', async () => {
+    writeNote('partial.md');
+    enqueueProactiveSuggestions(stateDb, [
+      { notePath: 'partial.md', entity: 'A', score: 30, confidence: 'high' },
+      { notePath: 'partial.md', entity: 'B', score: 30, confidence: 'high' },
+      { notePath: 'partial.md', entity: 'C', score: 30, confidence: 'high' },
+    ]);
+
+    const result = await drainProactiveQueue(
+      stateDb,
+      vaultPath,
+      { minScore: 20, maxPerFile: 5, maxPerDay: 10 },
+      async () => ({ applied: ['A'], skipped: ['B', 'C'] }),
+    );
+
+    expect(result.applied).toHaveLength(1);
+    expect(result.rejections).toHaveLength(2);
+    expect(result.rejections.map(r => r.entity).sort()).toEqual(['B', 'C']);
+    expect(result.rejections.every(r => r.reason === 'apply_empty')).toBe(true);
+  });
+
+  it('records apply_error when applyFn throws', async () => {
+    writeNote('boom.md');
+    enqueueProactiveSuggestions(stateDb, [
+      { notePath: 'boom.md', entity: 'Kaboom', score: 30, confidence: 'high' },
+    ]);
+
+    const result = await drainProactiveQueue(
+      stateDb,
+      vaultPath,
+      { minScore: 20, maxPerFile: 5, maxPerDay: 10 },
+      async () => { throw new Error('disk on fire'); },
+    );
+
+    expect(result.rejections).toHaveLength(1);
+    expect(result.rejections[0].reason).toBe('apply_error');
+    expect(result.rejections[0].detail).toMatch(/disk on fire/);
+  });
+});


### PR DESCRIPTION
## Summary

- **P42 Issue 2**: `flywheel_doctor` reports `queue_pending: 6, applied_24h: 0, survived: 0`. Diagnosing why means digging into code — every rejection path in the proactive drain was silent.
- Drain now records per-candidate rejection reason (`active_edit`, `stat_failed`, `daily_cap`, `apply_empty`, `apply_error`) with human-readable detail, persisted to `write_state` across restarts.
- `flywheel_doctor` surfaces `pending_breakdown` (per-row age + likely_reasons against current threshold) and `last_drain` (counts + rejection sample).

## What changes

**`proactiveQueue.ts`**
- `DrainResult.rejections: Rejection[]` — new field populated at every skip path
- `Rejection` type: `{note_path, entity, score, confidence, reason, detail?}`
- Partial-apply path now credits each non-applied entity individually (previously only hit the skipped counter when `applied.length === 0`)

**`pipeline.ts`**
- After drain, writes snapshot (counts + up to 25 rejection samples) to `write_state['last_proactive_drain']`
- Emits histogram log line: `Proactive drain rejections: 7 (apply_empty=5 active_edit=2)`

**`health.ts`**
- Proactive linking section in `flywheel_doctor` output now returns:
  - `min_score`, `max_per_day` (config surface)
  - `pending_breakdown`: up to 25 most-recent pending rows with `age_hours` + `likely_reasons` (score vs current threshold, confidence check, expiry)
  - `last_drain`: { at, age_minutes, counts, rejection_count, rejection_sample }

## Out of scope

- Tuning the threshold itself (adaptive_strictness → proactive) — diagnose first, tune second.
- Per-entity rejection logging inside `applyProactiveSuggestions` (would require threading reasons through the ApplyFn contract). Current surface catches the aggregate at the drain boundary, which covers the P42 symptom.

## Test plan

- [x] 6 new drain tests in `packages/mcp-server/test/shared/proactiveQueueDrain.test.ts` — one per rejection reason
- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] Full `test/shared` + `test/read/core` suites pass (177/177)
- [ ] Manual smoke: run flywheel_doctor on a vault with pending items, verify `pending_breakdown` shows age and reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)