### PR TITLE
chore: release flywheel-memory v2.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5975,7 +5975,7 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Summary:
- bump flywheel-memory to 2.12.1
- carry the chat-scoped session isolation MCP fix into a patch release
- retain the audit lockfile refresh included in main

Verification:
- npm run build -w @velvetmonkey/vault-core
- npm run lint in packages/mcp-server
- npm run build in packages/mcp-server
