### PR TITLE
fix: update post-publish smoke expectations

### DIFF
--- a/packages/mcp-server/scripts/post-publish-codex-smoke.mjs
+++ b/packages/mcp-server/scripts/post-publish-codex-smoke.mjs
@@ -41,7 +41,7 @@ try {
   const tools = await client.listTools();
   const toolNames = new Set(tools.tools.map(tool => tool.name));
 
-  const required = ['search', 'vault_create_note', 'flywheel_doctor'];
+  const required = ['search', 'note', 'doctor'];
   const missing = required.filter(name => !toolNames.has(name));
   if (missing.length > 0) {
     throw new Error(`Missing expected tools: ${missing.join(', ')}`);


### PR DESCRIPTION
## Summary
- update the post-publish Codex smoke check to validate current merged tool names
- stop expecting retired standalone tool names after the action-param tool collapse

## Validation
- smoke logic inspected against the published `2.10.0` surface
- local rerun still needs repo dependencies installed in the fresh worktree because the script imports `@modelcontextprotocol/sdk`
