### PR TITLE
fix(installer): make curl|bash + iex|irm work end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,54 @@ jobs:
       - name: Build
         run: npm run build
 
+  installer-smoke:
+    name: "Installer Smoke"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Smoke 1 — process substitution (bash <(curl …) shape)
+        run: |
+          mkdir -p /tmp/vault-procsub && cd /tmp/vault-procsub
+          bash <(cat $GITHUB_WORKSPACE/skills/flywheel/scripts/install.sh)
+          test -f .mcp.json
+          jq -e '.mcpServers.flywheel.command == "npx"' .mcp.json
+          jq -e '.mcpServers.flywheel.args == ["-y","@velvetmonkey/flywheel-memory"]' .mcp.json
+      - name: Smoke 2 — pure pipe (curl … | bash shape)
+        run: |
+          mkdir -p /tmp/vault-pipe && cd /tmp/vault-pipe
+          cat $GITHUB_WORKSPACE/skills/flywheel/scripts/install.sh | bash
+          test -f .mcp.json
+          jq -e '.mcpServers.flywheel' .mcp.json
+      - name: Smoke 3 — in-tree invocation
+        run: |
+          mkdir -p /tmp/vault-tree && cd /tmp/vault-tree
+          bash $GITHUB_WORKSPACE/skills/flywheel/scripts/install.sh
+          test -f .mcp.json
+          # SKILL.md must NOT be copied (fallback retired — single-purpose installer).
+          if [ -f .claude/skills/flywheel/SKILL.md ]; then
+            echo "::error::installer regressed: SKILL.md was copied (fallback should be retired)" >&2
+            exit 1
+          fi
+      - name: Smoke 4 — idempotency
+        run: |
+          cd /tmp/vault-procsub
+          bash <(cat $GITHUB_WORKSPACE/skills/flywheel/scripts/install.sh) | tee /tmp/second-run.log
+          grep -q "unchanged" /tmp/second-run.log
+      - name: Smoke 5 — vault arg + non-existent dir rejection
+        run: |
+          # Positional vault arg targets a different directory.
+          mkdir -p /tmp/vault-arg
+          bash $GITHUB_WORKSPACE/skills/flywheel/scripts/install.sh /tmp/vault-arg
+          test -f /tmp/vault-arg/.mcp.json
+          # Non-existent dir exits non-zero.
+          if bash $GITHUB_WORKSPACE/skills/flywheel/scripts/install.sh /tmp/does-not-exist; then
+            echo "::error::installer accepted non-existent vault dir" >&2
+            exit 1
+          fi
+
   # ---------------------------------------------------------------------------
   # Focused test jobs — each surfaces as its own pass/fail check in GitHub
   # ---------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -2601,9 +2601,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "overrides": {
     "@hono/node-server": "^1.19.13",
     "hono": "^4.12.14",
