### PR TITLE
feat: add scoped private memory ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ An agent calling a proposal-writing skill works better when it can also search y
 
 ## The Flywheel Suite
 
-Flywheel Memory is the core memory engine. [Flywheel Crank](https://github.com/velvetmonkey/flywheel-crank) is the Obsidian plugin that visualizes the same local graph and workflows. [Flywheel Engine](https://github.com/velvetmonkey/flywheel-engine) is the service layer that calls Flywheel over MCP. Start with Flywheel Memory; add the other layers when you want UI or automation around the same vault.
+Flywheel Memory is the core memory engine. [Flywheel Crank](https://github.com/velvetmonkey/flywheel-crank) is the Obsidian plugin that visualizes the same local graph and workflows. Start with Flywheel Memory; add Crank when you want a UI around the same vault.
 
 ---
 

--- a/packages/core/src/migrations.ts
+++ b/packages/core/src/migrations.ts
@@ -503,6 +503,46 @@ export function initSchema(db: Database.Database): void {
       db.prepare('INSERT OR REPLACE INTO schema_version (version) VALUES (?)').run(41);
     }
 
+    if (currentVersion < 42 && v40Applied) {
+      const memoryColumns = new Set(
+        (db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name: string }>).map((row) => row.name)
+      );
+
+      if (!memoryColumns.has('owner_scope')) {
+        db.exec(`ALTER TABLE memories ADD COLUMN owner_scope TEXT NOT NULL DEFAULT 'global'`);
+      }
+
+      db.exec(`
+        UPDATE memories
+        SET owner_scope = CASE
+          WHEN visibility = 'private' AND source_agent_id IS NOT NULL AND TRIM(source_agent_id) <> '' THEN source_agent_id
+          ELSE 'global'
+        END
+        WHERE owner_scope IS NULL OR TRIM(owner_scope) = ''
+      `);
+
+      db.exec(`
+        DELETE FROM memories
+        WHERE id NOT IN (
+          SELECT id FROM (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY key, owner_scope
+                     ORDER BY updated_at DESC, id DESC
+                   ) AS row_num
+            FROM memories
+          )
+          WHERE row_num = 1
+        )
+      `);
+
+      db.exec(`DROP INDEX IF EXISTS idx_memories_key_owner_scope`);
+      db.exec(`CREATE UNIQUE INDEX idx_memories_key_owner_scope ON memories(key, owner_scope)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_memories_owner_scope ON memories(owner_scope)`);
+
+      db.prepare('INSERT OR REPLACE INTO schema_version (version) VALUES (?)').run(42);
+    }
+
     // Only stamp SCHEMA_VERSION at the end if every migration ran. Dry-run
     // skips v40 → leave schema_version at 39 so the next non-dry-run boot
     // re-enters the v40 branch.

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -10,7 +10,7 @@
 // =============================================================================
 
 /** Current schema version - bump when schema changes */
-export const SCHEMA_VERSION = 41;
+export const SCHEMA_VERSION = 42;
 
 /** State database filename */
 export const STATE_DB_FILENAME = 'state.db';
@@ -373,11 +373,14 @@ CREATE TABLE IF NOT EXISTS memories (
   accessed_at INTEGER NOT NULL,
   ttl_days INTEGER,
   superseded_by INTEGER REFERENCES memories(id),
-  visibility TEXT NOT NULL DEFAULT 'shared'
+  visibility TEXT NOT NULL DEFAULT 'shared',
+  owner_scope TEXT NOT NULL DEFAULT 'global'
 );
 CREATE INDEX IF NOT EXISTS idx_memories_key ON memories(key);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_key_owner_scope ON memories(key, owner_scope);
 CREATE INDEX IF NOT EXISTS idx_memories_entity ON memories(entity);
 CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(memory_type);
+CREATE INDEX IF NOT EXISTS idx_memories_owner_scope ON memories(owner_scope);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
   key, value,

--- a/packages/mcp-server/src/core/write/memory.ts
+++ b/packages/mcp-server/src/core/write/memory.ts
@@ -32,6 +32,7 @@ export interface Memory {
   ttl_days: number | null;
   superseded_by: number | null;
   visibility: string;
+  owner_scope: string;
 }
 
 export interface StoreMemoryOptions {
@@ -61,6 +62,8 @@ export interface ListMemoryOptions {
   agent_id?: string;
   include_expired?: boolean;
 }
+
+const GLOBAL_OWNER_SCOPE = 'global';
 
 export interface SessionSummary {
   id: number;
@@ -174,6 +177,29 @@ function removeGraphSignals(stateDb: StateDb, memoryKey: string): void {
   updateStoredNoteLinks(stateDb, sourcePath, new Set());
 }
 
+function resolveOwnerScope(
+  agentId: string | undefined,
+  visibility: 'shared' | 'private',
+): string {
+  if (visibility === 'private') {
+    if (!agentId) {
+      throw new Error('Private memories require agent_id');
+    }
+    return agentId;
+  }
+  return GLOBAL_OWNER_SCOPE;
+}
+
+function applyVisibilityFilter(conditions: string[], params: unknown[], agentId?: string): void {
+  if (agentId) {
+    conditions.push('(owner_scope = ? OR owner_scope = ?)');
+    params.push(GLOBAL_OWNER_SCOPE, agentId);
+    return;
+  }
+  conditions.push('owner_scope = ?');
+  params.push(GLOBAL_OWNER_SCOPE);
+}
+
 // =============================================================================
 // CORE FUNCTIONS
 // =============================================================================
@@ -197,6 +223,7 @@ export function storeMemory(
     session_id,
     visibility = 'shared',
   } = options;
+  const ownerScope = resolveOwnerScope(agent_id, visibility);
 
   const now = Date.now();
 
@@ -210,8 +237,8 @@ export function storeMemory(
 
   // Check if memory with this key already exists
   const existing = stateDb.db.prepare(
-    'SELECT id FROM memories WHERE key = ?'
-  ).get(key) as { id: number } | undefined;
+    'SELECT id FROM memories WHERE key = ? AND owner_scope = ?'
+  ).get(key, ownerScope) as { id: number } | undefined;
 
   if (existing) {
     // Upsert: update existing memory
@@ -220,35 +247,37 @@ export function storeMemory(
         value = ?, memory_type = ?, entity = ?, entities_json = ?,
         source_agent_id = ?, source_session_id = ?,
         confidence = ?, updated_at = ?, accessed_at = ?,
-        ttl_days = ?, visibility = ?, superseded_by = NULL
-      WHERE key = ?
+        ttl_days = ?, visibility = ?, owner_scope = ?, superseded_by = NULL
+      WHERE key = ? AND owner_scope = ?
     `).run(
       value, type, entity ?? null, entitiesJson,
       agent_id ?? null, session_id ?? null,
       confidence, now, now,
-      ttl_days ?? null, visibility, key,
+      ttl_days ?? null, visibility, ownerScope, key, ownerScope,
     );
   } else {
     // Insert new memory
     stateDb.db.prepare(`
       INSERT INTO memories (key, value, memory_type, entity, entities_json,
         source_agent_id, source_session_id, confidence,
-        created_at, updated_at, accessed_at, ttl_days, visibility)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        created_at, updated_at, accessed_at, ttl_days, visibility, owner_scope)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       key, value, type, entity ?? null, entitiesJson,
       agent_id ?? null, session_id ?? null, confidence,
-      now, now, now, ttl_days ?? null, visibility,
+      now, now, now, ttl_days ?? null, visibility, ownerScope,
     );
   }
 
-  // Update graph signals
-  updateGraphSignals(stateDb, key, detectedEntities);
+  // Private memories must not leak into shared graph-derived signals.
+  if (visibility === 'shared') {
+    updateGraphSignals(stateDb, key, detectedEntities);
+  }
 
   // Return the stored memory
   return stateDb.db.prepare(
-    'SELECT * FROM memories WHERE key = ?'
-  ).get(key) as Memory;
+    'SELECT * FROM memories WHERE key = ? AND owner_scope = ?'
+  ).get(key, ownerScope) as Memory;
 }
 
 /**
@@ -257,10 +286,23 @@ export function storeMemory(
 export function getMemory(
   stateDb: StateDb,
   key: string,
+  agent_id?: string,
 ): Memory | null {
-  const memory = stateDb.db.prepare(
-    'SELECT * FROM memories WHERE key = ? AND superseded_by IS NULL'
-  ).get(key) as Memory | undefined;
+  let memory: Memory | undefined;
+  if (agent_id) {
+    memory = stateDb.db.prepare(`
+      SELECT * FROM memories
+      WHERE key = ?
+        AND superseded_by IS NULL
+        AND (owner_scope = ? OR owner_scope = ?)
+      ORDER BY CASE owner_scope WHEN ? THEN 0 ELSE 1 END, updated_at DESC, id DESC
+      LIMIT 1
+    `).get(key, GLOBAL_OWNER_SCOPE, agent_id, agent_id) as Memory | undefined;
+  } else {
+    memory = stateDb.db.prepare(
+      'SELECT * FROM memories WHERE key = ? AND superseded_by IS NULL AND owner_scope = ? ORDER BY updated_at DESC, id DESC LIMIT 1'
+    ).get(key, GLOBAL_OWNER_SCOPE) as Memory | undefined;
+  }
 
   if (!memory) return null;
 
@@ -292,10 +334,7 @@ export function searchMemories(
     conditions.push('(m.entity = ? COLLATE NOCASE OR m.entities_json LIKE ?)');
     params.push(entity, `%"${entity}"%`);
   }
-  if (agent_id) {
-    conditions.push("(m.visibility = 'shared' OR m.source_agent_id = ?)");
-    params.push(agent_id);
-  }
+  applyVisibilityFilter(conditions, params, agent_id);
 
   const where = conditions.length > 0 ? `AND ${conditions.join(' AND ')}` : '';
 
@@ -341,10 +380,7 @@ export function listMemories(
     conditions.push('(entity = ? COLLATE NOCASE OR entities_json LIKE ?)');
     params.push(entity, `%"${entity}"%`);
   }
-  if (agent_id) {
-    conditions.push("(visibility = 'shared' OR source_agent_id = ?)");
-    params.push(agent_id);
-  }
+  applyVisibilityFilter(conditions, params, agent_id);
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
   params.push(limit);
@@ -360,18 +396,26 @@ export function listMemories(
 export function forgetMemory(
   stateDb: StateDb,
   key: string,
+  agent_id?: string,
 ): boolean {
-  const memory = stateDb.db.prepare(
-    'SELECT id FROM memories WHERE key = ?'
-  ).get(key) as { id: number } | undefined;
+  let memory: Memory | undefined;
+  if (agent_id) {
+    memory = stateDb.db.prepare(
+      'SELECT * FROM memories WHERE key = ? AND superseded_by IS NULL AND owner_scope = ? ORDER BY updated_at DESC, id DESC LIMIT 1'
+    ).get(key, agent_id) as Memory | undefined;
+  } else {
+    memory = stateDb.db.prepare(
+      'SELECT * FROM memories WHERE key = ? AND superseded_by IS NULL AND owner_scope = ? ORDER BY updated_at DESC, id DESC LIMIT 1'
+    ).get(key, GLOBAL_OWNER_SCOPE) as Memory | undefined;
+  }
 
   if (!memory) return false;
 
-  // Remove graph edges
-  removeGraphSignals(stateDb, key);
+  if (memory.visibility === 'shared' && memory.owner_scope === GLOBAL_OWNER_SCOPE) {
+    removeGraphSignals(stateDb, key);
+  }
 
-  // Delete the memory
-  stateDb.db.prepare('DELETE FROM memories WHERE key = ?').run(key);
+  stateDb.db.prepare('DELETE FROM memories WHERE id = ?').run(memory.id);
 
   return true;
 }

--- a/packages/mcp-server/src/tools/read/brief.ts
+++ b/packages/mcp-server/src/tools/read/brief.ts
@@ -123,9 +123,9 @@ function buildActiveEntitiesSection(stateDb: StateDb, limit: number): BriefSecti
  * Build active memories section.
  * Orders by type: recent observations first, then facts/preferences by confidence, then summaries.
  */
