### PR TITLE
chore: release v2.12.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5966,7 +5966,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.12.10",
+      "version": "2.12.11",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",
@@ -5992,13 +5992,13 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.12.10",
+      "version": "2.12.11",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@velvetmonkey/vault-core": "^2.12.10",
+        "@velvetmonkey/vault-core": "^2.12.11",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.12.10",
+  "version": "2.12.11",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.10",
+  "version": "2.12.11",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@velvetmonkey/vault-core": "^2.12.10",
+    "@velvetmonkey/vault-core": "^2.12.11",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary

Bump vault-core and flywheel-memory to 2.12.11. Already published to npm.

This release coordinates with the installer fix from #355 (no source-level changes; tracking the security advisory cleared in the dev tree via root override of `fast-uri`).

## Published

- `@velvetmonkey/vault-core@2.12.11`
- `@velvetmonkey/flywheel-memory@2.12.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)