### PR TITLE
feat(config): tighten policy-first guidance for structured work items (T-POLICY)

### DIFF
--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -484,8 +484,10 @@ Escalation: "search" (enriched metadata + content preview) → "read"
 ## Write
 
 **Before writing, check for saved policies** with \`policy(action="list")\`. Policies ensure notes are
-created with the correct structure and frontmatter for this vault. Use a matching policy instead of
-raw write tools when one exists. Fall back to direct tools only when no policy fits.
+created with the correct structure and frontmatter for this vault. This matters most for *structured
+work items* — tickets, project notes, formal vault entries — where a policy carries integrations and
+audit trail (e.g. \`create-cherwell\` for Cherwell tickets). Use a matching policy via \`policy(action="execute")\`
+instead of raw write tools when one exists. Fall back to direct tools only when no policy fits.
 
 **Every new note should have \`type\`, \`aliases\`, and \`description\` in frontmatter** — this is what powers
 entity categorization, search ranking, and link suggestions. Notes without frontmatter are nearly invisible


### PR DESCRIPTION
## Summary

Roadmap T-POLICY (vault: \`tech/flywheel/roadmap/roadmap-active.md\`). Adds explicit structured-work-item language to the existing Write-section policy guidance in the MCP server's \`instructions\` field.

## Context

Real incident: a Cherwell ticket was filed manually as a daily-note task instead of using the matching \`create-cherwell\` policy. Existing config.ts:486 already says *"Before writing, check for saved policies"* — softer phrasing without the structured-work-item callout that would've flagged the ticket case. This PR sharpens it.

## Change

- \`packages/mcp-server/src/config.ts\` — the existing 3-line policy paragraph in the Write category now explicitly names *tickets, project notes, formal vault entries* as the high-value targets, with \`create-cherwell\` as a named-policy example.

## Companion edit (separate, ships in same release)

\`flywheel-engine/src/context.ts\` BASE_RUNTIME_INSTRUCTIONS gets the same rule. The engine's session-controller doesn't forward the MCP server's \`instructions\` field into the LLM system prompt, so server-side guidance alone misses the Telegram-bot path where the incident happened. That edit will land via the engine 2.12.9 release, not this PR.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run lint\` (tsc --noEmit) clean
- [ ] CI matrix
- [ ] Smoke test post-engine-restart: Telegram message asking to file a Cherwell-style ticket should produce a \`policy(action: list)\` call in journalctl before any \`note(action: create)\` or \`edit_section\` call

## Out of scope

- Authoring the actual \`create-cherwell\` policy. The standing instruction nudges agents to *check* for the policy; when it lands in the vault, agents discover it automatically.
- Rewiring engine session-controller to forward the MCP \`instructions\` capability — bigger change with broader blast radius; the BASE_RUNTIME_INSTRUCTIONS edit covers the immediate need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)