### PR TITLE
chore: release v2.12.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5949,7 +5949,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.12.8",
+      "version": "2.12.9",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5975,13 +5975,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.12.8",
+      "version": "2.12.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@velvetmonkey/vault-core": "^2.12.8",
+        "@velvetmonkey/vault-core": "^2.12.9",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.12.8",
+  "version": "2.12.9",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.8",
+  "version": "2.12.9",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@velvetmonkey/vault-core": "^2.12.8",
+    "@velvetmonkey/vault-core": "^2.12.9",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
Patch: ships T-POLICY MCP server guidance tightening from #348. vault-core@2.12.9 + flywheel-memory@2.12.9 already published to npm.

## Changes since 2.12.8

- **#348** — `feat(config): tighten policy-first guidance for structured work items`. Names tickets/project notes/formal entries explicitly in the Write-section policy paragraph, with `create-cherwell` as a named-policy example so agents recognise the pattern.

Companion edit lands in flywheel-engine 2.12.9 BASE_RUNTIME_INSTRUCTIONS so the rule reaches the Telegram-bot path, which doesn't see the MCP server's instructions field.