### PR TITLE
Fix integrity worker tsx loader resolution

### DIFF
--- a/packages/mcp-server/src/core/read/integrity.ts
+++ b/packages/mcp-server/src/core/read/integrity.ts
@@ -7,8 +7,9 @@
 
 import * as path from 'node:path';
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { Worker } from 'node:worker_threads';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 export const INTEGRITY_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 export const INTEGRITY_CHECK_TIMEOUT_MS = 2 * 60 * 1000;
@@ -36,6 +37,13 @@ interface IntegrityWorkerMessage {
   busyTimeoutMs: number;
 }
 
+const requireFromHere = createRequire(import.meta.url);
+
+export function resolveTsxImportSpecifier(): string {
+  const tsxLoaderPath = requireFromHere.resolve('tsx');
+  return pathToFileURL(tsxLoaderPath).href;
+}
+
 function resolveWorkerSpec(): { filename: string; execArgv?: string[] } {
   const thisFile = fileURLToPath(import.meta.url);
   const thisDir = path.dirname(thisFile);
@@ -47,7 +55,7 @@ function resolveWorkerSpec(): { filename: string; execArgv?: string[] } {
   if (existsSync(distPath)) return { filename: distPath };
 
   const srcPath = path.join(thisDir, 'integrity-worker.ts');
-  return { filename: srcPath, execArgv: ['--import', 'tsx'] };
+  return { filename: srcPath, execArgv: ['--import', resolveTsxImportSpecifier()] };
 }
 
 export async function runIntegrityWorker(

--- a/packages/mcp-server/test/read/core/integrity.test.ts
+++ b/packages/mcp-server/test/read/core/integrity.test.ts
@@ -2,9 +2,10 @@ import { afterEach, describe, expect, test } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 
 import { openStateDb } from '@velvetmonkey/vault-core';
-import { runIntegrityWorker } from '../../../src/core/read/integrity.js';
+import { resolveTsxImportSpecifier, runIntegrityWorker } from '../../../src/core/read/integrity.js';
 
 const tempDirs: string[] = [];
 
@@ -16,6 +17,15 @@ afterEach(() => {
 });
 
 describe('integrity worker', () => {
+  test('resolves the tsx loader relative to the package', () => {
+    const specifier = resolveTsxImportSpecifier();
+    const resolvedPath = fileURLToPath(specifier).replace(/\\/g, '/');
+
+    expect(specifier).not.toBe('tsx');
+    expect(specifier.startsWith('file:')).toBe(true);
+    expect(resolvedPath).toContain('/node_modules/tsx/');
+  });
+
   test('runs quick_check in a worker and creates a backup', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'flywheel-integrity-'));
     tempDirs.push(tempDir);


### PR DESCRIPTION
## Summary
- resolve the integrity worker `tsx` loader relative to `packages/mcp-server` instead of using a bare module specifier
- pass the worker fallback an absolute `file:` URL so startup health checks do not depend on the process cwd
- add a regression test that locks the fallback to a resolved loader path under `node_modules/tsx`

## Testing
- `npm run build -w @velvetmonkey/vault-core`
- `npm test -- test/read/core/integrity.test.ts test/read/tools/health.test.ts`
- `npm run lint`