### PR TITLE
fix(fts5): quote tokens to prevent column-reference injection

### DIFF
--- a/packages/core/src/queries.ts
+++ b/packages/core/src/queries.ts
@@ -72,7 +72,10 @@ export function searchEntitiesPrefix(
   prefix: string,
   limit: number = 20
 ): EntitySearchResult[] {
-  return searchEntities(stateDb, `${escapeFts5Query(prefix)}*`, limit);
+  // Append `*` BEFORE escaping so the suffix-aware quoter places it correctly
+  // (quoted phrase + outer `*` for prefix search). Pre-escaping here would
+  // produce already-quoted input that the second escape pass cannot reuse.
+  return searchEntities(stateDb, `${prefix}*`, limit);
 }
 
 /**
@@ -488,21 +491,33 @@ export function escapeFts5Query(query: string): string {
     return '';
   });
 
-  // Clean remaining tokens
+  // Clean remaining tokens. Strips FTS5 syntax punctuation (`:` and `-` previously
+  // tripped queries like `2026-05-08` → SQLite parsed `05` as a column reference,
+  // returning `no such column: 05`). `+`, `.`, `_` were also unhandled — see
+  // 2026-05-08 morning-briefing failure.
   const cleaned = withoutPhrases
-    .replace(/[(){}[\]^~:-]/g, ' ')
+    .replace(/[(){}[\]^~:+._-]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 
-  // Split into tokens, skip explicit AND/OR/NOT operators
-  const tokens = cleaned.split(' ').filter(t => t && t !== 'AND' && t !== 'OR' && t !== 'NOT');
+  // Split into tokens, skip explicit FTS5 operators (AND/OR/NOT/NEAR).
+  const tokens = cleaned
+    .split(' ')
+    .filter(t => t && t !== 'AND' && t !== 'OR' && t !== 'NOT' && t !== 'NEAR');
 
-  // Combine: quoted phrases + OR-joined tokens
+  // Wrap each token as an FTS5 phrase literal so bareword reserved keywords and
+  // numeric tokens cannot be parsed as column references. Preserve trailing `*`
+  // for prefix search by placing it OUTSIDE the quotes (`"foo"*` not `"foo*"`).
+  const safeTokens = tokens.map(t =>
+    t.endsWith('*') ? `"${t.slice(0, -1)}"*` : `"${t}"`
+  );
+
+  // Combine: quoted phrases + OR-joined safe tokens
   const parts = [...phrases];
-  if (tokens.length === 1) {
-    parts.push(tokens[0]);
-  } else if (tokens.length > 1) {
-    parts.push(tokens.join(' OR '));
+  if (safeTokens.length === 1) {
+    parts.push(safeTokens[0]);
+  } else if (safeTokens.length > 1) {
+    parts.push(safeTokens.join(' OR '));
   }
 
   return parts.join(' ') || '';

--- a/packages/core/test/sqlite.test.ts
+++ b/packages/core/test/sqlite.test.ts
@@ -499,24 +499,54 @@ describe('SQLite State Management', () => {
   });
 
   describe('FTS5 Query Escaping', () => {
-    it('should strip special characters and OR-join tokens', () => {
-      expect(escapeFts5Query('test (query)')).toBe('test OR query');
-      expect(escapeFts5Query('test: value')).toBe('test OR value');
+    it('should strip special characters and OR-join quoted tokens', () => {
+      expect(escapeFts5Query('test (query)')).toBe('"test" OR "query"');
+      expect(escapeFts5Query('test: value')).toBe('"test" OR "value"');
     });
 
     it('should extract quoted phrases and OR-join remaining tokens', () => {
-      expect(escapeFts5Query('test "value"')).toBe('"value" test');
-      expect(escapeFts5Query('"project alpha" beta gamma')).toBe('"project alpha" beta OR gamma');
+      expect(escapeFts5Query('test "value"')).toBe('"value" "test"');
+      expect(escapeFts5Query('"project alpha" beta gamma')).toBe('"project alpha" "beta" OR "gamma"');
     });
 
-    it('should return single token as-is', () => {
-      expect(escapeFts5Query('test')).toBe('test');
-      expect(escapeFts5Query('test' + '*')).toBe('test*');
+    it('should wrap single tokens in quotes', () => {
+      expect(escapeFts5Query('test')).toBe('"test"');
     });
 
-    it('should skip explicit operators', () => {
-      expect(escapeFts5Query('test AND value')).toBe('test OR value');
-      expect(escapeFts5Query('test OR value')).toBe('test OR value');
+    it('should preserve prefix-search * outside the quote (regression)', () => {
+      expect(escapeFts5Query('test' + '*')).toBe('"test"*');
+    });
+
+    it('should skip explicit boolean operators', () => {
+      expect(escapeFts5Query('test AND value')).toBe('"test" OR "value"');
+      expect(escapeFts5Query('test OR value')).toBe('"test" OR "value"');
+    });
+
+    // Regression: 2026-05-08 morning-briefing job failed with `no such column: 05`
+    // because the date `2026-05-08` was unquoted, so SQLite parsed `05` as a
+    // column reference. With the fix each numeric token is quoted as a phrase.
+    it('should safely handle date-formatted queries', () => {
+      const result = escapeFts5Query('2026-05-08');
+      expect(result).toBe('"2026" OR "05" OR "08"');
+      expect(result).not.toContain(' 05 ');
+      expect(result).not.toMatch(/^05/);
+    });
+
+    it('should safely handle dotted filenames', () => {
+      expect(escapeFts5Query('file.txt')).toBe('"file" OR "txt"');
+    });
+
+    it('should safely handle plus-containing tokens like C++', () => {
+      // The strip pass removes `+`, leaving the bare letter; quoting prevents
+      // SQLite from interpreting it as anything other than a literal.
+      expect(escapeFts5Query('C++')).toBe('"C"');
+    });
+
+    it('should filter the FTS5 NEAR keyword to prevent operator injection', () => {
+      // NEAR alone is filtered, leaving an empty query.
+      expect(escapeFts5Query('NEAR')).toBe('');
+      // NEAR mixed with real tokens: NEAR is dropped, others quoted.
+      expect(escapeFts5Query('NEAR foo bar')).toBe('"foo" OR "bar"');
     });
   });
 


### PR DESCRIPTION
## Summary

- 2026-05-08 morning-briefing job (06:01:39) hit \`MCP error: no such column: 05\` when searching memory for \`nightly research reflection may08 2026-05-08\`. Root cause: \`escapeFts5Query\` strips FTS5 punctuation but doesn't quote the resulting tokens, so SQLite parses bare \`05\` as a column reference.
- **Fix**: wrap each cleaned token as an FTS5 phrase literal (\`\"foo\"\`). Suffix-aware so prefix searches survive (\`test*\` → \`\"test\"*\`, not \`\"test*\"\`). Strip class extended to drop \`+\`, \`.\`, \`_\` (so \`C++\`, \`file.txt\` are safe). FTS5 \`NEAR\` keyword filtered alongside \`AND\`/\`OR\`/\`NOT\`.
- **Knock-on**: \`searchEntitiesPrefix\` previously double-escaped (called \`escapeFts5Query\` then re-passed through \`searchEntities\` which escapes again). With the new quoting that chain produced \`\"foo\" \"\"*\` — invalid FTS5. Switched to single-pass: the outer escape handles the \`*\` suffix correctly.

## Council review

This fix was reviewed by Gemini (correctness hawk persona) before implementation. Gemini caught that naïve unconditional token quoting breaks prefix searches and proposed the suffix-aware quoting pattern adopted here.

## Verification

- \`npx vitest run test/sqlite.test.ts\` (packages/core): **296/296 pass**, including 5 new regression cases:
  - \`2026-05-08\` → \`\"2026\" OR \"05\" OR \"08\"\` (no column-reference error)
  - \`C++\` → \`\"C\"\` (no FTS5 syntax error)
  - \`file.txt\` → \`\"file\" OR \"txt\"\`
  - \`NEAR\` → \`''\` (filtered)
  - \`test*\` → \`\"test\"*\` (prefix-search regression preserved)
- \`npx vitest run test/write/tools/entity-search.test.ts\` (packages/mcp-server): **19/19 pass** (proves \`searchEntitiesPrefix\` chain still works after de-double-escaping)

## Test plan

- [ ] CI green
- [ ] Live verify: post-merge + release, send the morning-briefing query through \`mcp__flywheel__memory action=search\` and confirm no \`no such column\` error in the journal

## Notes

- Depends on #352 (npm audit fix) for CI Security Audit to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)