-function buildActiveMemoriesSection(stateDb: StateDb, limit: number): BriefSection {
+function buildActiveMemoriesSection(stateDb: StateDb, limit: number, agent_id?: string): BriefSection {
   // Fetch more than limit so we can reorder by type group, then truncate
-  const memories = listMemories(stateDb, { limit: limit * 2 });
+  const memories = listMemories(stateDb, { limit: limit * 2, agent_id });
 
   const observations = memories.filter(m => m.memory_type === 'observation');
   const factsAndPrefs = memories.filter(m => m.memory_type === 'fact' || m.memory_type === 'preference');
@@ -257,14 +257,20 @@ export async function runBrief(
   stateDb: StateDb,
   args: { max_tokens?: number; focus?: string; agent_id?: string },
 ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
-  const sections: BriefSection[] = [
-    buildSessionSection(stateDb, 5, args.agent_id),
-    buildActiveEntitiesSection(stateDb, 10),
-    buildActiveMemoriesSection(stateDb, 20),
-    buildCorrectionsSection(stateDb, 10),
-    buildVaultPulseSection(stateDb),
-    buildProactiveLinkingSection(stateDb),
-  ].filter((s): s is BriefSection => s !== null);
+  const focus = args.focus === 'personal' ? 'personal' : 'full';
+  const sections: BriefSection[] = (focus === 'personal'
+    ? [
+        buildSessionSection(stateDb, 5, args.agent_id),
+        buildActiveMemoriesSection(stateDb, 20, args.agent_id),
+      ]
+    : [
+        buildSessionSection(stateDb, 5, args.agent_id),
+        buildActiveEntitiesSection(stateDb, 10),
+        buildActiveMemoriesSection(stateDb, 20, args.agent_id),
+        buildCorrectionsSection(stateDb, 10),
+        buildVaultPulseSection(stateDb),
+        buildProactiveLinkingSection(stateDb),
+      ]).filter((s): s is BriefSection => s !== null);
 
   if (args.max_tokens) {
     let totalTokens = 0;

--- a/packages/mcp-server/src/tools/write/memory.ts
+++ b/packages/mcp-server/src/tools/write/memory.ts
@@ -34,14 +34,17 @@ export function registerMemoryTools(
       entity: z.string().optional().describe('[store|search] Primary entity association'),
       confidence: z.number().min(0).max(1).optional().describe('[store] Confidence level (0-1, default 1.0)'),
       ttl_days: z.number().min(1).optional().describe('[store] Time-to-live in days (null = permanent)'),
+      visibility: z.enum(['shared', 'private']).optional().describe('[store] Memory visibility. Defaults to private when agent_id is supplied, otherwise shared'),
       query: z.string().optional().describe('[search] FTS5 search query'),
       limit: z.number().min(1).max(200).optional().describe('[search|list] Max results to return'),
-      agent_id: z.string().optional().describe('[store|search|list|summarize_session|brief] Agent identifier for scoped memory/session context'),
+      agent_id: z.string().optional().describe('[store|get|search|list|forget|summarize_session|brief] Agent identifier for scoped memory/session context'),
       session_id: z.string().optional().describe('[summarize_session] Session ID'),
       summary: z.string().optional().describe('[summarize_session] Session summary text'),
       topics: z.array(z.string()).optional().describe('[summarize_session] Topics discussed'),
       notes_modified: z.array(z.string()).optional().describe('[summarize_session] Note paths modified'),
       tool_count: z.number().optional().describe('[summarize_session] Number of tool calls'),
+      focus: z.enum(['full', 'personal']).optional().describe('[brief] Brief composition mode'),
+      max_tokens: z.number().min(1).max(8000).optional().describe('[brief] Approximate token budget'),
     },
     async (args) => {
       const stateDb = getStateDb();
@@ -82,6 +85,7 @@ export function registerMemoryTools(
             ttl_days: args.ttl_days,
             agent_id: agentId,
             session_id: sessionId,
+            visibility: args.visibility ?? (agentId ? 'private' : 'shared'),
           });
           return {
             content: [{
@@ -95,6 +99,8 @@ export function registerMemoryTools(
                   entity: memory.entity,
                   entities_detected: memory.entities_json ? JSON.parse(memory.entities_json) : [],
                   confidence: memory.confidence,
+                  visibility: memory.visibility,
+                  owner_scope: memory.owner_scope,
                 },
               }, null, 2),
             }],
@@ -108,7 +114,7 @@ export function registerMemoryTools(
               isError: true,
             };
           }
-          const memory = getMemory(stateDb, args.key);
+          const memory = getMemory(stateDb, args.key, agentId);
           if (!memory) {
             return {
               content: [{ type: 'text' as const, text: JSON.stringify({ found: false, key: args.key }) }],
@@ -126,6 +132,8 @@ export function registerMemoryTools(
                   entity: memory.entity,
                   entities: memory.entities_json ? JSON.parse(memory.entities_json) : [],
                   confidence: memory.confidence,
+                  visibility: memory.visibility,
+                  owner_scope: memory.owner_scope,
                   created_at: memory.created_at,
                   updated_at: memory.updated_at,
                   accessed_at: memory.accessed_at,
@@ -159,6 +167,8 @@ export function registerMemoryTools(
                   type: m.memory_type,
                   entity: m.entity,
                   confidence: m.confidence,
+                  visibility: m.visibility,
+                  owner_scope: m.owner_scope,
                   updated_at: m.updated_at,
                 })),
                 count: results.length,
@@ -184,6 +194,8 @@ export function registerMemoryTools(
                   type: m.memory_type,
                   entity: m.entity,
                   confidence: m.confidence,
+                  visibility: m.visibility,
+                  owner_scope: m.owner_scope,
                   updated_at: m.updated_at,
                 })),
                 count: results.length,
@@ -199,7 +211,7 @@ export function registerMemoryTools(
               isError: true,
             };
           }
