### PR TITLE
fix(proactive): persist rejection_breakdown + diagnose queue stalls

### DIFF
--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -1287,9 +1287,9 @@ export class PipelineRunner {
     if (totalApplied > 0) {
       serverLog('watcher', `Proactive drain: applied ${totalApplied} links in ${result.applied.length} files`);
     }
+    const byReason: Record<string, number> = {};
+    for (const r of result.rejections) byReason[r.reason] = (byReason[r.reason] ?? 0) + 1;
     if (result.rejections.length > 0) {
-      const byReason: Record<string, number> = {};
-      for (const r of result.rejections) byReason[r.reason] = (byReason[r.reason] ?? 0) + 1;
       const summary = Object.entries(byReason).map(([k, v]) => `${k}=${v}`).join(' ');
       serverLog('watcher', `Proactive drain rejections: ${result.rejections.length} (${summary})`);
     }
@@ -1307,6 +1307,7 @@ export class PipelineRunner {
         skipped_daily_cap: result.skippedDailyCap,
         rejection_count: result.rejections.length,
         rejection_sample: result.rejections.slice(0, 25),
+        rejection_breakdown: byReason,
       });
     } catch { /* non-critical */ }
 

--- a/packages/mcp-server/src/tools/read/health.ts
+++ b/packages/mcp-server/src/tools/read/health.ts
@@ -668,6 +668,7 @@ export function registerHealthTools(
           skipped_daily_cap: number;
           rejection_count: number;
           rejection_sample: Array<Record<string, unknown>>;
+          rejection_breakdown?: Record<string, number>;
         }>(stateDb, 'last_proactive_drain');
 
         return {
@@ -691,6 +692,7 @@ export function registerHealthTools(
             skipped_mtime: lastDrain.skipped_mtime,
             skipped_daily_cap: lastDrain.skipped_daily_cap,
             rejection_count: lastDrain.rejection_count,
+            rejection_breakdown: lastDrain.rejection_breakdown ?? {},
             rejection_sample: lastDrain.rejection_sample,
           } : null,
         };
@@ -1277,6 +1279,40 @@ export function registerHealthTools(
           if (hashCount) {
             checks.push({ name: 'content_hashes', status: 'ok',
               detail: `${hashCount.count} content hashes cached` });
+          }
+        } catch { /* skip */ }
+      }
+
+      // 15. Proactive queue stall detection
+      if (stateDb) {
+        try {
+          const queuePending = stateDb.db.prepare(
+            `SELECT COUNT(*) as cnt FROM proactive_queue WHERE status = 'pending'`,
+          ).get() as { cnt: number };
+          const proactiveSummary = getProactiveLinkingSummary(stateDb, 1);
+          const lastDrain = getWriteState<{
+            rejection_count: number;
+            rejection_breakdown?: Record<string, number>;
+          }>(stateDb, 'last_proactive_drain');
+
+          if (queuePending.cnt > 0 && proactiveSummary.total_applied === 0) {
+            const top = Object.entries(lastDrain?.rejection_breakdown ?? {})
+              .sort(([, a], [, b]) => b - a)
+              .slice(0, 2)
+              .map(([reason, count]) => `${reason} (${count})`)
+              .join(', ');
+            checks.push({
+              name: 'proactive_queue',
+              status: 'warning',
+              detail: `${queuePending.cnt} pending, 0 applied in 24h. Top rejections: ${top || 'unknown'}`,
+              fix: 'Lower proactive_min_score or inspect via pipeline_status',
+            });
+          } else {
+            checks.push({
+              name: 'proactive_queue',
+              status: 'ok',
+              detail: `${queuePending.cnt} pending, ${proactiveSummary.total_applied} applied in 24h`,
+            });
           }
         } catch { /* skip */ }
       }

--- a/packages/mcp-server/test/read/tools/health.test.ts
+++ b/packages/mcp-server/test/read/tools/health.test.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'url';
 import { connectTestClient, type TestClient, createTestServer, type TestServerContext } from '../helpers/createTestServer.js';
 import { recordIndexEvent } from '../../../src/core/shared/indexActivity.js';
 import { setEmbeddingsDatabase, setEmbeddingsBuildState } from '../../../src/core/read/embeddings.js';