-    "protobufjs": "^7.5.5"
+    "protobufjs": "^7.5.5",
+    "fast-uri": "^3.1.2"
   },
   "devDependencies": {
     "glob": "^13.0.6",

--- a/skills/flywheel/SKILL.md
+++ b/skills/flywheel/SKILL.md
@@ -39,8 +39,8 @@ Do **not** apply for:
 
 | Runtime | How the skill loads |
 |---|---|
-| Claude Code | Auto-discovered from `<vault>/.claude/skills/flywheel/SKILL.md` after the install script runs. |
-| Codex CLI | Copy `SKILL.md` to `~/.codex/skills/flywheel/SKILL.md` manually, or have the install script do it (`--codex` flag). |
+| Claude Code | Auto-discovered from `~/.claude/skills/flywheel/SKILL.md` (global) or `<vault>/.claude/skills/flywheel/SKILL.md` (project) after `npx -y skills add velvetmonkey/flywheel-memory -g`. |
+| Codex CLI | Same: `npx -y skills add velvetmonkey/flywheel-memory -g` installs the skill where Codex looks for it. |
 | ChatGPT (Custom GPT) | Paste the body of this `SKILL.md` into the GPT instruction set. The MCP install path (`.mcp.json`) does not apply. |
 
 The `.mcp.json` register step works in any client that speaks the Model Context Protocol — Claude Code, Codex CLI, Cursor, Windsurf, VS Code with MCP extensions, etc. See the project README's [client setup guide](../../docs/SETUP.md) for client-specific config differences.
@@ -51,7 +51,7 @@ Before installing, confirm:
 
 1. **Node ≥ 18** is on PATH. `node --version` should print `v18` or higher. The MCP server runs via `npx`; npx is bundled with npm.
 2. **A folder of `.md` files.** It does not need to be a fully-fledged Obsidian vault — Flywheel works on plain Markdown directories.
-3. **Write access** to the vault directory. Flywheel keeps a local index at `<vault>/.flywheel/state.db` and (when run via the install script) copies this skill into `<vault>/.claude/skills/flywheel/`.
+3. **Write access** to the vault directory. Flywheel keeps a local index at `<vault>/.flywheel/state.db` and writes/merges `<vault>/.mcp.json` to register the MCP server.
 
 If any prerequisite is missing, stop and tell the user what to install before continuing.
 
@@ -89,11 +89,7 @@ bash /path/to/flywheel-memory/skills/flywheel/scripts/install.sh
 iex (irm https://raw.githubusercontent.com/velvetmonkey/flywheel-memory/main/skills/flywheel/scripts/install.ps1)
 ```
 
-The MCP installer:
-
-1. Writes (or merges) `.mcp.json` in the current directory with the canonical Flywheel snippet.
-2. Optionally, with `--codex`, also copies the skill into `~/.codex/skills/flywheel/` for users who haven't installed via `npx skills` yet.
-3. Prints the restart instruction.
+The MCP installer is single-purpose: it writes (or merges) `.mcp.json` in the current directory with the canonical Flywheel snippet, then prints the restart instruction. It does *not* install the agent skill — Step 1 (`npx -y skills add ...`) handles that.
 
 ### Manual install (no installers)
 

--- a/skills/flywheel/scripts/install.ps1
+++ b/skills/flywheel/scripts/install.ps1
@@ -1,28 +1,26 @@
 # Flywheel MCP installer (PowerShell, Windows).
 #
-# Primary job: write/merge Flywheel into <vault>/.mcp.json so the Flywheel
-# MCP server is registered for the user's client (Claude Code, Codex, etc).
+# Single job: write/merge Flywheel into <vault>/.mcp.json so the Flywheel MCP
+# server is registered for the user's client (Claude Code, Codex, etc).
 #
-# Secondary: also drop SKILL.md into <vault>/.claude/skills/flywheel/ at
-# project scope as a fallback for users who haven't installed the skill
-# via `npx skills add velvetmonkey/flywheel-memory`.
+# The Flywheel agent skill (SKILL.md) is installed separately via:
+#   npx -y skills add velvetmonkey/flywheel-memory -g
+# Run that first; this script only handles the MCP wiring step.
+#
+# Safe to invoke via:
+#   iex (irm https://raw.githubusercontent.com/.../install.ps1)  # remote
+#   pwsh /path/to/cloned/repo/.../install.ps1                    # in-tree
+# Both shapes write the same .mcp.json. No filesystem siblings required, so
+# this works under Invoke-Expression where $MyInvocation.MyCommand.Path is null.
 
 param(
-  [string]$Vault = (Get-Location).Path,
-  [switch]$Codex
+  [string]$Vault = (Get-Location).Path
 )
 
 $ErrorActionPreference = 'Stop'
 
 if (-not (Test-Path $Vault -PathType Container)) {
   Write-Error "vault directory does not exist: $Vault"
-  exit 1
-}
-
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$SkillSrc = Join-Path (Split-Path -Parent $ScriptDir) 'SKILL.md'
-if (-not (Test-Path $SkillSrc)) {
-  Write-Error "SKILL.md not found at $SkillSrc"
   exit 1
 }
 
@@ -33,7 +31,6 @@ $Snippet = [ordered]@{
   env     = [ordered]@{ FLYWHEEL_WATCH_POLL = 'true' }
 }
 
-# 1. Merge .mcp.json
 $McpFile = Join-Path $Vault '.mcp.json'
 if (Test-Path $McpFile) {
   $raw = Get-Content $McpFile -Raw
@@ -51,26 +48,13 @@ $data['mcpServers']['flywheel'] = $Snippet
 $data | ConvertTo-Json -Depth 10 | Set-Content -Path $McpFile -Encoding UTF8
 Write-Host "  written:   $McpFile"
 
-# 2. Install SKILL.md into vault's .claude/skills/flywheel/
-$SkillDestDir = Join-Path $Vault '.claude/skills/flywheel'
-New-Item -ItemType Directory -Force -Path $SkillDestDir | Out-Null
-Copy-Item -Force $SkillSrc (Join-Path $SkillDestDir 'SKILL.md')
-Write-Host "  installed: $(Join-Path $SkillDestDir 'SKILL.md')"
-
-# 3. Optional Codex install
-if ($Codex) {
-  $CodexDir = Join-Path $HOME '.codex/skills/flywheel'
-  New-Item -ItemType Directory -Force -Path $CodexDir | Out-Null
-  Copy-Item -Force $SkillSrc (Join-Path $CodexDir 'SKILL.md')
-  Write-Host "  installed: $(Join-Path $CodexDir 'SKILL.md') (codex)"
-}
-
 Write-Host ''
-Write-Host 'Flywheel skill installed.'
+Write-Host "Flywheel MCP wired into $McpFile"
 Write-Host ''
 Write-Host 'Next steps:'
-Write-Host '  1. Exit your current Claude Code or Codex session if one is running.'
-Write-Host '  2. Re-launch the client from this directory: `claude` or `codex`.'
-Write-Host '  3. The Flywheel MCP server starts on first tool call (~3-5s warmup).'
+Write-Host '  1. If you haven''t installed the agent skill: npx -y skills add velvetmonkey/flywheel-memory -g'
+Write-Host '  2. Exit your current Claude Code or Codex session if one is running.'
+Write-Host '  3. Re-launch the client from this directory: `claude` or `codex`.'
+Write-Host '  4. The Flywheel MCP server starts on first tool call (~3-5s warmup).'
 Write-Host ''
 Write-Host 'Do NOT continue in the same session — MCP servers register at client startup only.'

--- a/skills/flywheel/scripts/install.sh
+++ b/skills/flywheel/scripts/install.sh
@@ -1,28 +1,22 @@
 #!/usr/bin/env bash
 # Flywheel MCP installer (POSIX).
 #
-# Primary job: write/merge Flywheel into <vault>/.mcp.json so the Flywheel
-# MCP server is registered for the user's client (Claude Code, Codex, etc).
+# Single job: write/merge Flywheel into <vault>/.mcp.json so the Flywheel MCP
+# server is registered for the user's client (Claude Code, Codex, etc).
 #
-# Secondary: also drop SKILL.md into <vault>/.claude/skills/flywheel/ at
-# project scope as a fallback for users who haven't installed the skill
-# via `npx skills add velvetmonkey/flywheel-memory`. If the user already
-# ran the canonical skill install, this overwrite is harmless.
+# The Flywheel agent skill (SKILL.md) is installed separately via:
+#   npx -y skills add velvetmonkey/flywheel-memory -g
+# Run that first; this script only handles the MCP wiring step.
 #
-# Optional --codex flag also installs to ~/.codex/skills/flywheel/.
+# Safe to invoke via:
+#   bash <(curl -fsSL .../install.sh)        # process substitution
+#   curl -fsSL .../install.sh | bash         # pure pipe
+#   bash /path/to/cloned/repo/.../install.sh # in-tree
+# All three shapes write the same .mcp.json.
 
 set -euo pipefail
 
-VAULT=""
-INSTALL_CODEX=false
-for arg in "$@"; do
-  case "$arg" in
-    --codex) INSTALL_CODEX=true ;;
-    --*) echo "error: unknown flag: $arg" >&2; exit 1 ;;
-    *) if [ -z "$VAULT" ]; then VAULT="$arg"; else echo "error: unexpected argument: $arg" >&2; exit 1; fi ;;
-  esac
-done
-VAULT="${VAULT:-$PWD}"
+VAULT="${1:-$PWD}"
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "error: python3 is required for JSON merging but was not found on PATH" >&2
@@ -34,18 +28,6 @@ if [ ! -d "$VAULT" ]; then
   exit 1
 fi
 
-cd "$VAULT"
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKILL_SRC="$(cd "$SCRIPT_DIR/.." && pwd)/SKILL.md"
-
-if [ ! -f "$SKILL_SRC" ]; then
-  echo "error: SKILL.md not found at $SKILL_SRC" >&2
-  echo "  this script expects to live at <repo>/skills/flywheel/scripts/install.sh" >&2
-  exit 1
-fi
-
-# 1. Merge Flywheel into .mcp.json
 MCP_FILE="$VAULT/.mcp.json"
 python3 - "$MCP_FILE" <<'PY'
 import json, os, sys
@@ -74,26 +56,13 @@ else:
     print(f"  written:   {path}")
 PY
 
-# 2. Install SKILL.md into vault's .claude/skills/flywheel/
-SKILL_DEST_DIR="$VAULT/.claude/skills/flywheel"
-mkdir -p "$SKILL_DEST_DIR"
-cp "$SKILL_SRC" "$SKILL_DEST_DIR/SKILL.md"
-echo "  installed: $SKILL_DEST_DIR/SKILL.md"
-
-# 3. Optional Codex install
-if [ "$INSTALL_CODEX" = true ]; then
-  CODEX_DIR="$HOME/.codex/skills/flywheel"
-  mkdir -p "$CODEX_DIR"
-  cp "$SKILL_SRC" "$CODEX_DIR/SKILL.md"
-  echo "  installed: $CODEX_DIR/SKILL.md (codex)"
-fi
-
 echo
-echo "Flywheel skill installed."
+echo "Flywheel MCP wired into $MCP_FILE"
 echo
 echo "Next steps:"
-echo "  1. Exit your current Claude Code or Codex session if one is running."
-echo "  2. Re-launch the client from this directory: \`claude\` or \`codex\`."
-echo "  3. The Flywheel MCP server starts on first tool call (~3-5s warmup)."
+echo "  1. If you haven't installed the agent skill: npx -y skills add velvetmonkey/flywheel-memory -g"
+echo "  2. Exit your current Claude Code or Codex session if one is running."
+echo "  3. Re-launch the client from this directory: \`claude\` or \`codex\`."
+echo "  4. The Flywheel MCP server starts on first tool call (~3-5s warmup)."
 echo
 echo "Do NOT continue in the same session — MCP servers register at client startup only."


### PR DESCRIPTION
## Summary

The README's headline install command was broken on every fresh install since 539648c (Step 2 promoted to install.sh) and 8ede620 (`npx skills add` made canonical Step 1):

```
$ bash <(curl -fsSL https://raw.githubusercontent.com/velvetmonkey/flywheel-memory/main/skills/flywheel/scripts/install.sh)
error: SKILL.md not found at /dev/SKILL.md
  this script expects to live at <repo>/skills/flywheel/scripts/install.sh
```

Cause: install.sh resolved a sibling `SKILL.md` via `BASH_SOURCE`, which under process substitution is `/dev/fd/63`. `dirname/..` becomes `/dev`, so `SKILL_SRC` evaluates to `/dev/SKILL.md` and the script aborts before performing its primary `.mcp.json` merge.

`install.ps1` had the same shape and crashed harder under `iex (irm ...)` because `$MyInvocation.MyCommand` is `$null` there — `Split-Path -Parent $null` would throw before any safety check could run.

No CI exercised either installer, which is why this shipped silently.

## Fix

Refactor both installers to single-purpose `.mcp.json` mergers. The agent skill is now installed only via `npx -y skills add velvetmonkey/flywheel-memory -g` (Step 1 of the documented flow); the installer no longer needs a sibling `SKILL.md`. The `--codex` flag is retired — `npx skills add` already drops the skill where Codex looks for it.

- `skills/flywheel/scripts/install.sh` — drops `SKILL_SRC` lookup, `--codex` flag, and SKILL.md copy. Curl-safe by construction.
- `skills/flywheel/scripts/install.ps1` — drops `$MyInvocation.MyCommand.Path` lookup (the iex landmine), `-Codex` switch, and SKILL.md copy.
- `skills/flywheel/SKILL.md` — Compatibility table updated (Codex install path is now `npx skills add`); `--codex` and SKILL.md-fallback wording removed.
- `.github/workflows/ci.yml` — new `installer-smoke` job, 5 cases (process substitution, pure pipe, in-tree, idempotency, vault arg + missing dir rejection).

Net: -3 lines despite adding the CI job (installers shrunk).

## Required follow-up after merge

**Branch protection on `main` must add `Installer Smoke` to required status checks.** This is the second half of the release gate — without it, a future regression to install.sh could still merge. One-time admin action; not part of this PR.

The release-flywheel skill (in user's local `~/.claude/commands/`) was also updated with a `gh run list` precheck that aborts release if the latest CI on main isn't green.

## Test plan

Local repro pre-fix and verification post-fix all run:

- [x] `bash <(cat install.sh)` (process substitution shape) writes `.mcp.json` with `command=npx`
- [x] `cat install.sh | bash` (pure pipe shape) writes `.mcp.json`
- [x] `bash /path/to/repo/install.sh` (in-tree) writes `.mcp.json` and does **not** copy SKILL.md (fallback retired)
- [x] Second run prints `unchanged` — idempotent
- [x] Positional vault arg writes to that directory; non-existent dir exits non-zero
- [ ] CI `installer-smoke` job passes
- [ ] Manual: PowerShell `iex (irm <PR-branch-install.ps1>)` writes `.mcp.json` with `command=cmd` (no Windows runner in this CI; covered manually pre-merge)

## Out of scope (tracked separately)

- `npx -y skills add velvetmonkey/flywheel-memory -g` registry resolution check (third-party `vercel-labs/skills`)
- Removing python3 dependency from install.sh
- JSON-with-comments tolerance in `.mcp.json` parse
- WSL/Windows snippet cross-platform idempotency (bash installer overwriting PS-written `cmd /c npx` snippet)
- Adding a Windows runner step for PS smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)