### PR TITLE
test: raise timeout for salvage-from-corrupt-file test (Windows flake)

### DIFF
--- a/packages/core/test/backup.test.ts
+++ b/packages/core/test/backup.test.ts
@@ -489,7 +489,7 @@ describe('Backup & Recovery', () => {
       }
     });
 
-    it('salvages from a partially-readable corrupt file', () => {
+    it('salvages from a partially-readable corrupt file', { timeout: 15_000 }, () => {
       // Create a DB with data
       const sourceDb = openStateDb(testVaultPath);
       sourceDb.db.prepare(


### PR DESCRIPTION
## Summary

`test/backup.test.ts > salvageFeedbackTables (extended) > "salvages from a partially-readable corrupt file"` hit the default 5000ms vitest timeout on the **Test: full (Node 22 / windows-latest)** matrix in [run 25312184891](https://github.com/velvetmonkey/flywheel-memory/actions/runs/25312184891). Actual measured run was ~7.5s on the slower runner.

Sibling tests in the same file (`safeBackupAsync`, `checkDbIntegrity`, `attemptSalvage`, `safeBackupAsync (extended)`) already use `{ timeout: 15_000 }`. This change extends the same convention to the affected test — the slow runner has 2x headroom now.

No production code changes; SQLite corruption-salvage logic is unchanged.

## Test plan

- [x] Targeted local run: `npx vitest run test/backup.test.ts -t 'salvages from a partially-readable corrupt file'` → passes (172ms on WSL)
- [ ] CI matrix passes — including Windows / Node 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)