+import { setWriteState } from '@velvetmonkey/vault-core';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES_PATH = path.join(__dirname, '..', 'fixtures');
@@ -252,6 +253,93 @@ describe('flywheel_doctor', () => {
     // This only holds when there are aliases/paths expanding the surface beyond canonical count
     if (indexEntitySize !== dbEntityCount) {
       expect(denominator).not.toBe(indexEntitySize);
+    }
+  });
+
+  test('proactive_queue stall check fires when pending>0 and total_applied=0', async () => {
+    const stateDb = context.stateDb!;
+
+    stateDb.db.prepare(`DELETE FROM proactive_queue`).run();
+    stateDb.db.prepare(`DELETE FROM wikilink_applications WHERE source = 'proactive'`).run();
+
+    const now = Date.now();
+    stateDb.db.prepare(
+      `INSERT INTO proactive_queue (note_path, entity, score, confidence, queued_at, expires_at, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run('notes/stall-a.md', 'EntA', 25, 'high', now - 3600_000, now + 86400_000, 'pending');
+    stateDb.db.prepare(
+      `INSERT INTO proactive_queue (note_path, entity, score, confidence, queued_at, expires_at, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run('notes/stall-b.md', 'EntB', 25, 'high', now - 3600_000, now + 86400_000, 'pending');
+
+    setWriteState(stateDb, 'last_proactive_drain', {
+      at: now,
+      total_applied: 0,
+      applied_files: 0,
+      expired: 0,
+      skipped_active: 0,
+      skipped_mtime: 0,
+      skipped_daily_cap: 0,
+      rejection_count: 5,
+      rejection_sample: [],
+      rejection_breakdown: { active_edit: 3, apply_empty: 2 },
+    });
+
+    try {
+      const result = await client.callTool('flywheel_doctor', {});
+      const data = JSON.parse(result.content[0].text);
+      const check = data.checks.find((c: any) => c.name === 'proactive_queue');
+      expect(check).toBeDefined();
+      expect(check.status).toBe('warning');
+      expect(check.detail).toMatch(/2 pending, 0 applied/);
+      expect(check.detail).toMatch(/active_edit \(3\)/);
+      expect(check.detail).toMatch(/apply_empty \(2\)/);
+      expect(check.fix).toMatch(/proactive_min_score|pipeline_status/);
+    } finally {
+      stateDb.db.prepare(`DELETE FROM proactive_queue`).run();
+      setWriteState(stateDb, 'last_proactive_drain', null);
+    }
+  });
+
+  test('proactive_queue check stays ok when queue is drained cleanly', async () => {
+    const stateDb = context.stateDb!;
+    stateDb.db.prepare(`DELETE FROM proactive_queue`).run();
+    setWriteState(stateDb, 'last_proactive_drain', null);
+
+    const result = await client.callTool('flywheel_doctor', {});
+    const data = JSON.parse(result.content[0].text);
+    const check = data.checks.find((c: any) => c.name === 'proactive_queue');
+    expect(check).toBeDefined();
+    expect(check.status).toBe('ok');
+  });
+
+  test('health report surfaces rejection_breakdown on last_drain', async () => {
+    const stateDb = context.stateDb!;
+    const now = Date.now();
+
+    setWriteState(stateDb, 'last_proactive_drain', {
+      at: now,
+      total_applied: 4,
+      applied_files: 2,
+      expired: 0,
+      skipped_active: 1,
+      skipped_mtime: 0,
+      skipped_daily_cap: 0,
+      rejection_count: 6,
+      rejection_sample: [],
+      rejection_breakdown: { active_edit: 4, apply_empty: 2 },
+    });
+
+    try {
+      const result = await client.callTool('flywheel_doctor', { report: 'health', detail: 'full' });
+      const data = JSON.parse(result.content[0].text);
+      expect(data.proactive_linking?.last_drain).toBeDefined();
+      expect(data.proactive_linking.last_drain.rejection_breakdown).toEqual({
+        active_edit: 4,
+        apply_empty: 2,
+      });
+    } finally {
+      setWriteState(stateDb, 'last_proactive_drain', null);
     }
   });
 });

