### PR TITLE
fix(vault-core): move owner_scope indexes out of SCHEMA_SQL (P0 startup crash)

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -357,7 +357,14 @@ CREATE TABLE IF NOT EXISTS corrections (
 CREATE INDEX IF NOT EXISTS idx_corrections_status ON corrections(status);
 CREATE INDEX IF NOT EXISTS idx_corrections_entity ON corrections(entity);
 
--- Memories (v26): lightweight key-value working memory for agents
+-- Memories (v26): lightweight key-value working memory for agents.
+--
+-- Rule: indexes/views/triggers that reference a column added in a later
+-- migration must be created INSIDE that migration block in migrations.ts, not
+-- here. This file runs against existing tables with IF-NOT-EXISTS semantics
+-- that preserve the old shape, so column-dependent statements crash boot on
+-- upgrading vaults before the migration loop has a chance to add the column.
+-- Example: owner_scope (v42) — its indexes live in the v42 migration block.
 CREATE TABLE IF NOT EXISTS memories (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   key TEXT NOT NULL,
@@ -377,10 +384,10 @@ CREATE TABLE IF NOT EXISTS memories (
   owner_scope TEXT NOT NULL DEFAULT 'global'
 );
 CREATE INDEX IF NOT EXISTS idx_memories_key ON memories(key);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_key_owner_scope ON memories(key, owner_scope);
 CREATE INDEX IF NOT EXISTS idx_memories_entity ON memories(entity);
 CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(memory_type);
-CREATE INDEX IF NOT EXISTS idx_memories_owner_scope ON memories(owner_scope);
+-- idx_memories_key_owner_scope (UNIQUE) and idx_memories_owner_scope are created
+-- by the v42 migration in migrations.ts, after that migration adds owner_scope.
 
 CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
   key, value,

--- a/packages/core/test/sqlite.test.ts
+++ b/packages/core/test/sqlite.test.ts
@@ -117,6 +117,46 @@ describe('SQLite State Management', () => {
       expect(rows.c).toBe(1);
     });
 
+    it('P42: v42 migration upgrades a pre-owner_scope memories table without crashing', () => {
+      // Regression test for the 2.12.6 startup crash: SCHEMA_SQL must not
+      // contain index statements that reference a column added by a later
+      // migration. A real user vault hit this when v2.12.6 booted on a v41
+      // DB and `CREATE INDEX ... ON memories(key, owner_scope)` from
+      // SCHEMA_SQL fired before the v42 migration could ALTER TABLE the
+      // column in. Synthesize that state and assert the migration recovers.
+      stateDb = openStateDb(testVaultPath);
+      stateDb.db.exec('DROP INDEX IF EXISTS idx_memories_key_owner_scope');
+      stateDb.db.exec('DROP INDEX IF EXISTS idx_memories_owner_scope');
+      stateDb.db.exec('ALTER TABLE memories DROP COLUMN owner_scope');
+      stateDb.db.exec('DELETE FROM schema_version WHERE version >= 42');
+      stateDb.close();
+      // ts-friendly clear so afterEach doesn't double-close.
+      stateDb = undefined as unknown as StateDb;
+
+      // Reopen — must not throw the "no such column: owner_scope" error.
+      stateDb = openStateDb(testVaultPath);
+
+      const col = stateDb.db
+        .prepare("SELECT name FROM pragma_table_info('memories') WHERE name = 'owner_scope'")
+        .get() as { name: string } | undefined;
+      expect(col?.name).toBe('owner_scope');
+
+      const indexes = stateDb.db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'memories' AND name LIKE '%owner_scope%' ORDER BY name",
+        )
+        .all() as Array<{ name: string }>;
+      expect(indexes.map(i => i.name)).toEqual([
+        'idx_memories_key_owner_scope',
+        'idx_memories_owner_scope',
+      ]);
+
+      const version = stateDb.db
+        .prepare('SELECT MAX(version) as v FROM schema_version')
+        .get() as { v: number };
+      expect(version.v).toBeGreaterThanOrEqual(42);
+    });
+
     it('P42: v39 migration collapses legacy mixed-case wikilink_applications rows', () => {
       // Hand-seed a pre-v39 state: drop the NOCASE index, recreate the v38
       // shape (only entity is COLLATE NOCASE), insert rows that collide


### PR DESCRIPTION
## Summary

P0 startup crash for any vault upgrading from a pre-2.12.5 schema to v2.12.6. Reproduced against a real 143MB user state.db at schema_version=41 — boot console:

\`\`\`
[vault-core] state.db error (no such column: owner_scope) — NOT deleting (recoverable)
[Memory] ERROR [statedb] StateDb initialization failed: no such column: owner_scope
[Memory] WARN  [server] Auto-wikilinks will be disabled for this session
[Memory] ERROR [fts5] Build failed: FTS5 database not initialized
[Memory] ERROR [semantic] Build failed: Embeddings database not initialized
[Memory] ERROR (repeating) entity: {"error":"StateDb not available"}
\`\`\`

## Root cause

\`SCHEMA_SQL\` had two indexes referencing \`memories.owner_scope\` (\`schema.ts\` lines 380, 383). \`db.exec(SCHEMA_SQL)\` runs at \`migrations.ts:81\`, **before** the migration loop. On a v41 DB:

1. \`CREATE TABLE IF NOT EXISTS memories (... owner_scope ...)\` — table already exists from v41, IF NOT EXISTS is a no-op, column is **not** added.
2. \`CREATE UNIQUE INDEX ... ON memories(key, owner_scope)\` — fails: \`no such column: owner_scope\`.
3. The exception is caught in \`sqlite.ts:282\` as "recoverable" (no corruption regex match), re-thrown. But \`initSchema\` never finished — \`ctx.stateDb\` is null, every downstream subsystem fails.
4. The v42 migration that *would* have ALTER TABLEd the column in (\`migrations.ts:512\`) never gets to run.

## Fix

Drop the two \`owner_scope\`-dependent index lines from \`SCHEMA_SQL\`. Both are already created inside the v42 migration block (\`migrations.ts:540-541\`):

\`\`\`sql
DROP INDEX IF EXISTS idx_memories_key_owner_scope
CREATE UNIQUE INDEX idx_memories_key_owner_scope ON memories(key, owner_scope)
CREATE INDEX IF NOT EXISTS idx_memories_owner_scope ON memories(owner_scope)
\`\`\`

For new DBs the v42 migration still runs (currentVersion=0 < 42 and v40Applied is set true after the v40 block) so they get the indexes. For upgrading v41 DBs the migration runs cleanly because \`SCHEMA_SQL\` no longer touches the missing column.

Adds a comment above the \`memories\` block documenting the rule that already implicitly governs every other migration in this file: **column-dependent indexes/views/triggers belong inside the migration that adds the column, not in \`SCHEMA_SQL\`**. \`SCHEMA_SQL\` runs against existing tables with IF-NOT-EXISTS semantics that preserve the old shape, so column-dependent statements crash boot before the migration loop has a chance to add the column.

## Regression test

\`packages/core/test/sqlite.test.ts\` — \`P42: v42 migration upgrades a pre-owner_scope memories table without crashing\`. Synthesizes the bad state by:
1. Dropping the two owner_scope indexes
2. \`ALTER TABLE memories DROP COLUMN owner_scope\`
3. Rewinding \`schema_version\` to remove v42

Then reopens and asserts the column + both indexes are recreated and \`schema_version\` reaches 42.

## Test plan

- [x] Reproduced the crash locally against the user's 143MB \`state.db\` (errors as quoted above).
- [x] Applied fix, rebuilt, re-ran openStateDb against the same DB — opens cleanly, \`schema_version=42\`, both indexes present.
- [x] New regression test passes (\`npx vitest run test/sqlite.test.ts -t 'P42: v42 migration upgrades'\`, 133ms).
- [x] Full vault-core suite passes (\`npm test --workspace @velvetmonkey/vault-core\`, 291/291).
- [ ] CI matrix passes.
- [ ] User reload-Obsidian smoke test post-release (no \`state.db error\` line, \`boot_complete\` reached, wikilink suggestions work).

## User unblock workaround (pre-release)

For affected users who can't wait for the patch release:

\`\`\`bash
sqlite3 ~/obsidian/<vault>/.flywheel/state.db "ALTER TABLE memories ADD COLUMN owner_scope TEXT NOT NULL DEFAULT 'global';"
\`\`\`

Then restart Obsidian. The next boot reaches the v42 migration, sees the column already present (\`if (!memoryColumns.has('owner_scope'))\` skips the ALTER), runs the data backfill, creates the indexes.

## Out of scope

- Reworking the "NOT deleting (recoverable)" classification in \`sqlite.ts:282\` to detect partially-applied migrations and retry. Worth filing as a follow-up; the immediate fix unblocks every affected user without it.
- Auditing every column in \`SCHEMA_SQL\` for similar latent ordering bugs. The convention comment is the lightweight defence; full audit can wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)