### PR TITLE
fix: restore structured log wikilinking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5949,7 +5949,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5975,13 +5975,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@velvetmonkey/vault-core": "^2.11.0",
+        "@velvetmonkey/vault-core": "^2.11.1",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@velvetmonkey/vault-core": "^2.11.0",
+    "@velvetmonkey/vault-core": "^2.11.1",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/mcp-server/src/tools/write/editSection.ts
+++ b/packages/mcp-server/src/tools/write/editSection.ts
@@ -277,7 +277,11 @@ async function handleAdd(
       let childTextsForLinks: string[] = [];
 
       if (children && children.length > 0) {
-        const childBlocks = children.map(({ label, content: childContent }) => {
+        const processedChildren = children.map(({ label, content: childContent }) => {
+          const { content: processedChildContent } = maybeApplyWikilinks(childContent, skipWikilinks, notePath, ctx.content);
+          return { label, content: processedChildContent };
+        });
+        const childBlocks = processedChildren.map(({ label, content: childContent }) => {
           const sanitized = sanitizeForObsidian(childContent);
           const processed = indentContinuation(sanitized);
           const lines = processed.split('\n');
@@ -288,7 +292,7 @@ async function handleAdd(
         });
         finalContent = `- ${processedContent}\n${childBlocks.join('\n')}`;
         finalFormat = 'plain';
-        childTextsForLinks = children.map(c => c.content);
+        childTextsForLinks = processedChildren.map(c => c.content);
       }
 
       // 3. Suggest outgoing links
@@ -300,7 +304,7 @@ async function handleAdd(
         const result = await suggestRelatedLinks(suggestionText, { maxSuggestions, notePath });
         if (result.suffix) {
           if (childTextsForLinks.length > 0) {
-            finalContent = finalContent + ' ' + result.suffix;
+            finalContent = `${finalContent}\n  ${result.suffix}`;
           } else {
             processedContent = processedContent + ' ' + result.suffix;
             finalContent = processedContent;

--- a/packages/mcp-server/test/write/integration/mcp-write.test.ts
+++ b/packages/mcp-server/test/write/integration/mcp-write.test.ts
@@ -10,11 +10,12 @@ import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { initializeEntityIndex } from '../../../src/core/write/wikilinks.js';
 import {
   createWriteTestServer,
   type WriteTestServerContext,
 } from '../../helpers/createWriteTestServer.js';
-import { createTestNote } from '../helpers/testUtils.js';
+import { createEntityCacheInStateDb, createTestNote } from '../helpers/testUtils.js';
 
 /** Parse the first text content block from a tool result */
 function parseResult(result: { content: unknown }): unknown {
@@ -181,6 +182,43 @@ describe('MCP Write Integration', () => {
         expect(fileContent).toContain('- Summary');
         expect(fileContent).toContain('  - **Result:** Passed');
         expect(fileContent).toContain('  - **Owner:** Jordan Smith');
+      });
+
+      it('applies wikilinks inside child content', async () => {
+        await createTestNote(ctx.vaultPath, 'people/Jordan Smith.md', [
+          '# Jordan Smith',
+          '',
+          'Person note.',
+        ].join('\n'));
+        createEntityCacheInStateDb(ctx.stateDb, ctx.vaultPath, {
+          people: ['Jordan Smith'],
+        });
+        await initializeEntityIndex(ctx.vaultPath);
+
+        await createTestNote(ctx.vaultPath, 'child-links.md', [
+          '# Test',
+          '',
+          '## Log',
+          '',
+        ].join('\n'));
+
+        const result = await client.callTool({
+          name: 'edit_section',
+          arguments: {
+            action: 'add',
+            path: 'child-links.md',
+            section: 'Log',
+            content: 'Summary',
+            suggestOutgoingLinks: false,
+            children: [
+              { label: '**Owner:**', content: 'Jordan Smith reviewed this.' },
+            ],
+          },
+        });
+        expect(result.isError).toBeFalsy();
+
+        const fileContent = readFileSync(path.join(ctx.vaultPath, 'child-links.md'), 'utf-8');
+        expect(fileContent).toContain('  - **Owner:** [[Jordan Smith]] reviewed this.');
       });
 
       it('indents multi-line child content', async () => {


### PR DESCRIPTION
## Summary
- apply auto-wikilinking to edit_section child content
- format structured suffix suggestions as their own indented line
- bump flywheel-memory and workspace vault-core to 2.11.1