### PR TITLE
fix(parser): drop emoji false-positive in isBinaryContent

### DIFF
--- a/packages/mcp-server/src/core/read/parser.ts
+++ b/packages/mcp-server/src/core/read/parser.ts
@@ -17,16 +17,15 @@ import type { VaultFile } from './vault.js';
 /** Maximum file size to parse (10MB) - skip larger files */
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
-/** Check if content appears to be binary */
+/** Check if content appears to be binary.
+ * Null-byte presence is the canonical text-vs-binary signal (used by git, file(1)).
+ * The previous printable-ratio heuristic counted every UTF-8 multi-byte sequence as
+ * non-printable, which falsely flagged emoji-heavy markdown (e.g. daily notes with
+ * log markers like 🐵) as binary and silently dropped indexing — see 2026-05-08
+ * incident where today's daily note was rejected 300 times.
+ */
 function isBinaryContent(content: string): boolean {
-  // Check for null bytes or high ratio of non-printable characters
-  const nullBytes = (content.match(/\x00/g) || []).length;
-  if (nullBytes > 0) return true;
-
-  // Check first 1000 chars for non-printable (excluding common whitespace)
-  const sample = content.slice(0, 1000);
-  const nonPrintable = sample.replace(/[\x20-\x7E\t\n\r]/g, '').length;
-  return nonPrintable / sample.length > 0.1;
+  return content.includes('\x00');
 }
 
 /**

--- a/packages/mcp-server/test/read/parser-binary-detection.test.ts
+++ b/packages/mcp-server/test/read/parser-binary-detection.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for isBinaryContent in parser.ts.
+ *
+ * 2026-05-08: emoji-heavy markdown (e.g. daily notes containing engine log
+ * markers like 🐵) was being falsely flagged as binary because the previous
+ * heuristic counted every UTF-8 multi-byte sequence as non-printable. Today's
+ * daily note was rejected 300 times before this fix landed.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { parseNoteWithWarnings } from '../../src/core/read/parser.js';
+import type { VaultFile } from '../../src/core/read/vault.js';
+
+let tmpDir: string;
+
+async function makeFile(name: string, contents: Buffer | string): Promise<VaultFile> {
+  const absolutePath = path.join(tmpDir, name);
+  await fs.writeFile(absolutePath, contents);
+  return { path: name, absolutePath };
+}
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fw-binary-detect-'));
+});
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('isBinaryContent (regression coverage)', () => {
+  it('accepts emoji-heavy markdown', async () => {
+    const content = `---
+type: daily
+---
+# Log
+- **00:01** 🐵 @thevelvetmonke (21.1s, sonnet) — note 🎉
+- **00:02** 🐵 reply 🚀
+- **00:03** 🐵 reply 💡
+${'- 🐵 entry 🍌\n'.repeat(50)}
+`;
+    const file = await makeFile('emoji-daily.md', content);
+    const result = await parseNoteWithWarnings(file);
+    expect(result.skipped).toBe(false);
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  it('accepts plain ASCII markdown', async () => {
+    const content = `---
+type: note
+---
+# Plain
+Just ordinary words and [[wikilinks]].
+`;
+    const file = await makeFile('plain.md', content);
+    const result = await parseNoteWithWarnings(file);
+    expect(result.skipped).toBe(false);
+  });
+
+  it('rejects PNG bytes (null bytes in IHDR)', async () => {
+    const png = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+      0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x10,
+    ]);
+    const file = await makeFile('image.md', png);
+    const result = await parseNoteWithWarnings(file);
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toBe('Binary content detected');
+  });
+
+  it('rejects PDF bytes (null bytes in xref)', async () => {
+    const pdf = Buffer.concat([
+      Buffer.from('%PDF-1.4\n'),
+      Buffer.from([0x00, 0x00, 0x00]),
+      Buffer.from('1 0 obj\n<< >>\nendobj\n'),
+    ]);
+    const file = await makeFile('doc.md', pdf);
+    const result = await parseNoteWithWarnings(file);
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toBe('Binary content detected');
+  });
+});


### PR DESCRIPTION
## Summary

- Today (2026-05-08) `daily-notes/2026-05-08.md` was rejected by the watcher 300 times with `Binary content detected` because the previous `isBinaryContent` heuristic counted every UTF-8 multi-byte sequence (emoji, en-dash, smart-quote, etc.) as non-printable and tripped a 10 % threshold. Daily notes contain emoji log markers (🐵 from flywheel-engine), so this fired routinely.
- Replaced the heuristic with a null-byte-only check — the canonical text-vs-binary signal used by `git` and `file(1)`, and sufficient for a markdown-only vault.
- Added focused regression tests under `test/read/parser-binary-detection.test.ts`: emoji-heavy md (must pass), plain ASCII md (must pass), real PNG header bytes (must fail), real PDF bytes with embedded nulls (must fail).

## Verification done locally

- `npx vitest run test/read/parser-binary-detection.test.ts` → 4/4 pass
- Full read suite (`npx vitest run test/read/`) → 511/511 pass, no regressions
- Battle-hardening binary-content suite (`test/write/battle-hardening/input-formats.test.ts`) → 19/19 pass
- After installing the local build globally and restarting `flywheel-memory.service`, today's daily note re-indexed successfully (`Batch complete: 1 files, 9130ms, 25 steps` at 15:36:48 BST). Direct DB inspection confirms `content_hashes.daily-notes/2026-05-08.md` updated and FTS5 returns matches for content unique to today.

## Test plan

- [ ] CI green
- [ ] Reviewer confirms approach (null-byte-only check) is acceptable — Gemini reviewed in council and validated the simplification (no existing test fails; the 10 % heuristic only ever caught null-free pathological garbage which is not a realistic vault input)
- [ ] After merge, run release flow per `release` skill so the published package matches what's running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)