### PR TITLE
fix(test): Windows CI compat — os.tmpdir() and write-server for tasks list

### DIFF
--- a/packages/mcp-server/test/read/tools/primitives.test.ts
+++ b/packages/mcp-server/test/read/tools/primitives.test.ts
@@ -165,22 +165,35 @@ describe('note_read', () => {
 });
 
 // ── tasks ─────────────────────────────────────────────────────────────────────
+// Both list and toggle use a shared write-capable server with a temp vault.
+// This avoids CRLF/path-separator issues with fixtures on Windows and ensures
+// tasks are indexed before the server starts.
 
 describe('tasks', () => {
+  let writeContext: WriteTestServerContext;
+  let writeClient: TestClient;
+
+  beforeAll(async () => {
+    // Create note BEFORE createWriteTestServer so buildVaultIndex picks it up
+    const tempVaultPath = await createTempVault();
+    await createTestNote(
+      tempVaultPath,
+      'tasks-note.md',
+      '# Tasks Note\n\n- [ ] Open task one\n- [ ] Open task two\n- [x] Done task\n'
+    );
+    writeContext = await createWriteTestServer(tempVaultPath);
+    writeClient = connectTestClient(writeContext.server);
+  });
+
+  afterAll(async () => {
+    if (writeContext) await writeContext.cleanup();
+  });
+
   // ── action=list ────────────────────────────────────────────────
-  // Uses the read-side test server (falls back to disk scan when task cache not set up)
 
   describe('action=list', () => {
-    let client: TestClient;
-
-    beforeAll(async () => {
-      const context = await createTestServer(FIXTURES_PATH);
-      client = connectTestClient(context.server);
-    });
-
     test('returns tasks array with correct shape', async () => {
-      // Scope to tasks-note.md to avoid relying on vault-wide cache
-      const result = await client.callTool('tasks', {
+      const result = await writeClient.callTool('tasks', {
         action: 'list',
         path: 'tasks-note.md',
       });
@@ -196,7 +209,7 @@ describe('tasks', () => {
     });
 
     test('status: "open" filter returns only open tasks', async () => {
-      const result = await client.callTool('tasks', {
+      const result = await writeClient.callTool('tasks', {
         action: 'list',
         path: 'tasks-note.md',
         status: 'open',
@@ -209,7 +222,7 @@ describe('tasks', () => {
     });
 
     test('status: "completed" filter returns only completed tasks', async () => {
-      const result = await client.callTool('tasks', {
+      const result = await writeClient.callTool('tasks', {
         action: 'list',
         path: 'tasks-note.md',
         status: 'completed',
@@ -222,7 +235,7 @@ describe('tasks', () => {
     });
 
     test('path not found returns error JSON', async () => {
-      const result = await client.callTool('tasks', {
+      const result = await writeClient.callTool('tasks', {
         action: 'list',
         path: 'does-not-exist.md',
       });
@@ -234,29 +247,8 @@ describe('tasks', () => {
   });
 
   // ── action=toggle ──────────────────────────────────────────────
-  // Uses write-capable server with a temp vault to avoid mutating fixtures
 
   describe('action=toggle', () => {
-    let writeContext: WriteTestServerContext;
-    let writeClient: TestClient;
-
-    beforeAll(async () => {
-      const tempVaultPath = await createTempVault();
-      await createTestNote(
-        tempVaultPath,
-        'tasks-note.md',
-        `# Tasks Note\n\n- [ ] Open task one\n- [ ] Open task two\n- [x] Done task\n`
-      );
-      writeContext = await createWriteTestServer(tempVaultPath);
-      writeClient = connectTestClient(writeContext.server);
-    });
-
-    afterAll(async () => {
-      if (writeContext) {
-        await writeContext.cleanup();
-      }
-    });
-
     test('dry_run: true does not modify the file', async () => {
       const { readFile } = await import('fs/promises');
 
@@ -272,7 +264,6 @@ describe('tasks', () => {
       expect(data.preview).toBeDefined();
       expect(data.dryRun).toBe(true);
 
-      // File must not have changed
       const content = await readFile(path.join(writeContext.vaultPath, 'tasks-note.md'), 'utf8');
       expect(content).toContain('- [ ] Open task one');
     });

--- a/packages/mcp-server/test/write/security/tool-integration.test.ts
+++ b/packages/mcp-server/test/write/security/tool-integration.test.ts
@@ -28,6 +28,7 @@ import {
 import { createTestNote } from '../helpers/testUtils.js';
 import fs from 'fs/promises';
 import path from 'path';
+import os from 'os';
 
 /** Parse the first text content block from a tool result */
 function parseResult(result: { content: unknown }): Record<string, unknown> {
@@ -314,7 +315,7 @@ describe('Tool-level path security (T32)', () => {
   describe('symlink escape (note delete)', () => {
     it('rejects symlink pointing outside vault', async () => {
       // Create a temp dir outside the vault
-      const outsideDir = await fs.mkdtemp('/tmp/flywheel-outside-');
+      const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'flywheel-outside-'));
       const outsideFile = path.join(outsideDir, 'secret.md');
       await fs.writeFile(outsideFile, 'secret content');
 


### PR DESCRIPTION
## Summary

- **primitives.test.ts**: merge `tasks action=list` into shared `createWriteTestServer` describe (was using FIXTURES_PATH which had CRLF/path-separator issues on Windows). Both list and toggle now share one temp vault, note created before `buildVaultIndex`.
- **tool-integration.test.ts**: replace hardcoded \`'/tmp/flywheel-outside-'\` with \`path.join(os.tmpdir(), 'flywheel-outside-')\` — fixes symlink-escape test on Windows.

## Test plan
- [x] `npx vitest run test/read/tools/primitives.test.ts test/write/security/tool-integration.test.ts` — 34/34 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)