--- a/packages/mcp-server/test/shared/proactiveQueueDrain.test.ts
+++ b/packages/mcp-server/test/shared/proactiveQueueDrain.test.ts
@@ -146,6 +146,38 @@ describe('Proactive Queue Drain — rejection diagnostics', () => {
     expect(result.rejections.every(r => r.reason === 'apply_empty')).toBe(true);
   });
 
+  it('mixed-reason drain aggregates into a rejection_breakdown histogram', async () => {
+    // Reproduces the pipeline.ts aggregation path: the persistence layer
+    // computes `byReason` from the full rejection list and stores it in
+    // last_proactive_drain so flywheel_doctor can surface top reasons.
+    writeNote('fine.md');                 // will apply_empty (applyFn returns [])
+    writeNote('hot.md', 1000);            // < 60s → active_edit
+    // ghost.md — missing → stat_failed
+
+    enqueueProactiveSuggestions(stateDb, [
+      { notePath: 'fine.md', entity: 'EntFine1', score: 30, confidence: 'high' },
+      { notePath: 'fine.md', entity: 'EntFine2', score: 30, confidence: 'high' },
+      { notePath: 'hot.md', entity: 'EntHot', score: 30, confidence: 'high' },
+      { notePath: 'ghost.md', entity: 'EntGhost', score: 30, confidence: 'high' },
+    ]);
+
+    const result = await drainProactiveQueue(
+      stateDb,
+      vaultPath,
+      { minScore: 20, maxPerFile: 5, maxPerDay: 10 },
+      async () => ({ applied: [], skipped: [] }),
+    );
+
+    // Same aggregation shape pipeline.ts persists.
+    const byReason: Record<string, number> = {};
+    for (const r of result.rejections) byReason[r.reason] = (byReason[r.reason] ?? 0) + 1;
+
+    expect(byReason.apply_empty).toBe(2);
+    expect(byReason.active_edit).toBe(1);
+    expect(byReason.stat_failed).toBe(1);
+    expect(Object.values(byReason).reduce((a, b) => a + b, 0)).toBe(result.rejections.length);
+  });
+
   it('records apply_error when applyFn throws', async () => {
     writeNote('boom.md');
     enqueueProactiveSuggestions(stateDb, [


### PR DESCRIPTION
## Summary

Follow-up to #292. The drain already computes a `byReason` histogram for the log line but throws it away — persist it alongside `rejection_count` and the 25-row sample in `last_proactive_drain`, so `flywheel_doctor` can surface top rejection reasons instead of forcing operators to eyeball raw samples.

- **`pipeline.ts`** — hoist `byReason` out of the log block, persist as `rejection_breakdown` on the `setWriteState('last_proactive_drain', …)` payload.
- **`health.ts`** — surface `rejection_breakdown` on the `last_drain` output.
- **`health.ts` diagnosis branch** — new check #15 `proactive_queue`. When pending > 0 and `total_applied == 0` in the last 24h, push a `warning` naming the top-2 rejection reasons and pointing at `proactive_min_score` / `pipeline_status` for triage. Otherwise push `ok` with pending/applied counts.

## Test plan

- [x] New unit test in `proactiveQueueDrain.test.ts` — mixed-reason drain (`apply_empty` x2, `active_edit`, `stat_failed`) produces a consistent histogram shape via the same loop pipeline.ts uses.
- [x] New tests in `health.test.ts`:
  - stall fires `warning` with top reasons embedded in `detail` and a `fix` string
  - drained queue stays `ok`
  - `flywheel_doctor report=health` surfaces `proactive_linking.last_drain.rejection_breakdown` on the wire
- [x] `npm run build` + `npm run lint` clean
- [x] Full mcp-server suite green on all affected areas (only pre-existing `memory.trace.test.ts` failure remains — unrelated, fails on `main` as well)

🤖 Generated with [Claude Code](https://claude.com/claude-code)