### PR TITLE
chore: release v2.12.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5949,7 +5949,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.12.6",
+      "version": "2.12.7",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5975,13 +5975,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.12.6",
+      "version": "2.12.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@velvetmonkey/vault-core": "^2.12.6",
+        "@velvetmonkey/vault-core": "^2.12.7",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.12.6",
+  "version": "2.12.7",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.6",
+  "version": "2.12.7",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@velvetmonkey/vault-core": "^2.12.6",
+    "@velvetmonkey/vault-core": "^2.12.7",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
P0 patch: ships the v42 startup-crash fix from #344. vault-core@2.12.7 + flywheel-memory@2.12.7 already published to npm.

## Single fix in this release

- **#344** — `fix(vault-core): move owner_scope indexes out of SCHEMA_SQL into v42 migration`. Affected any vault upgrading from a pre-2.12.5 schema; reproduced against a real 143MB user `state.db` that crashed on `no such column: owner_scope` and lost StateDb / FTS5 / embeddings / wikilinks for the session.

## User upgrade path

Reload Obsidian after the npm publish lands. flywheel-crank pins `@latest`, so this auto-resolves. The v42 migration runs once on first boot post-upgrade and adds the column + indexes; existing memories are tagged `owner_scope='global'` (or `source_agent_id` for private memories).