### PR TITLE
fix: normalize write suggestion defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5949,7 +5949,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.11.1",
+      "version": "2.11.2",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5975,13 +5975,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.11.1",
+      "version": "2.11.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@velvetmonkey/vault-core": "^2.11.1",
+        "@velvetmonkey/vault-core": "^2.11.2",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@velvetmonkey/vault-core": "^2.11.1",
+    "@velvetmonkey/vault-core": "^2.11.2",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/mcp-server/src/core/write/policy/executor.ts
+++ b/packages/mcp-server/src/core/write/policy/executor.ts
@@ -169,7 +169,7 @@ async function executeAddToSection(
   const format = (params.format as FormatType) || 'plain';
   const skipWikilinks = Boolean(params.skipWikilinks);
   const preserveListNesting = params.preserveListNesting !== false;
-  const suggestOutgoingLinks = params.suggestOutgoingLinks !== false;
+  const suggestOutgoingLinks = params.suggestOutgoingLinks === true;
   const maxSuggestions = Number(params.maxSuggestions) || 3;
 
   const outcome = await executeMutation(
@@ -260,7 +260,7 @@ async function executeReplaceInSection(
   const mode = (params.mode as MatchMode) || 'first';
   const useRegex = Boolean(params.useRegex);
   const skipWikilinks = Boolean(params.skipWikilinks);
-  const suggestOutgoingLinks = params.suggestOutgoingLinks !== false;
+  const suggestOutgoingLinks = params.suggestOutgoingLinks === true;
   const maxSuggestions = Number(params.maxSuggestions) || 3;
 
   const outcome = await executeMutation(

--- a/packages/mcp-server/src/tools/write/mutations.ts
+++ b/packages/mcp-server/src/tools/write/mutations.ts
@@ -283,7 +283,7 @@ export function registerMutationTools(
             childTextsForLinks = children.map(c => c.content);
           }
 
-          // 3. Suggest outgoing links (enabled by default)
+          // 3. Suggest outgoing links when explicitly enabled
           let suggestInfo: string | undefined;
           if (suggestOutgoingLinks && !skipWikilinks) {
             const suggestionText = childTextsForLinks.length > 0
@@ -447,7 +447,7 @@ export function registerMutationTools(
           // 2. Apply wikilinks to replacement text (unless skipped)
           let { content: processedReplacement } = maybeApplyWikilinks(workingReplacement, skipWikilinks, notePath, ctx.content);
 
-          // 3. Suggest outgoing links (enabled by default)
+          // 3. Suggest outgoing links when explicitly enabled
           if (suggestOutgoingLinks && !skipWikilinks) {
             const result = await suggestRelatedLinks(processedReplacement, { maxSuggestions, notePath });
             if (result.suffix) {

--- a/packages/mcp-server/src/tools/write/notes.ts
+++ b/packages/mcp-server/src/tools/write/notes.ts
@@ -160,7 +160,7 @@ export function registerNoteTools(
         // 4. Apply wikilinks to content (unless skipped)
         let { content: processedContent, wikilinkInfo } = maybeApplyWikilinks(effectiveContent, skipWikilinks, notePath);
 
-        // 5. Suggest outgoing links (enabled by default)
+        // 5. Suggest outgoing links when explicitly enabled
         let suggestInfo: string | undefined;
         if (suggestOutgoingLinks && !skipWikilinks) {
           const result = await suggestRelatedLinks(processedContent, { maxSuggestions, notePath });

--- a/packages/mcp-server/src/tools/write/tasks.ts
+++ b/packages/mcp-server/src/tools/write/tasks.ts
@@ -167,7 +167,7 @@ export function registerTaskTools(
           // 2. Apply wikilinks to task text (unless skipped)
           let { content: processedTask, wikilinkInfo } = maybeApplyWikilinks(workingTask, skipWikilinks, notePath);
 
-          // 3. Suggest outgoing links (enabled by default)
+          // 3. Suggest outgoing links when explicitly enabled
           let suggestInfo: string | undefined;
           if (suggestOutgoingLinks && !skipWikilinks) {
             const result = await suggestRelatedLinks(processedTask, { maxSuggestions, notePath });

--- a/packages/mcp-server/test/write/core/policy-executor.test.ts
+++ b/packages/mcp-server/test/write/core/policy-executor.test.ts
@@ -2,7 +2,7 @@
  * Tests for policy executor step output passing
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { executePolicy } from '../../../src/core/write/policy/executor.js';
 import type { PolicyDefinition } from '../../../src/core/write/policy/types.js';
 import {
@@ -10,9 +10,11 @@ import {
   cleanupTempVault,
   openStateDb,
   deleteStateDb,
+  createEntityCacheInStateDb,
   type StateDb,
 } from '../helpers/testUtils.js';
-import { setWriteStateDb } from '../../../src/core/write/wikilinks.js';
+import { initializeEntityIndex, setWriteStateDb } from '../../../src/core/write/wikilinks.js';
+import * as wikilinksModule from '../../../src/core/write/wikilinks.js';
 import { readVaultFile } from '../../../src/core/write/writer.js';
 import path from 'path';
 import fs from 'fs/promises';
@@ -20,6 +22,14 @@ import fs from 'fs/promises';
 describe('Policy Executor - Step Output Passing', () => {
   let vaultPath: string;
   let db: StateDb | null = null;
+
+  async function createTestEntitySetup(): Promise<void> {
+    createEntityCacheInStateDb(db!, vaultPath, {
+      technologies: ['TypeScript', 'JavaScript', 'Python'],
+      projects: ['MCP Server'],
+    });
+    await initializeEntityIndex(vaultPath);
+  }
 
   beforeEach(async () => {
     vaultPath = await createTempVault();
@@ -306,5 +316,80 @@ Original content here.
     expect(restored).toContain('title: Important Note');
     expect(restored).toContain('custom_field: preserve-me');
     expect(restored).toContain('tags:');
+  });
+
+  it('does not add outgoing link suffixes by default for policy writes', async () => {
+    await fs.writeFile(
+      path.join(vaultPath, 'project.md'),
+      '# Project\n\n## Notes\n\n'
+    );
+    await createTestEntitySetup();
+    const suggestSpy = vi.spyOn(wikilinksModule, 'suggestRelatedLinks');
+
+    const policy: PolicyDefinition = {
+      version: '1.0',
+      name: 'policy-default-no-suffix',
+      description: 'Policy writes should not append suffix suggestions unless enabled',
+      steps: [
+        {
+          id: 'add-note',
+          tool: 'vault_add_to_section',
+          params: {
+            path: 'project.md',
+            section: '## Notes',
+            content: 'Discussed TypeScript and JavaScript today.',
+            format: 'plain',
+          },
+        },
+      ],
+    };
+
+    const result = await executePolicy(policy, vaultPath, {}, false);
+
+    expect(result.success).toBe(true);
+    expect(suggestSpy).not.toHaveBeenCalled();
+    const { content } = await readVaultFile(vaultPath, 'project.md');
+    expect(content).toContain('[[TypeScript]]');
+    expect(content).toContain('[[JavaScript]]');
+    expect(content).not.toContain('→ [[');
+    suggestSpy.mockRestore();
+  });
+
+  it('adds outgoing link suffixes for policy writes when explicitly enabled', async () => {
+    await fs.writeFile(
+      path.join(vaultPath, 'project.md'),
+      '# Project\n\n## Notes\n\n'
+    );
+    const suggestSpy = vi.spyOn(wikilinksModule, 'suggestRelatedLinks').mockResolvedValue({
+      suggestions: ['MCP Server'],
+      suffix: '→ [[MCP Server]]',
+    });
+
+    const policy: PolicyDefinition = {
+      version: '1.0',
+      name: 'policy-explicit-suffix',
+      description: 'Policy writes should append suffix suggestions when enabled',
+      steps: [
+        {
+          id: 'add-note',
+          tool: 'vault_add_to_section',
+          params: {
+            path: 'project.md',
+            section: '## Notes',
+            content: 'Discussed TypeScript and JavaScript today.',
+            format: 'plain',
+            suggestOutgoingLinks: true,
+          },
+        },
+      ],
+    };
+
+    const result = await executePolicy(policy, vaultPath, {}, false);
+
+    expect(result.success).toBe(true);
+    expect(suggestSpy).toHaveBeenCalled();
+    const { content } = await readVaultFile(vaultPath, 'project.md');
+    expect(content).toContain('→ [[MCP Server]]');
+    suggestSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- keep auto-wikilinks on by default for write paths
- keep outgoing link suffix suggestions opt-in in policy execution
- add regression coverage for the default contract