-          const deleted = forgetMemory(stateDb, args.key);
+          const deleted = forgetMemory(stateDb, args.key, agentId);
           return {
             content: [{
               type: 'text' as const,

--- a/packages/mcp-server/test/write/traces/no-refresh/memory-scope.trace.test.ts
+++ b/packages/mcp-server/test/write/traces/no-refresh/memory-scope.trace.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createWriteTestServer, type WriteTestServerContext } from '../../../helpers/createWriteTestServer.js';
+import { connectTestClient, type TestClient } from '../../../read/helpers/createTestServer.js';
+import { snap } from '../helpers/snapshotTools.js';
+
+describe('Trace: Memory scope and personal briefing', () => {
+  let ctx: WriteTestServerContext;
+  let client: TestClient;
+
+  beforeAll(async () => {
+    ctx = await createWriteTestServer();
+    client = connectTestClient(ctx.server);
+  }, 30_000);
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  it('keeps private and shared memories isolated by scope', async () => {
+    await snap(client, 'memory', {
+      action: 'store',
+      key: 'user.pref.drink',
+      value: 'Shared coffee preference',
+      type: 'preference',
+      visibility: 'shared',
+    });
+
+    await snap(client, 'memory', {
+      action: 'store',
+      key: 'user.pref.drink',
+      value: 'Private tea preference',
+      type: 'preference',
+      agent_id: 'tg-user:42',
+      visibility: 'private',
+    });
+
+    const shared = await snap(client, 'memory', {
+      action: 'get',
+      key: 'user.pref.drink',
+    });
+    expect(shared.memory.value).toContain('Shared coffee preference');
+
+    const scoped = await snap(client, 'memory', {
+      action: 'get',
+      key: 'user.pref.drink',
+      agent_id: 'tg-user:42',
+    });
+    expect(scoped.memory.value).toContain('Private tea preference');
+  });
+
+  it('brief focus personal excludes global sections', async () => {
+    await snap(client, 'memory', {
+      action: 'store',
+      key: 'user.pref.music',
+      value: 'Likes ambient playlists trace-scope',
+      type: 'preference',
+      agent_id: 'tg-user:77',
+      visibility: 'private',
+    });
+
+    const result = await snap(client, 'memory', {
+      action: 'brief',
+      agent_id: 'tg-user:77',
+      focus: 'personal',
+    });
+
+    expect(result).toHaveProperty('recent_sessions');
+    expect(result).toHaveProperty('active_memories');
+    expect(result).toHaveProperty('_meta');
+    expect(result).not.toHaveProperty('active_entities');
+    expect(result).not.toHaveProperty('pending_corrections');
+    expect(result).not.toHaveProperty('vault_pulse');
+    expect(JSON.stringify(result)).toContain('ambient playlists trace-scope');
+  });
+
+  it('forget with agent_id deletes private only', async () => {
+    await snap(client, 'memory', {
+      action: 'store',
+      key: 'user.pref.snack',
+      value: 'Shared almonds',
+      type: 'fact',
+      visibility: 'shared',
+    });
+
+    await snap(client, 'memory', {
+      action: 'store',
+      key: 'user.pref.snack',
+      value: 'Private mango',
+      type: 'fact',
+      agent_id: 'tg-user:9',
+      visibility: 'private',
+    });
+
+    const forgotten = await snap(client, 'memory', {
+      action: 'forget',
+      key: 'user.pref.snack',
+      agent_id: 'tg-user:9',
+    });
+    expect(forgotten.forgotten).toBe(true);
+
+    const shared = await snap(client, 'memory', {
+      action: 'get',
+      key: 'user.pref.snack',
+    });
+    expect(shared.memory.value).toContain('Shared almonds');
+
+    const scoped = await snap(client, 'memory', {
+      action: 'get',
+      key: 'user.pref.snack',
+      agent_id: 'tg-user:9',
+    });
+    expect(scoped.memory.value).toContain('Shared almonds');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds explicit scoped ownership to Flywheel memories via a new `owner_scope` column and `(key, owner_scope)` uniqueness so shared and private memories can coexist under the same logical key.
- Tightens the `memory` MCP contract so `store` supports `visibility`, scoped reads/writes honor `agent_id`, and `brief` supports `focus:"personal"` plus `max_tokens`.
- Prevents private memories from leaking into shared graph-derived signals by skipping shared recency/link updates for private writes.
- Adds focused trace coverage for scoped get/forget behavior and personal brief shaping.

## Behavior changes
- Unscoped `get`, `list`, `search`, and `forget` now operate on global shared memories only.
- Scoped calls with `agent_id` can see global shared plus same-scope private memories.
- Scoped `get(key, agent_id)` prefers the same-scope private memory over the global shared one.
- Scoped `forget(key, agent_id)` deletes only the same-scope private memory.
- `memory(action:"brief", focus:"personal")` now returns only `recent_sessions`, `active_memories`, and `_meta`.

## Schema and migration
- Bumps schema version from `41` to `42`.
- Adds `owner_scope TEXT NOT NULL DEFAULT 'global'` to `memories`.
- Backfills legacy rows to either `global` or `source_agent_id` for older private rows.
- Deduplicates conflicting `(key, owner_scope)` rows during migration, keeping the newest row.

## Test plan
- [x] `npm -C flywheel-memory run test -w @velvetmonkey/vault-core`
- [x] `npm -C flywheel-memory run test -w @velvetmonkey/flywheel-memory -- test/write/traces/no-refresh/memory.trace.test.ts test/write/traces/no-refresh/memory-scope.trace.test.ts`
- [x] `npm -C flywheel-memory run build -w @velvetmonkey/flywheel-memory`

## Notes
- I intentionally left `packages/mcp-server/test/graph-quality/reports/cross-vault-learning-report.json` out of the commit because it only had generated timestamp/duration churn from a test report.