### PR TITLE
feat(skills): add Flywheel agent skill for kepano-style onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,16 @@ Skills encode methodology: how to do something. Flywheel encodes knowledge: what
 
 An agent calling a proposal-writing skill works better when it can also search your vault for the client's history, past invoices, project notes, and team relationships. Skills tell agents how to work. Flywheel tells them what you know.
 
+### Install Flywheel as a Skill
+
+For users arriving from the Agent Skills ecosystem (kepano/obsidian-skills, claude-plugins.dev, skillsmp.com), Flywheel ships its own [`SKILL.md`](skills/flywheel/SKILL.md). It teaches an agent when to invoke Flywheel, walks the user through `.mcp.json` setup, and documents the read/write idiom. From your vault directory:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/velvetmonkey/flywheel-memory/main/skills/flywheel/scripts/install.sh)
+```
+
+The installer merges `.mcp.json`, copies the skill into `<vault>/.claude/skills/flywheel/`, and prints restart instructions. PowerShell variant for Windows users at [`skills/flywheel/scripts/install.ps1`](skills/flywheel/scripts/install.ps1). [Skill source and example queries ->](skills/flywheel/)
+
 [OpenClaw](https://github.com/openclaw) skills and Flywheel connect through MCP. OpenClaw routes intent and manages session flow; Flywheel provides the structured context and safe writes that make responses accurate. [Integration guide ->](docs/OPENCLAW.md)
 
 ---

--- a/skills/flywheel/SKILL.md
+++ b/skills/flywheel/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: flywheel
+description: Install and use the Flywheel MCP server to give an agent grounded memory over an Obsidian vault or any folder of plain Markdown notes — search, read, and safely write through bounded tool calls instead of raw Read/Grep/Edit.
+when_to_use: |
+  Use when the user wants AI memory over their Markdown notes. Trigger phrases:
+  "memory for my vault", "search my notes", "second brain for AI",
+  "let Claude (or Codex) work over my Obsidian", "Obsidian + agent",
+  "give my agent my notes". Do not use for code repositories, non-Markdown
+  directories, or when the user explicitly wants raw filesystem reads.
+---
+
+Flywheel turns a folder of `.md` files into a queryable knowledge layer over MCP. This skill walks the agent through registering the MCP server, restarting the client, and using the bounded read/write surface that follows.
+
+## When to use this skill
+
+Apply when:
+
+- The current directory (or a directory the user names) is a folder of Markdown notes — Obsidian-managed or not.
+- The user wants the agent to *answer from* their notes, *cite* them, or *append* to them.
+- The user asks for "memory", "second brain", or "search my vault".
+
+Do **not** apply for:
+
+- Code repositories (use `Read`/`Grep`/`Edit`).
+- One-shot file edits where the agent already knows the path.
+- Non-Markdown content (HTML, code, binary files).
+
+## Compatibility
+
+| Runtime | How the skill loads |
+|---|---|
+| Claude Code | Auto-discovered from `<vault>/.claude/skills/flywheel/SKILL.md` after the install script runs. |
+| Codex CLI | Copy `SKILL.md` to `~/.codex/skills/flywheel/SKILL.md` manually, or have the install script do it (`--codex` flag). |
+| ChatGPT (Custom GPT) | Paste the body of this `SKILL.md` into the GPT instruction set. The MCP install path (`.mcp.json`) does not apply. |
+
+The `.mcp.json` register step works in any client that speaks the Model Context Protocol — Claude Code, Codex CLI, Cursor, Windsurf, VS Code with MCP extensions, etc. See the project README's [client setup guide](../../docs/SETUP.md) for client-specific config differences.
+
+## Prerequisites
+
+Before installing, confirm:
+
+1. **Node ≥ 18** is on PATH. `node --version` should print `v18` or higher. The MCP server runs via `npx`; npx is bundled with npm.
+2. **A folder of `.md` files.** It does not need to be a fully-fledged Obsidian vault — Flywheel works on plain Markdown directories.
+3. **Write access** to the vault directory. Flywheel keeps a local index at `<vault>/.flywheel/state.db` and (when run via the install script) copies this skill into `<vault>/.claude/skills/flywheel/`.
+
+If any prerequisite is missing, stop and tell the user what to install before continuing.
+
+## Install (one-time, per vault) — STOP after this step
+
+The MCP server registration only takes effect on the **next** client launch. Do not call any `mcp__flywheel__*` tool until the user has restarted their client.
+
+### Automated install (recommended)
+
+From the vault directory:
+
+**POSIX (macOS/Linux/WSL):**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/velvetmonkey/flywheel-memory/main/skills/flywheel/scripts/install.sh)
+```
+
+Or, if the user already has the `flywheel-memory` repo cloned:
+
+```bash
+bash /path/to/flywheel-memory/skills/flywheel/scripts/install.sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iex (irm https://raw.githubusercontent.com/velvetmonkey/flywheel-memory/main/skills/flywheel/scripts/install.ps1)
+```
+
+The script:
+
+1. Writes (or merges) `.mcp.json` in the current directory with the canonical Flywheel snippet.
+2. Copies this `SKILL.md` to `<vault>/.claude/skills/flywheel/SKILL.md` so Claude Code auto-discovers it next session.
+3. Prints the restart instruction.
+
+### Manual install
+
+Add to the vault's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "flywheel": {
+      "command": "npx",
+      "args": ["-y", "@velvetmonkey/flywheel-memory"]
+    }
+  }
+}
+```
+
+Windows users: replace `"command": "npx"` with `"command": "cmd"` and prepend `"/c", "npx"` to args, plus set `FLYWHEEL_WATCH_POLL: "true"`. See the project README's Windows section.
+
+### After install — restart the client
+
+```text
+1. Exit your current client session (Ctrl+D / `exit` / close the window).
+2. Re-launch from the vault directory: `claude` or `codex`.
+3. The Flywheel MCP server starts on first tool call (≈3-5s warmup via npx).
+```
+
+**Stop here on first install.** Tell the user: *"`.mcp.json` is written. Exit and re-launch `claude` (or `codex`) from this directory, then ask me again."* Do not attempt to call Flywheel tools in the same session — they are only registered at client startup.
+
+## Pick a preset before querying
+
+Flywheel exposes three preset tiers. The default `agent` preset is narrow — pick the right tier *before* attempting a query so the right tool is available.
+
+| Preset | When to use | How to set |
+|---|---|---|
+| `agent` (default, 12-13 tools) | First-time use, simple search + write workflows. | Default — no config change. |
+| `power` (17 tools) | Wikilink work, alias hygiene, corrections, schema renames. | Add `"env": { "FLYWHEEL_TOOLS": "power" }` under the server config in `.mcp.json`. |
+| `full` (19 tools) | Graph traversal, temporal analysis, cross-vault, advanced diagnostics. | Set `FLYWHEEL_TOOLS` to `full`. |
+| `auto` (20 tools) | Full surface plus runtime tool discovery via `discover_tools`. | Set `FLYWHEEL_TOOLS` to `auto`. |
+
+Under Claude Code (`CLAUDECODE=1`), the `memory` tool is suppressed because Claude Code ships its own memory plane — the agent preset exposes 12 tools instead of 13. The briefing entrypoint still works via `memory(action: "brief")` if explicitly required.
+
+## Tool surface (agent preset)
+
+Once the MCP is live, prefer these tools over raw filesystem operations:
+
+| Tool | Purpose | Idiom |
+|---|---|---|
+| `mcp__flywheel__search` | Hybrid BM25 + semantic search across the vault. | First call for any "find X" / "what do I know about X" question. |
+| `mcp__flywheel__read` | Note structure (`action: structure`), one section (`action: section`), or vault-wide heading search (`action: sections`). | After `search`, when the snippet is not enough. |
+| `mcp__flywheel__find_notes` | Enumerate notes by folder, tag, or frontmatter. | Structural listing — not relevance-ranked search. |
+| `mcp__flywheel__edit_section` | Bounded write to a named section (`action: add` / `remove` / `replace`). | Use instead of `Edit` for any vault write. Single section target = high reliability. |
+| `mcp__flywheel__note` | Create / move / rename / delete a note. | Whole-note operations only. |
+| `mcp__flywheel__memory` | Cross-session memory store (`action: store` / `get` / `search` / `brief`). | Suppressed under Claude Code; do not call here. |
+| `mcp__flywheel__tasks` | List or toggle tasks (`action: list` / `toggle`). | Task-frontmatter aware. |
+
+Full tool reference: [docs/TOOLS.md](../../docs/TOOLS.md). Browse with `mcp__flywheel__doctor` (`action: pipeline` / `health` / `stats`) when a query returns unexpected results.
+
+## Read/write idiom
+
+The shape Flywheel rewards:
+
+1. **Search first.** Issue `search(query: "...")` with the user's natural language. The result includes ranked snippets, section provenance, frontmatter, backlinks, and outlinks — usually enough to answer without reading full files.
+2. **Cite, don't paraphrase.** When answering, name the path and quote the section so the user can verify in their vault.
+3. **Read on escalation.** If the snippet is insufficient, call `read(action: structure, path: "...")` for the outline plus metadata, or `read(action: section, path: "...", heading: "...")` for one section's full text.
+4. **Write through `edit_section`.** Never use `Edit` to modify vault files — the bounded `edit_section(action: add)` preserves Markdown structure, supports rollback via the local Git mirror, and triggers the wikilink suggestion pipeline. Target a single named section.
+
+## Verification (run on a fresh install)
+
+After the user restarts the client and asks a vault question:
+
+1. **Tool registration check.** Before the first user query, confirm `mcp__flywheel__search` appears in the available tool list. If not, the MCP server failed to register — re-check `.mcp.json` and tell the user to fully exit (not just `/clear`) and relaunch.
+2. **Search smoke test.** Run a known-good query that should hit something in the vault (e.g., the user's own name from a daily note). Confirm the result is grounded in their actual files (paths returned should exist on disk).
+3. **Bounded write smoke test.** Pick a note with at least one `## ` section. Run `edit_section(action: add, path: <note>, section: <heading>, content: "Status: paid")`. Confirm the file on disk now contains that line under that section, with surrounding content intact.
+
+If any of the three fails, do not proceed with the user's actual task — surface the failure first.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `mcp__flywheel__*` tools missing from tool list | MCP not registered, or client not restarted after `.mcp.json` write. | `cat .mcp.json` → confirm the `flywheel` block exists. Fully exit the client and relaunch. |
+| Search returns empty | Index not yet built, or wrong directory. | Wait 5-10s for the watcher to ingest, or run `mcp__flywheel__refresh_index`. Confirm `pwd` is the vault root. |
+| Stale results after editing files | Watcher missed an event (common on Windows / network drives). | Run `mcp__flywheel__refresh_index` to force a full rescan. As last resort: delete `.flywheel/state.db` and let Flywheel rebuild. |
+| Write succeeds but section content looks wrong | `section` heading text didn't match the file's heading. | Call `read(action: structure, path: ...)` first to confirm the exact heading text, then retry the write. |
+
+## Reference
+
+- Project README and full tool reference: `../../README.md`, `../../docs/TOOLS.md`.
+- Multi-vault config: `../../docs/CONFIGURATION.md#multi-vault`.
+- Client-specific setup (Cursor, VS Code, Windsurf, etc.): `../../docs/SETUP.md`.
+- Demo prompts that exercise this skill: [examples/carter-strategy-queries.md](examples/carter-strategy-queries.md).

