### PR TITLE
chore: release flywheel-memory v2.12.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5975,7 +5975,7 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.12.2",
+      "version": "2.12.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release branch for @velvetmonkey/flywheel-memory@2.12.3.\n\nPublished to npm: yes\nPost-publish smoke against @latest: passed\n\nChanges:\n- bump package version to 2.12.3\n- tag release as flywheel-memory-v2.12.3\n