### PR TITLE
chore: release v2.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5949,7 +5949,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5975,13 +5975,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@velvetmonkey/vault-core": "^2.9.0",
+        "@velvetmonkey/vault-core": "^2.9.1",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@velvetmonkey/vault-core": "^2.9.0",
+    "@velvetmonkey/vault-core": "^2.9.1",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
Bump vault-core and flywheel-memory to 2.9.1. Already published to npm.