--- a/skills/flywheel/examples/carter-strategy-queries.md
+++ b/skills/flywheel/examples/carter-strategy-queries.md
@@ -1,0 +1,59 @@
+# Example queries that exercise the Flywheel skill
+
+These prompts are taken from the [carter-strategy demo vault](../../../demos/carter-strategy/) — a battle-tested fixture for verifying Flywheel works end-to-end. Each shows the natural-language ask and the Flywheel tool path the agent should follow.
+
+> Run them from `flywheel-memory/demos/carter-strategy/` after installing the skill (`bash ../../skills/flywheel/scripts/install.sh` from that directory) and restarting your client.
+
+## Read-only: search-and-cite
+
+### 1. Cross-note billing total
+
+```
+How much have I billed Acme Corp?
+```
+
+Expected path: `search` (query: "Acme Corp billing invoice") → returns the client note plus invoice backlinks → answer cites the invoice paths and the running total. No file reads required.
+
+### 2. Task triage across the vault
+
+```
+What's overdue this week?
+```
+
+Expected path: `tasks(action: list)` filtered by due date → answer lists task lines with their source notes.
+
+### 3. Team availability cross-reference
+
+```
+Who's available to staff the Beta Corp Dashboard?
+```
+
+Expected path: `search` against project + team notes → cross-reference utilization frontmatter → cite candidates with their current load.
+
+### 4. Period summary
+
+```
+Summarize my Q4 2025.
+```
+
+Expected path: `search` ("Q4 2025") → `read(action: structure)` on the Quarterly Review note → cite top wins, blockers, and revenue.
+
+## Bounded write — proves `edit_section`
+
+### 5. Append a status under a known section
+
+```
+Append "Status: paid" under the Billing section of clients/Acme Corp.md.
+```
+
+Expected path: `read(action: structure, path: "clients/Acme Corp.md")` to confirm the heading text → `edit_section(action: add, path: "clients/Acme Corp.md", section: "Billing", content: "Status: paid")` → confirm by re-reading the section.
+
+This is the recommended *first* write any new user runs. Single section target, single line, deterministic — if it works, the bounded-write path is healthy.
+
+## What to check after running these
+
+- `search` returns ranked results with `path`, `snippet`, `frontmatter`, `backlinks`, `outlinks`, and `section_content`.
+- `edit_section(action: add)` appends the line to the correct section without disturbing surrounding content.
+- The vault's Git mirror at `.flywheel/.git/` records the write as a commit, so the user can `git diff` to inspect or `git revert` to undo.
+
+If any of these break, see [Troubleshooting in SKILL.md](../SKILL.md#troubleshooting).

--- a/skills/flywheel/scripts/install.ps1
+++ b/skills/flywheel/scripts/install.ps1
@@ -1,0 +1,71 @@
+# Flywheel skill installer (PowerShell, Windows).
+# Writes/merges .mcp.json in the current directory and installs SKILL.md
+# into <vault>/.claude/skills/flywheel/ for auto-discovery by Claude Code.
+
+param(
+  [string]$Vault = (Get-Location).Path,
+  [switch]$Codex
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $Vault -PathType Container)) {
+  Write-Error "vault directory does not exist: $Vault"
+  exit 1
+}
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillSrc = Join-Path (Split-Path -Parent $ScriptDir) 'SKILL.md'
+if (-not (Test-Path $SkillSrc)) {
+  Write-Error "SKILL.md not found at $SkillSrc"
+  exit 1
+}
+
+# Windows requires `cmd /c npx` because npx is a .cmd script that cannot be spawned directly.
+$Snippet = [ordered]@{
+  command = 'cmd'
+  args    = @('/c', 'npx', '-y', '@velvetmonkey/flywheel-memory')
+  env     = [ordered]@{ FLYWHEEL_WATCH_POLL = 'true' }
+}
+
+# 1. Merge .mcp.json
+$McpFile = Join-Path $Vault '.mcp.json'
+if (Test-Path $McpFile) {
+  $raw = Get-Content $McpFile -Raw
+  try {
+    $data = $raw | ConvertFrom-Json -AsHashtable
+  } catch {
+    Write-Error "existing $McpFile is not valid JSON: $_"
+    exit 1
+  }
+} else {
+  $data = @{}
+}
+if (-not $data.ContainsKey('mcpServers')) { $data['mcpServers'] = @{} }
+$data['mcpServers']['flywheel'] = $Snippet
+$data | ConvertTo-Json -Depth 10 | Set-Content -Path $McpFile -Encoding UTF8
+Write-Host "  written:   $McpFile"
+
+# 2. Install SKILL.md into vault's .claude/skills/flywheel/
+$SkillDestDir = Join-Path $Vault '.claude/skills/flywheel'
+New-Item -ItemType Directory -Force -Path $SkillDestDir | Out-Null
+Copy-Item -Force $SkillSrc (Join-Path $SkillDestDir 'SKILL.md')
+Write-Host "  installed: $(Join-Path $SkillDestDir 'SKILL.md')"
+
+# 3. Optional Codex install
+if ($Codex) {
+  $CodexDir = Join-Path $HOME '.codex/skills/flywheel'
+  New-Item -ItemType Directory -Force -Path $CodexDir | Out-Null
+  Copy-Item -Force $SkillSrc (Join-Path $CodexDir 'SKILL.md')
+  Write-Host "  installed: $(Join-Path $CodexDir 'SKILL.md') (codex)"
+}
+
+Write-Host ''
+Write-Host 'Flywheel skill installed.'
+Write-Host ''
+Write-Host 'Next steps:'
+Write-Host '  1. Exit your current Claude Code or Codex session if one is running.'
+Write-Host '  2. Re-launch the client from this directory: `claude` or `codex`.'
+Write-Host '  3. The Flywheel MCP server starts on first tool call (~3-5s warmup).'
+Write-Host ''
+Write-Host 'Do NOT continue in the same session — MCP servers register at client startup only.'

