### PR TITLE
fix(wikilinks): exclude pure version strings from implicit detection

### DIFF
--- a/packages/core/src/wikilinks.ts
+++ b/packages/core/src/wikilinks.ts
@@ -951,7 +951,10 @@ export function resolveAliasWikilinks(
 const DEFAULT_IMPLICIT_CONFIG: Required<ImplicitEntityConfig> = {
   detectImplicit: false,
   implicitPatterns: ['proper-nouns', 'quoted-terms'],
-  excludePatterns: ['^The ', '^A ', '^An ', '^This ', '^That ', '^These ', '^Those '],
+  excludePatterns: [
+    '^The ', '^A ', '^An ', '^This ', '^That ', '^These ', '^Those ',
+    '^v?\\d+(?:\\.\\d+){1,3}(?:[-.][a-zA-Z0-9]+)?$',
+  ],
   minEntityLength: 3,
 };
 

--- a/packages/core/test/wikilinks.test.ts
+++ b/packages/core/test/wikilinks.test.ts
@@ -1595,4 +1595,39 @@ describe('noise reduction', () => {
       expect(names).toContain('CLOUD-99999');
     });
   });
+
+  describe('version-string exclusion (defense-in-depth vs auto-logger pollution)', () => {
+    // Pins the regex literal shipped in DEFAULT_IMPLICIT_CONFIG.excludePatterns.
+    // detectImplicitEntities's proper-noun capture won't match pure version
+    // strings today, but any other path that routes text through shouldExclude
+    // (explicit suggestion matching against canonical entities, future capture
+    // patterns) inherits this backstop.
+    const VERSION_PATTERN = /^v?\d+(?:\.\d+){1,3}(?:[-.][a-zA-Z0-9]+)?$/i;
+
+    it('matches pure version strings that the auto-logger was leaking', () => {
+      expect(VERSION_PATTERN.test('v2.8.0')).toBe(true);
+      expect(VERSION_PATTERN.test('1.27.35')).toBe(true);
+      expect(VERSION_PATTERN.test('v3.0.0-beta')).toBe(true);
+      expect(VERSION_PATTERN.test('2.1')).toBe(true);
+      expect(VERSION_PATTERN.test('v1.0.0.0')).toBe(true);
+    });
+
+    it('does not match legitimate tech/version phrases that should stay linkable', () => {
+      expect(VERSION_PATTERN.test('1.2 million')).toBe(false);
+      expect(VERSION_PATTERN.test('iOS 17.4')).toBe(false);
+      expect(VERSION_PATTERN.test('Section 1.1')).toBe(false);
+      expect(VERSION_PATTERN.test('React 18')).toBe(false);
+      expect(VERSION_PATTERN.test('v2.8.0 released')).toBe(false);
+    });
+
+    it('ships in DEFAULT_IMPLICIT_CONFIG.excludePatterns so every call inherits it', () => {
+      // If a consumer ever captures a version string (via a future pattern or
+      // explicit match), the default exclude list filters it out without an
+      // explicit config override.
+      const matches = detectImplicitEntities('Release v2.8.0 Version ships today with 1.27.35 updates.');
+      const names = matches.map(m => m.text);
+      expect(names).not.toContain('v2.8.0');
+      expect(names).not.toContain('1.27.35');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Defense-in-depth backstop for auto-logger pollution (flywheel-engine PR #11 is the primary fix).
- Adds an anchored version-string pattern to \`DEFAULT_IMPLICIT_CONFIG.excludePatterns\` so any path that routes candidate text through \`shouldExclude\` — today or in a future capture pattern — filters out \`v2.8.0\`, \`1.27.35\`, \`v3.0.0-beta\` etc. without touching legitimate phrases like \`Section 1.1\`, \`React 18\`, \`iOS 17.4\`.
- Anchored on both ends (\`^...\$\`) so it only fires on pure version tokens, never on prose containing version numbers.

## Test plan

- [x] New \`describe('version-string exclusion ...')\` block in \`packages/core/test/wikilinks.test.ts\`:
  - positive cases: \`v2.8.0\`, \`1.27.35\`, \`v3.0.0-beta\`, \`2.1\`, \`v1.0.0.0\`
  - negative cases: \`1.2 million\`, \`iOS 17.4\`, \`Section 1.1\`, \`React 18\`, \`v2.8.0 released\`
  - end-to-end: \`detectImplicitEntities\` on prose containing version strings does not surface them as entity candidates
- [x] All 150 vault-core wikilinks tests pass
- [x] \`npm run build\` + \`npm run lint\` green

## Relation to A2 engine PR

This is the vault-core-side backstop. The primary fix is in flywheel-engine (\`daily-log.ts\` passes \`skipWikilinks: true\`). This PR catches any residual path — e.g. hand-written notes that happen to contain raw version strings, or future callers that bypass the \`skipWikilinks\` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)