### PR TITLE
chore: release v2.12.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5966,7 +5966,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.12.9",
+      "version": "2.12.10",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5992,13 +5992,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.12.9",
+      "version": "2.12.10",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@velvetmonkey/vault-core": "^2.12.9",
+        "@velvetmonkey/vault-core": "^2.12.10",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.12.9",
+  "version": "2.12.10",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.9",
+  "version": "2.12.10",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@velvetmonkey/vault-core": "^2.12.9",
+    "@velvetmonkey/vault-core": "^2.12.10",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
Bump vault-core and flywheel-memory to 2.12.10. Already published to npm.

## Changes since 2.12.9

- fix(parser): drop emoji false-positive in isBinaryContent (#351) — daily notes containing emoji log markers (e.g. 🐵) were being silently dropped from indexing. Switched to null-byte-only detection.
- fix(fts5): quote tokens to prevent column-reference injection (#353) — date-formatted queries like \`2026-05-08\` returned \`no such column: 05\`. Suffix-aware quoting + extended strip class. Also fixes \`searchEntitiesPrefix\` double-escape.
- chore(deps): bump simple-git to ^3.36.0 (high RCE) (#352) — GHSA-hffm-xvc3-vprc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)