--- a/skills/flywheel/scripts/install.sh
+++ b/skills/flywheel/scripts/install.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Flywheel skill installer (POSIX).
+# Writes/merges .mcp.json in the current directory and installs SKILL.md
+# into <vault>/.claude/skills/flywheel/ for auto-discovery by Claude Code.
+# Optional --codex flag also installs to ~/.codex/skills/flywheel/.
+
+set -euo pipefail
+
+VAULT=""
+INSTALL_CODEX=false
+for arg in "$@"; do
+  case "$arg" in
+    --codex) INSTALL_CODEX=true ;;
+    --*) echo "error: unknown flag: $arg" >&2; exit 1 ;;
+    *) if [ -z "$VAULT" ]; then VAULT="$arg"; else echo "error: unexpected argument: $arg" >&2; exit 1; fi ;;
+  esac
+done
+VAULT="${VAULT:-$PWD}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required for JSON merging but was not found on PATH" >&2
+  exit 1
+fi
+
+if [ ! -d "$VAULT" ]; then
+  echo "error: vault directory does not exist: $VAULT" >&2
+  exit 1
+fi
+
+cd "$VAULT"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_SRC="$(cd "$SCRIPT_DIR/.." && pwd)/SKILL.md"
+
+if [ ! -f "$SKILL_SRC" ]; then
+  echo "error: SKILL.md not found at $SKILL_SRC" >&2
+  echo "  this script expects to live at <repo>/skills/flywheel/scripts/install.sh" >&2
+  exit 1
+fi
+
+# 1. Merge Flywheel into .mcp.json
+MCP_FILE="$VAULT/.mcp.json"
+python3 - "$MCP_FILE" <<'PY'
+import json, os, sys
+path = sys.argv[1]
+snippet = {
+    "command": "npx",
+    "args": ["-y", "@velvetmonkey/flywheel-memory"],
+}
+if os.path.exists(path):
+    with open(path) as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError as e:
+            sys.exit(f"error: existing {path} is not valid JSON: {e}")
+else:
+    data = {}
+servers = data.setdefault("mcpServers", {})
+existing = servers.get("flywheel")
+if existing == snippet:
+    print(f"  unchanged: {path} already has the canonical Flywheel block")
+else:
+    servers["flywheel"] = snippet
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    print(f"  written:   {path}")
+PY
+
+# 2. Install SKILL.md into vault's .claude/skills/flywheel/
+SKILL_DEST_DIR="$VAULT/.claude/skills/flywheel"
+mkdir -p "$SKILL_DEST_DIR"
+cp "$SKILL_SRC" "$SKILL_DEST_DIR/SKILL.md"
+echo "  installed: $SKILL_DEST_DIR/SKILL.md"
+
+# 3. Optional Codex install
+if [ "$INSTALL_CODEX" = true ]; then
+  CODEX_DIR="$HOME/.codex/skills/flywheel"
+  mkdir -p "$CODEX_DIR"
+  cp "$SKILL_SRC" "$CODEX_DIR/SKILL.md"
+  echo "  installed: $CODEX_DIR/SKILL.md (codex)"
+fi
+
+echo
+echo "Flywheel skill installed."
+echo
+echo "Next steps:"
+echo "  1. Exit your current Claude Code or Codex session if one is running."
+echo "  2. Re-launch the client from this directory: \`claude\` or \`codex\`."
+echo "  3. The Flywheel MCP server starts on first tool call (~3-5s warmup)."
+echo
+echo "Do NOT continue in the same session — MCP servers register at client startup only."


