### PR TITLE
chore: release v2.12.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5949,7 +5949,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.12.7",
+      "version": "2.12.8",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5975,13 +5975,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.12.7",
+      "version": "2.12.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@velvetmonkey/vault-core": "^2.12.7",
+        "@velvetmonkey/vault-core": "^2.12.8",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.12.7",
+  "version": "2.12.8",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.7",
+  "version": "2.12.8",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@velvetmonkey/vault-core": "^2.12.7",
+    "@velvetmonkey/vault-core": "^2.12.8",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
Patch release: ships the staleness signals restore from #346. vault-core@2.12.8 + flywheel-memory@2.12.8 already published to npm.

## Changes since 2.12.7

- **#346** — `fix(insights): restore signals block in staleness response`. The merged `insights(action: 'staleness')` tool dropped the per-note `signals` block during T43 tool collapse, breaking flywheel-crank's Stale Notes panel with `Cannot read properties of undefined (reading 'backlink_count')`. Restored the full block (`backlink_count`, `hub_score`, `outlink_count`, `has_open_tasks`, `status_active`, `active_entity_ratio`) by porting back the open-task counts and recently-active entity set from the legacy `predict_stale_notes` implementation. Importance and staleness_risk weighting now match the legacy formulas.