### PR TITLE
chore: release v2.12.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5949,7 +5949,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.12.5",
+      "version": "2.12.6",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5975,13 +5975,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.12.5",
+      "version": "2.12.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@velvetmonkey/vault-core": "^2.12.5",
+        "@velvetmonkey/vault-core": "^2.12.6",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.12.5",
+  "version": "2.12.6",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.5",
+  "version": "2.12.6",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@velvetmonkey/vault-core": "^2.12.5",
+    "@velvetmonkey/vault-core": "^2.12.6",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
Bump vault-core and flywheel-memory to 2.12.6. Already published to npm.

## Changes since 2.12.5

- docs: positioning — portability framing + category positioning (#341)
- docs(readme): lead Get Started with `npx skills add`, demote raw .mcp.json to collapsed manual install (#340)
- docs(skills): lead install with `npx skills add`, demote install.sh to MCP wiring (#339)
- docs(skills): add Quick Start fallback section to SKILL.md (#338)
- feat(skills): add Flywheel agent skill for kepano-style onboarding (#337)

Docs + skills surface only — no runtime/code changes.