### PR TITLE
fix(security): T32 — replace validatePath() with validatePathSecure() across all write tools

### DIFF
--- a/packages/mcp-server/src/core/write/mutation-helpers.ts
+++ b/packages/mcp-server/src/core/write/mutation-helpers.ts
@@ -204,6 +204,11 @@ export async function ensureFileExists(
   vaultPath: string,
   notePath: string
 ): Promise<MutationResult | null> {
+  // Validate path before any filesystem access
+  const validation = await validatePathSecure(vaultPath, notePath);
+  if (!validation.valid) {
+    return errorResult(notePath, `Invalid path: ${validation.reason}`);
+  }
   const fullPath = path.join(vaultPath, notePath);
   try {
     await fs.access(fullPath);

--- a/packages/mcp-server/src/core/write/path-security.ts
+++ b/packages/mcp-server/src/core/write/path-security.ts
@@ -100,7 +100,11 @@ export function isWithinDirectory(child: string, parent: string, allowEqual = fa
 }
 
 /**
- * Validate path to prevent traversal attacks (sync version for reads)
+ * @deprecated Use validatePathSecure() instead. This sync version does not follow
+ * symlinks and does not check sensitive file patterns (.env, .key, SSH keys, etc.).
+ * It is retained only for existing tests. All tool code must use validatePathSecure().
+ *
+ * @see validatePathSecure
  */
 export function validatePath(vaultPath: string, notePath: string): boolean {
   // Reject absolute paths

--- a/packages/mcp-server/src/tools/write/merge.ts
+++ b/packages/mcp-server/src/tools/write/merge.ts
@@ -11,7 +11,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { validatePath, readVaultFile, writeVaultFile, WriteConflictError, type LineEnding } from '../../core/write/writer.js';
+import { validatePath, validatePathSecure, readVaultFile, writeVaultFile, WriteConflictError, type LineEnding } from '../../core/write/writer.js';
 import type { MutationResult } from '../../core/write/types.js';
 import { initializeEntityIndex } from '../../core/write/wikilinks.js';
 import {
@@ -42,20 +42,22 @@ export function registerMergeTools(
     async ({ source_path, target_path, dry_run }) => {
       try {
         const vaultPath = getVaultPath();
-        // 1. Validate paths
-        if (!validatePath(vaultPath, source_path)) {
+        // 1. Validate paths (async: follows symlinks, blocks sensitive file patterns)
+        const sourceValidation = await validatePathSecure(vaultPath, source_path);
+        if (!sourceValidation.valid) {
           const result: MutationResult = {
             success: false,
-            message: 'Invalid source path: path traversal not allowed',
+            message: `Invalid source path: ${sourceValidation.reason}`,
             path: source_path,
           };
           return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
         }
 
-        if (!validatePath(vaultPath, target_path)) {
+        const targetValidation = await validatePathSecure(vaultPath, target_path);
+        if (!targetValidation.valid) {
           const result: MutationResult = {
             success: false,
-            message: 'Invalid target path: path traversal not allowed',
+            message: `Invalid target path: ${targetValidation.reason}`,
             path: target_path,
           };
           return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
@@ -227,11 +229,12 @@ export function registerMergeTools(
     async ({ source_name, target_path, dry_run }) => {
       try {
         const vaultPath = getVaultPath();
-        // 1. Validate target path
-        if (!validatePath(vaultPath, target_path)) {
+        // 1. Validate target path (async: follows symlinks, blocks sensitive file patterns)
+        const absorbTargetValidation = await validatePathSecure(vaultPath, target_path);
+        if (!absorbTargetValidation.valid) {
           const result: MutationResult = {
             success: false,
-            message: 'Invalid target path: path traversal not allowed',
+            message: `Invalid target path: ${absorbTargetValidation.reason}`,
             path: target_path,
           };
           return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };

--- a/packages/mcp-server/src/tools/write/move-notes.ts
+++ b/packages/mcp-server/src/tools/write/move-notes.ts
@@ -7,7 +7,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { validatePath, readVaultFile, writeVaultFile, computeContentHash } from '../../core/write/writer.js';
+import { validatePath, validatePathSecure, readVaultFile, writeVaultFile, computeContentHash } from '../../core/write/writer.js';
 import type { MutationResult } from '../../core/write/types.js';
 import { commitChange } from '../../core/write/git.js';
 import { initializeEntityIndex } from '../../core/write/wikilinks.js';
@@ -188,20 +188,22 @@ export function registerMoveNoteTools(
     async ({ oldPath, newPath, updateBacklinks, commit, dry_run }) => {
       try {
         const vaultPath = getVaultPath();
-        // 1. Validate paths
-        if (!validatePath(vaultPath, oldPath)) {
+        // 1. Validate paths (async: follows symlinks, blocks sensitive file patterns)
+        const oldPathValidation = await validatePathSecure(vaultPath, oldPath);
+        if (!oldPathValidation.valid) {
           const result: MutationResult = {
             success: false,
-            message: 'Invalid source path: path traversal not allowed',
+            message: `Invalid source path: ${oldPathValidation.reason}`,
             path: oldPath,
           };
           return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
         }
 
-        if (!validatePath(vaultPath, newPath)) {
+        const newPathValidation = await validatePathSecure(vaultPath, newPath);
+        if (!newPathValidation.valid) {
           const result: MutationResult = {
             success: false,
-            message: 'Invalid destination path: path traversal not allowed',
+            message: `Invalid destination path: ${newPathValidation.reason}`,
             path: newPath,
           };
           return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
@@ -383,11 +385,12 @@ export function registerMoveNoteTools(
     async ({ path: notePath, newTitle, updateBacklinks, commit, dry_run }) => {
       try {
         const vaultPath = getVaultPath();
-        // 1. Validate path
-        if (!validatePath(vaultPath, notePath)) {
+        // 1. Validate path (async: follows symlinks, blocks sensitive file patterns)
+        const renamePathValidation = await validatePathSecure(vaultPath, notePath);
+        if (!renamePathValidation.valid) {
           const result: MutationResult = {
             success: false,
-            message: 'Invalid path: path traversal not allowed',
+            message: `Invalid path: ${renamePathValidation.reason}`,
             path: notePath,
           };
           return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };

--- a/packages/mcp-server/src/tools/write/notes.ts
+++ b/packages/mcp-server/src/tools/write/notes.ts
@@ -5,7 +5,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { writeVaultFile, validatePath, sanitizeNotePath, injectMutationMetadata } from '../../core/write/writer.js';
+import { writeVaultFile, validatePath, validatePathSecure, sanitizeNotePath, injectMutationMetadata } from '../../core/write/writer.js';
 import {
   maybeApplyWikilinks,
   suggestRelatedLinks,
@@ -61,8 +61,9 @@ export function registerNoteTools(
         const notePath = sanitizeNotePath(rawNotePath);
 
         // 1. Validate path
-        if (!validatePath(vaultPath, notePath)) {
-          return formatMcpResult(errorResult(notePath, 'Invalid path: path traversal not allowed'));
+        const pathValidation = await validatePathSecure(vaultPath, notePath);
+        if (!pathValidation.valid) {
+          return formatMcpResult(errorResult(notePath, `Invalid path: ${pathValidation.reason}`));
         }
 
         const fullPath = path.join(vaultPath, notePath);
@@ -82,6 +83,11 @@ export function registerNoteTools(
         let effectiveContent = content;
         let effectiveFrontmatter = frontmatter;
         if (template) {
+          // Validate template path before reading — prevents arbitrary file read (LFI)
+          const templateValidation = await validatePathSecure(vaultPath, template);
+          if (!templateValidation.valid) {
+            return formatMcpResult(errorResult(notePath, `Invalid template path: ${templateValidation.reason}`));
+          }
           const templatePath = path.join(vaultPath, template);
           try {
             const raw = await fs.readFile(templatePath, 'utf-8');
@@ -242,9 +248,10 @@ export function registerNoteTools(
     async ({ path: notePath, confirm, commit, dry_run }) => {
       try {
         const vaultPath = getVaultPath();
-        // 1. Validate path
-        if (!validatePath(vaultPath, notePath)) {
-          return formatMcpResult(errorResult(notePath, 'Invalid path: path traversal not allowed'));
+        // 1. Validate path (async: follows symlinks, blocks sensitive file patterns)
+        const deletePathValidation = await validatePathSecure(vaultPath, notePath);
+        if (!deletePathValidation.valid) {
+          return formatMcpResult(errorResult(notePath, `Invalid path: ${deletePathValidation.reason}`));
         }
 
         // 2. Check if file exists

--- a/packages/mcp-server/test/write/security/tool-integration.test.ts
+++ b/packages/mcp-server/test/write/security/tool-integration.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tool-level security integration tests
+ *
+ * Tests path boundary enforcement at the MCP tool input boundary —
+ * the same interface Claude sees. Complements the unit tests in
+ * path-encoding.test.ts and permission-bypass.test.ts which test
+ * validatePath/validatePathSecure directly.
+ *
+ * These tests verify that individual tool handlers correctly use
+ * validatePathSecure() rather than the deprecated sync validatePath().
+ *
+ * Covered:
+ *   vault_create_note  — note path traversal, template LFI
+ *   vault_delete_note  — path traversal on delete
+ *   vault_move_note    — traversal on source and destination
+ *   vault_rename_note  — traversal on source path
+ *   merge_entities     — traversal on source and target
+ *   absorb_as_alias    — traversal on target
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import {
+  createWriteTestServer,
+  type WriteTestServerContext,
+} from '../../helpers/createWriteTestServer.js';
+import { createTestNote } from '../helpers/testUtils.js';
+import fs from 'fs/promises';
+import path from 'path';
+
+/** Parse the first text content block from a tool result */
+function parseResult(result: { content: unknown }): Record<string, unknown> {
+  const content = result.content as Array<{ type: string; text: string }>;
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+describe('Tool-level path security (T32)', () => {
+  let ctx: WriteTestServerContext;
+  let client: Client;
+
+  beforeAll(async () => {
+    ctx = await createWriteTestServer();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await ctx.server.connect(serverTransport);
+
+    client = new Client(
+      { name: 'security-test', version: '1.0.0' },
+      { capabilities: {} },
+    );
+    await client.connect(clientTransport);
+  });
+
+  afterAll(async () => {
+    await client?.close();
+    await ctx?.cleanup();
+  });
+
+  // ============================================================
+  // vault_create_note — note path traversal
+  // ============================================================
+
+  describe('vault_create_note — note path', () => {
+    it('rejects simple path traversal', async () => {
+      const result = await client.callTool({
+        name: 'vault_create_note',
+        arguments: { path: '../outside.md', content: 'bad' },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid path|path traversal/i);
+    });
+
+    it('rejects absolute path', async () => {
+      const result = await client.callTool({
+        name: 'vault_create_note',
+        arguments: { path: '/etc/passwd.md', content: 'bad' },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+    });
+
+    it('rejects sensitive file target (.env)', async () => {
+      const result = await client.callTool({
+        name: 'vault_create_note',
+        arguments: { path: '.env', content: 'TOKEN=stolen' },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid path|sensitive/i);
+    });
+  });
+
+  // ============================================================
+  // vault_create_note — template LFI (Local File Inclusion)
+  // ============================================================
+
+  describe('vault_create_note — template path', () => {
+    it('rejects traversal in template path', async () => {
+      // Create a legit target note path to get past note-path validation
+      const result = await client.callTool({
+        name: 'vault_create_note',
+        arguments: {
+          path: 'notes/safe.md',
+          template: '../../etc/passwd',
+          content: '',
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid template path|path traversal/i);
+    });
+
+    it('rejects absolute path in template', async () => {
+      const result = await client.callTool({
+        name: 'vault_create_note',
+        arguments: {
+          path: 'notes/safe2.md',
+          template: '/etc/passwd',
+          content: '',
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+    });
+
+    it('rejects sensitive file as template (.env)', async () => {
+      // Create a .env file inside vault so it "exists" — should still be blocked
+      await fs.writeFile(path.join(ctx.vaultPath, '.env'), 'SECRET=test');
+      const result = await client.callTool({
+        name: 'vault_create_note',
+        arguments: {
+          path: 'notes/safe3.md',
+          template: '.env',
+          content: '',
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid template path|sensitive/i);
+    });
+  });
+
+  // ============================================================
+  // vault_delete_note
+  // ============================================================
+
+  describe('vault_delete_note', () => {
+    it('rejects path traversal', async () => {
+      const result = await client.callTool({
+        name: 'vault_delete_note',
+        arguments: { path: '../outside.md', confirm: true },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid path|path traversal/i);
+    });
+
+    it('rejects sensitive file target', async () => {
+      const result = await client.callTool({
+        name: 'vault_delete_note',
+        arguments: { path: '.env', confirm: true },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+    });
+  });
+
+  // ============================================================
+  // vault_move_note
+  // ============================================================
+
+  describe('vault_move_note', () => {
+    it('rejects path traversal on source', async () => {
+      const result = await client.callTool({
+        name: 'vault_move_note',
+        arguments: {
+          oldPath: '../outside.md',
+          newPath: 'notes/dest.md',
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid source path|path traversal/i);
+    });
+
+    it('rejects path traversal on destination', async () => {
+      await createTestNote(ctx.vaultPath, 'notes/move-source.md', '# Source\n');
+      const result = await client.callTool({
+        name: 'vault_move_note',
+        arguments: {
+          oldPath: 'notes/move-source.md',
+          newPath: '../../etc/escape.md',
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid destination path|path traversal/i);
+    });
+
+    it('rejects sensitive destination', async () => {
+      await createTestNote(ctx.vaultPath, 'notes/move-source2.md', '# Source\n');
+      const result = await client.callTool({
+        name: 'vault_move_note',
+        arguments: {
+          oldPath: 'notes/move-source2.md',
+          newPath: '.env',
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+    });
+  });
+
+  // ============================================================
+  // vault_rename_note
+  // ============================================================
+
+  describe('vault_rename_note', () => {
+    it('rejects path traversal on source', async () => {
+      const result = await client.callTool({
+        name: 'vault_rename_note',
+        arguments: {
+          path: '../outside.md',
+          newTitle: 'new-name',
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid path|path traversal/i);
+    });
+  });
+
+  // ============================================================
+  // merge_entities
+  // ============================================================
+
+  describe('merge_entities', () => {
+    it('rejects path traversal on source', async () => {
+      const result = await client.callTool({
+        name: 'merge_entities',
+        arguments: {
+          source_path: '../outside.md',
+          target_path: 'notes/target.md',
+          dry_run: true,
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid source path|path traversal/i);
+    });
+
+    it('rejects path traversal on target', async () => {
+      await createTestNote(ctx.vaultPath, 'notes/merge-source.md', '# Source\n');
+      const result = await client.callTool({
+        name: 'merge_entities',
+        arguments: {
+          source_path: 'notes/merge-source.md',
+          target_path: '../../etc/escape.md',
+          dry_run: true,
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid target path|path traversal/i);
+    });
+  });
+
+  // ============================================================
+  // absorb_as_alias
+  // ============================================================
+
+  describe('absorb_as_alias', () => {
+    it('rejects path traversal on target', async () => {
+      const result = await client.callTool({
+        name: 'absorb_as_alias',
+        arguments: {
+          source_name: 'SomeName',
+          target_path: '../../etc/escape.md',
+          dry_run: true,
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid target path|path traversal/i);
+    });
+
+    it('rejects sensitive file as target', async () => {
+      const result = await client.callTool({
+        name: 'absorb_as_alias',
+        arguments: {
+          source_name: 'SomeName',
+          target_path: '.env',
+          dry_run: true,
+        },
+      });
+      const data = parseResult(result);
+      expect(data.success).toBe(false);
+    });
+  });
+
+  // ============================================================
+  // Symlink escape (if OS supports symlink creation)
+  // ============================================================
+
+  describe('symlink escape (vault_delete_note)', () => {
+    it('rejects symlink pointing outside vault', async () => {
+      // Create a temp dir outside the vault
+      const outsideDir = await fs.mkdtemp('/tmp/flywheel-outside-');
+      const outsideFile = path.join(outsideDir, 'secret.md');
+      await fs.writeFile(outsideFile, 'secret content');
+
+      // Create a symlink inside the vault pointing to the outside file
+      const symlinkPath = path.join(ctx.vaultPath, 'escape-link.md');
+      try {
+        await fs.symlink(outsideFile, symlinkPath);
+      } catch {
+        // Skip if symlink creation not supported (some WSL configs)
+        await fs.rm(outsideDir, { recursive: true, force: true });
+        return;
+      }
+
+      const result = await client.callTool({
+        name: 'vault_delete_note',
+        arguments: { path: 'escape-link.md', confirm: true },
+      });
+
+      // Clean up regardless of result
+      await fs.rm(outsideDir, { recursive: true, force: true });
+      try { await fs.unlink(symlinkPath); } catch { /* already gone */ }
+
+      const data = parseResult(result);
+      // Should be blocked: symlink target is outside vault
+      expect(data.success).toBe(false);
+      expect(data.message).toMatch(/invalid path|outside vault|symlink/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Template LFI (highest severity):** `vault_create_note` now validates `template` param with `validatePathSecure()` before `fs.readFile` — previously `template: "../../etc/passwd"` would read arbitrary files
- **`ensureFileExists()` exposure:** Validates path before any `fs.*` call — previously did `path.join() + fs.access()` with zero validation
- **All tool-level `validatePath()` → `validatePathSecure()`:** `vault_delete_note`, `vault_move_note`, `vault_rename_note`, `merge_entities`, `absorb_as_alias` — the sync version doesn't follow symlinks or check sensitive file patterns
- **`validatePath()` marked `@deprecated`** — retained for existing unit tests, all tool code now uses the secure async version

## Test plan

- [ ] `test/write/security/tool-integration.test.ts` — 17 new tests covering path traversal, sensitive file patterns (`.env`), and symlink escapes at MCP tool level
- [ ] All 250 existing security tests pass (`test/write/security/`)
- [ ] All 30 write integration tests pass (`test/write/integration/`)
- [ ] Build clean

## Note

TOCTOU race window (check-then-use) remains — full fix requires a centralised `VaultFileSystem` wrapper (T33/T34 scope). Documented in code comment.

Closes T32 from external code review (Apr 6, 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)