### PR DESCRIPTION
## Summary

Publishes an [Agent Skills](https://agentskills.io)-compatible `SKILL.md` so users arriving from kepano/obsidian-skills, claude-plugins.dev, or skillsmp.com can install Flywheel directly into their vault, instead of hand-editing `.mcp.json` from the README.

- `skills/flywheel/SKILL.md` — model-invokable skill. Frontmatter triggers on "memory for my vault" / "search my notes" / "second brain for AI". Body covers compatibility (Claude Code auto-discovery, Codex CLI / ChatGPT manual placement), prerequisites, install with an explicit **stop-and-restart-client** barrier (MCP registers at startup only), preset selection (`agent`/`power`/`full`/`auto`), tool surface, read/write idiom, verification triple, and troubleshooting.
- `skills/flywheel/scripts/install.sh` — POSIX installer. Merges `.mcp.json` idempotently (Python `json`, no `jq` dependency), copies SKILL.md to `<vault>/.claude/skills/flywheel/` for project-level auto-discovery, optional `--codex` flag also installs to `~/.codex/skills/flywheel/`.
- `skills/flywheel/scripts/install.ps1` — PowerShell sibling for Windows. Uses `cmd /c npx` + `FLYWHEEL_WATCH_POLL=true` per the documented Windows MCP shape.
- `skills/flywheel/examples/carter-strategy-queries.md` — 5 prompts cribbed from the carter-strategy demo, including a deterministic single-section bounded write that validates `edit_section` on day-1.
- `README.md` — adds a one-paragraph **Install Flywheel as a Skill** subsection under the existing **Skills + Flywheel** section.

Closes the kepano/obsidian-skills positioning item from `roadmap-active.md` (Apr 2026).

## Design notes

- **Stop-and-restart barrier.** MCP clients resolve `.mcp.json` at startup; the skill cannot bind new MCP tools mid-session. Body explicitly tells the agent to stop after writing `.mcp.json`, instruct the user to restart, and only call `mcp__flywheel__*` tools in the *next* session.
- **No `jq` dependency.** Installer uses Python's `json` module — Python is on every modern macOS and most Linux distros; `jq` is not.
- **Cross-CLI honesty.** Auto-discovery works in Claude Code from `<vault>/.claude/skills/flywheel/`. Codex CLI users get a `--codex` flag (or manual copy). ChatGPT users paste the body into a Custom GPT — no false zero-config claim.
- **Day-1 deterministic write.** Verification step is "append `Status: paid` under a known `## ` section", not a multi-step task — single section target, low chance of LLM mis-targeting.

## Test plan

- [x] `install.sh` against a fresh `/tmp/test-flywheel-skill/` — `.mcp.json` written, SKILL.md copied to `.claude/skills/flywheel/`.
- [x] `install.sh` against a vault with an existing `.mcp.json` containing another MCP server — Flywheel block merged, existing block preserved.
- [x] `install.sh` rerun on already-installed vault — idempotent, prints `unchanged`.
- [x] `install.sh --codex` — also writes `~/.codex/skills/flywheel/SKILL.md`.
- [x] `install.sh --bogus` — exits non-zero with clear error.
- [ ] End-to-end smoke test under `claude` against `demos/carter-strategy/` after restart — confirm `mcp__flywheel__search` registers, returns grounded results, `edit_section(action: add)` executes a single-section write.
- [ ] PowerShell installer verified on a Windows host (deferred — no Windows test environment in CI).
- [ ] CI lint/build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)