### PR TITLE
docs: portability framing + category positioning (T-POS-1, T-POS-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Built for people who want AI to work over real notes without handing their vault
 - **Grounded search** — find the notes that matter, plus the linked context around them, without making the model trawl through a pile of files.
 - **Safe reversible writes** — update a live vault through bounded operations that preserve Markdown structure and can be undone.
 - **Local-first by default** — keep your notes on disk, use plain Markdown as the source of truth, and add local semantic search only if you want it.
+- **Portable by construction** — note text and entity edits land in Markdown. Flywheel's learned state (memories, link feedback, scoring) lives locally beside the vault in `.flywheel/state.db`. No cloud, no proprietary export needed — the parts that *are* your notes stay readable Markdown by definition.
 
 ### Why not raw file access or naive RAG?
 
@@ -71,7 +72,7 @@ Install Flywheel as an [Agent Skill](https://github.com/vercel-labs/skills) (the
 
 3. **Restart your client** (`claude` / `codex`) from the vault directory. MCP servers register at startup only.
 
-Then ask a question. Flywheel watches the vault, maintains local indexes, and serves structured context to MCP clients. Your source of truth stays in Markdown. If you delete `.flywheel/state.db`, Flywheel rebuilds from the vault.
+Then ask a question. Flywheel watches the vault, maintains local indexes, and serves structured context to MCP clients. Your source of truth stays in Markdown. If you delete `.flywheel/state.db`, Flywheel rebuilds note indexes from the vault — learned state (memories, link feedback) regenerates with use.
 
 <details>
 <summary><strong>Manual install (no installers — for Cursor, Windsurf, VS Code, Continue.dev, etc.)</strong></summary>
@@ -266,6 +267,8 @@ Skills encode methodology: how to do something. Flywheel encodes knowledge: what
 | Flywheel | Entities, relationships, history, context | "Everything you know about this client" |
 
 An agent calling a proposal-writing skill works better when it can also search your vault for the client's history, past invoices, project notes, and team relationships. Skills tell agents how to work. Flywheel tells them what you know.
+
+Other tools in the agent-context space treat knowledge as a side-effect of skill execution: state files written by a harness, scoped to its conventions. Flywheel treats knowledge as the substrate skills run on top of — an entity graph, temporal history, and grounded retrieval that any skill in any harness can read through MCP. A harness needs Flywheel-shaped state to be accurate; Flywheel works with any harness.
 
 For install steps, see [Your Vault in 2 Minutes](#your-vault-in-2-minutes) above. Skill source and example queries: [`skills/flywheel/`](skills/flywheel/).
 

--- a/skills/flywheel/SKILL.md
+++ b/skills/flywheel/SKILL.md
@@ -9,7 +9,7 @@ when_to_use: |
   directories, or when the user explicitly wants raw filesystem reads.
 ---
 
-Flywheel turns a folder of `.md` files into a queryable knowledge layer over MCP. This skill walks the agent through registering the MCP server, restarting the client, and using the bounded read/write surface that follows.
+Flywheel turns a folder of `.md` files into a queryable knowledge layer over MCP. Your notes stay the source of truth in Markdown; Flywheel's learned state lives locally beside the vault. This skill walks the agent through registering the MCP server, restarting the client, and using the bounded read/write surface that follows.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- **Portability framing (T-POS-1)** — new README value-prop bullet ("Portable by construction") + tightened state.db rebuild line. Counter to @kepano "file over app" framing without overclaiming. Honest split: note text + entity edits in Markdown; learned state in `.flywheel/state.db` locally.
- **Category positioning (T-POS-2)** — new paragraph inside the existing Skills + Flywheel section. Frames knowledge as the substrate skills run on top of, not as a side-effect of skill execution. No competitor naming, no comparison table, no new heading.
- **SKILL.md** — modest lead-paragraph extension matching the README framing.

Four edits, all additive, +5/-2.

## Roadmap

`tech/flywheel/roadmap/roadmap-active.md` (Obsidian vault):
- T-POS-1 — "Computed not stored" positioning in README and SKILL.md
- T-POS-2 — GBrain differentiation copy

## Why this shape (and not the original plan)

A 3-CLI roundtable ran on the original plan and forced structural changes:

- Original framing claimed "AI-computed knowledge persists into the vault as Markdown". Code truth-check disproved it — `memory(action: store)`, `wikilink_feedback`, `note_links`, `graph_snapshots` etc. all live in SQLite, not Markdown. Only entity aliases/merges write back to frontmatter. Shipping the original copy would be a public falsehood. Reframed to what's actually true.
- Original plan added a Skill-harness-vs-Knowledge-graph comparison table naming GBrain explicitly. Pulled — naming a smaller competitor in a top-level README elevates them to peer status. Replaced with category definition that owns the space without naming names.
- Original plan force-planted "compounding knowledge flywheel" inside a closing flourish. Pulled — README voice avoids marketing flourishes; phrase ownership is better suited to the tweet/blog deliverables already listed in the T-POS-2 acceptance criteria.

Verdict captured in `tech/flywheel/brainstorms/2026-05-04-pos-1-pos-2-roundtable.md`.

## Collateral

The `state.db` rebuild line on the existing README ("If you delete `.flywheel/state.db`, Flywheel rebuilds from the vault") was technically incomplete — only note indexes rebuild from vault; memories and feedback regenerate with use, they aren't reconstructed from Markdown. Tightened in this PR since the new portability bullet leans on it.

## Test plan

- [x] `grep` confirms killed framings ("computed not stored", "compounding knowledge flywheel") are absent
- [x] `grep` confirms each edit landed in the intended location
- [ ] Reviewer eyeballs README render on GitHub (anchor + voice + table integrity)
- [ ] Reviewer confirms the new bullet doesn't overclaim against current code

🤖 Generated with [Claude Code](https://claude.com/claude-code)