### PR TITLE
chore: bump flywheel-memory to 2.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5975,7 +5975,7 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.12.1",
+      "version": "2.12.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump `@velvetmonkey/flywheel-memory` to `2.12.2`
- capture the published release version in source control after the npm publish

## Verification
- `npm run build`
- `npm run lint`
- `npm pack --dry-run -w @velvetmonkey/flywheel-memory`
- `npm run smoke:registry-latest -w @velvetmonkey/flywheel-memory`
