### PR TITLE
docs(skills): lead install with `npx skills add`, demote install.sh to MCP wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,13 +243,26 @@ An agent calling a proposal-writing skill works better when it can also search y
 
 ### Install Flywheel as a Skill
 
-For users arriving from the Agent Skills ecosystem (kepano/obsidian-skills, claude-plugins.dev, skillsmp.com), Flywheel ships its own [`SKILL.md`](skills/flywheel/SKILL.md). It teaches an agent when to invoke Flywheel, walks the user through `.mcp.json` setup, and documents the read/write idiom. From your vault directory:
+For users arriving from the Agent Skills ecosystem (kepano/obsidian-skills, claude-plugins.dev, skillsmp.com), Flywheel ships its own [`SKILL.md`](skills/flywheel/SKILL.md). It teaches an agent when to invoke Flywheel, walks the user through `.mcp.json` setup, and documents the read/write idiom.
+
+**Step 1: install the skill** with [`npx skills`](https://github.com/vercel-labs/skills) (the standard Agent Skills installer — GitHub-as-registry):
+
+```bash
+npx -y skills add velvetmonkey/flywheel-memory       # project scope (.claude/skills/)
+npx -y skills add velvetmonkey/flywheel-memory -g    # global scope (~/.claude/skills/)
+```
+
+`npx skills` clones the repo, finds `skills/flywheel/SKILL.md`, and symlinks it into your agent's skills directory. Updates pull through automatically.
+
+**Step 2: wire the MCP server** so the skill's tools are actually callable. From your vault directory:
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/velvetmonkey/flywheel-memory/main/skills/flywheel/scripts/install.sh)
 ```
 
-The installer merges `.mcp.json`, copies the skill into `<vault>/.claude/skills/flywheel/`, and prints restart instructions. PowerShell variant for Windows users at [`skills/flywheel/scripts/install.ps1`](skills/flywheel/scripts/install.ps1). [Skill source and example queries ->](skills/flywheel/)
+The installer merges Flywheel into `<vault>/.mcp.json` and prints restart instructions. PowerShell variant for Windows users at [`skills/flywheel/scripts/install.ps1`](skills/flywheel/scripts/install.ps1). If you'd rather hand-edit, see the [Quick start](#your-vault-in-2-minutes) snippet above.
+
+**Step 3: restart your client** (`claude` / `codex`). MCP servers register at startup only. [Skill source and example queries ->](skills/flywheel/)
 
 [OpenClaw](https://github.com/openclaw) skills and Flywheel connect through MCP. OpenClaw routes intent and manages session flow; Flywheel provides the structured context and safe writes that make responses accurate. [Integration guide ->](docs/OPENCLAW.md)
 

--- a/skills/flywheel/SKILL.md
+++ b/skills/flywheel/SKILL.md
@@ -13,13 +13,13 @@ Flywheel turns a folder of `.md` files into a queryable knowledge layer over MCP
 
 ## Quick Start
 
-If `mcp__flywheel__*` tools are not registered in this session, redirect the user to the 3-line install instead of attempting Flywheel calls:
+If `mcp__flywheel__*` tools are not registered in this session, redirect the user to the 3-step install instead of attempting Flywheel calls:
 
-1. From the vault directory: `bash <(curl -fsSL https://raw.githubusercontent.com/velvetmonkey/flywheel-memory/main/skills/flywheel/scripts/install.sh)`
-2. Exit the client and relaunch (`claude` / `codex`) — MCP servers register at startup only.
-3. Ask the question again — Flywheel tools are now available.
+1. **Install the skill** (if not already): `npx -y skills add velvetmonkey/flywheel-memory -g`
+2. **Wire the MCP** in the vault directory: `bash <(curl -fsSL https://raw.githubusercontent.com/velvetmonkey/flywheel-memory/main/skills/flywheel/scripts/install.sh)`
+3. **Restart the client** (`claude` / `codex`) — MCP servers register at startup only — then ask the question again.
 
-Windows users substitute the PowerShell variant from the [Install](#install-one-time-per-vault--stop-after-this-step) section. Everything below this line is reference material the agent reads only once Flywheel is live.
+If the user already ran the skill install and only the MCP is missing, skip step 1. If both are missing, run them in order. Windows users substitute the PowerShell variant from the [Install](#install-one-time-per-vault--stop-after-this-step) section. Everything below this line is reference material the agent reads only once Flywheel is live.
 
 ## When to use this skill
 
@@ -57,9 +57,17 @@ If any prerequisite is missing, stop and tell the user what to install before co
 
 ## Install (one-time, per vault) — STOP after this step
 
-The MCP server registration only takes effect on the **next** client launch. Do not call any `mcp__flywheel__*` tool until the user has restarted their client.
+Flywheel install has two parts: the **skill** (this `SKILL.md`, so the agent knows when and how to use Flywheel) and the **MCP server** (so the tools actually exist). The standard flow is `npx skills add` for the skill, then `install.sh` (or manual `.mcp.json` edit) for the MCP. The MCP server registration only takes effect on the **next** client launch — do not call any `mcp__flywheel__*` tool until the user has restarted their client.
 
-### Automated install (recommended)
+### Step 1 — install the skill via `npx skills`
+
+```bash
+npx -y skills add velvetmonkey/flywheel-memory -g
+```
+
+Drop the `-g` to install at project scope (`.claude/skills/`) instead of global (`~/.claude/skills/`). `npx skills` symlinks the canonical SKILL.md from the repo, so updates pull through automatically. If the user landed here via `npx skills add` already, this step is done.
+
+### Step 2 — wire the MCP server
 
 From the vault directory:
 
@@ -81,13 +89,13 @@ bash /path/to/flywheel-memory/skills/flywheel/scripts/install.sh
 iex (irm https://raw.githubusercontent.com/velvetmonkey/flywheel-memory/main/skills/flywheel/scripts/install.ps1)
 ```
 
-The script:
+The MCP installer:
 
 1. Writes (or merges) `.mcp.json` in the current directory with the canonical Flywheel snippet.
-2. Copies this `SKILL.md` to `<vault>/.claude/skills/flywheel/SKILL.md` so Claude Code auto-discovers it next session.
+2. Optionally, with `--codex`, also copies the skill into `~/.codex/skills/flywheel/` for users who haven't installed via `npx skills` yet.
 3. Prints the restart instruction.
 
-### Manual install
+### Manual install (no installers)
 
 Add to the vault's `.mcp.json`:
 

--- a/skills/flywheel/scripts/install.ps1
+++ b/skills/flywheel/scripts/install.ps1
@@ -1,6 +1,11 @@
-# Flywheel skill installer (PowerShell, Windows).
-# Writes/merges .mcp.json in the current directory and installs SKILL.md
-# into <vault>/.claude/skills/flywheel/ for auto-discovery by Claude Code.
+# Flywheel MCP installer (PowerShell, Windows).
+#
+# Primary job: write/merge Flywheel into <vault>/.mcp.json so the Flywheel
+# MCP server is registered for the user's client (Claude Code, Codex, etc).
+#
+# Secondary: also drop SKILL.md into <vault>/.claude/skills/flywheel/ at
+# project scope as a fallback for users who haven't installed the skill
+# via `npx skills add velvetmonkey/flywheel-memory`.
 
 param(
   [string]$Vault = (Get-Location).Path,

--- a/skills/flywheel/scripts/install.sh
+++ b/skills/flywheel/scripts/install.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
-# Flywheel skill installer (POSIX).
-# Writes/merges .mcp.json in the current directory and installs SKILL.md
-# into <vault>/.claude/skills/flywheel/ for auto-discovery by Claude Code.
+# Flywheel MCP installer (POSIX).
+#
+# Primary job: write/merge Flywheel into <vault>/.mcp.json so the Flywheel
+# MCP server is registered for the user's client (Claude Code, Codex, etc).
+#
+# Secondary: also drop SKILL.md into <vault>/.claude/skills/flywheel/ at
+# project scope as a fallback for users who haven't installed the skill
+# via `npx skills add velvetmonkey/flywheel-memory`. If the user already
+# ran the canonical skill install, this overwrite is harmless.
+#
 # Optional --codex flag also installs to ~/.codex/skills/flywheel/.
 
 set -euo pipefail


### PR DESCRIPTION
## Summary

Aligns Flywheel's skill install docs with the kepano/[`vercel-labs/skills`](https://github.com/vercel-labs/skills) convention — `npx skills add <org/repo>`, GitHub-as-registry. Our `skills/flywheel/SKILL.md` layout already matches `npx skills`' discovery rules (root or `skills/*/SKILL.md`), so `npx -y skills add velvetmonkey/flywheel-memory` Just Works.

The new flow is two-step: install the skill via `npx skills`, then wire the MCP via `install.sh` (or hand-edit `.mcp.json`). `install.sh` is reframed as the MCP installer; its secondary skill-copy behavior is kept as a fallback for users who skip step 1.

### Changes

- **`README.md`** — *Install Flywheel as a Skill* now leads with `npx -y skills add velvetmonkey/flywheel-memory` (and `-g` for global scope), with `install.sh` demoted to *step 2: wire the MCP server*.
- **`skills/flywheel/SKILL.md`** —
  - *Quick Start*: three steps in the new order (skill install → MCP wire → restart). "Skip step 1 if already installed" hint so the agent picks the right escape hatch.
  - *Install*: split into *Step 1 — install the skill via `npx skills`* and *Step 2 — wire the MCP server*; install.sh reframed as MCP installer.
- **`skills/flywheel/scripts/install.sh`** + **`.ps1`** — header comments updated to reflect the new primary/secondary split. Behavior unchanged.

### Verification

```
$ npx -y skills add velvetmonkey/flywheel-memory --list
◇  Repository cloned
◇  Found 1 skill
◇  Available Skills
│    flywheel
│      Install and use the Flywheel MCP server to give an agent grounded memory ...
```

Frontmatter description renders correctly through the listing UI.

## Test plan

- [x] `npx -y skills add velvetmonkey/flywheel-memory --list` detects 1 skill, shows correct description.
- [x] `install.sh` smoke test against a fresh `/tmp/` directory still writes `.mcp.json` correctly with the updated header comments.
- [ ] CI lint pass.

Closes the "Update docs to default install path via npx skills add" follow-up from `roadmap-active.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)