### PR TITLE
fix(fts5): apply escapeFts5Query to memory + similarity + note search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5998,7 +5998,7 @@
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@velvetmonkey/vault-core": "^2.12.11",
+        "@velvetmonkey/vault-core": "^2.12.12",
         "better-sqlite3": "^12.0.0",
         "chokidar": "^4.0.0",
         "gray-matter": "^4.0.3",
@@ -6018,6 +6018,27 @@
         "tsx": "^4.19.0",
         "typescript": "^5.3.2",
         "vitest": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "packages/mcp-server/node_modules/@velvetmonkey/vault-core": {
+      "version": "2.12.12",
+      "resolved": "https://registry.npmjs.org/@velvetmonkey/vault-core/-/vault-core-2.12.12.tgz",
+      "integrity": "sha512-c9zPmg5LipaLL/4z+E2caJVhHZ2xXVYAfZ37gf2itTTiOBYsrxgrUodVo8uIg7FO1+uDe4lkKgnhW9E4H+rNag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "better-sqlite3": "^12.0.0",
+        "esbuild": "0.27.4",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,6 +119,7 @@ export {
   saveFlywheelConfigToDb,
   loadFlywheelConfigFromDb,
   getStateDbMetadata,
+  escapeFts5Query,
   // Merge Dismissals
   recordMergeDismissal,
   getDismissedMergePairs,

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@velvetmonkey/vault-core": "^2.12.11",
+    "@velvetmonkey/vault-core": "^2.12.12",
     "better-sqlite3": "^12.0.0",
     "chokidar": "^4.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/mcp-server/src/core/read/fts5.ts
+++ b/packages/mcp-server/src/core/read/fts5.ts
@@ -14,6 +14,7 @@
 
 import type Database from 'better-sqlite3';
 import * as fs from 'fs';
+import { escapeFts5Query } from '@velvetmonkey/vault-core';
 import { scanVault } from './vault.js';
 import { serverLog } from '../shared/serverLog.js';
 import { SYSTEM_EXCLUDED_DIRS } from '../shared/constants.js';
@@ -280,40 +281,6 @@ export function updateFTS5Incremental(
  * - Prefix: auth*
  * - Column filter: title:api
  */
-/**
- * Sanitize a natural language query for FTS5 MATCH.
- * Strips operators, escapes quotes, normalizes whitespace.
- */
-function sanitizeFTS5Query(query: string): string {
-  if (!query?.trim()) return '';
-
-  // Extract quoted phrases first (preserve as AND-joined phrase matches)
-  const phrases: string[] = [];
-  const withoutPhrases = query.replace(/"([^"]+)"/g, (_, phrase) => {
-    phrases.push(`"${phrase.replace(/"/g, '""')}"`);
-    return '';
-  });
-
-  // Clean remaining tokens
-  const cleaned = withoutPhrases
-    .replace(/[(){}[\]^~:\-]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-
-  // Split into tokens, skip explicit AND/OR operators
-  const tokens = cleaned.split(' ').filter(t => t && t !== 'AND' && t !== 'OR' && t !== 'NOT');
-
-  // Combine: quoted phrases + OR-joined tokens
-  // OR semantics with BM25 ranking: documents matching more terms score higher
-  const parts = [...phrases];
-  if (tokens.length === 1) {
-    parts.push(tokens[0]);
-  } else if (tokens.length > 1) {
-    parts.push(tokens.join(' OR '));
-  }
-
-  return parts.join(' ') || '';
-}
 
 export function searchFTS5(
   _vaultPath: string,
@@ -325,7 +292,7 @@ export function searchFTS5(
     throw new Error('FTS5 database not initialized. Call setFTS5Database() first.');
   }
 
-  const sanitized = sanitizeFTS5Query(query);
+  const sanitized = escapeFts5Query(query);
   if (!sanitized) return [];
 
   try {

--- a/packages/mcp-server/src/core/read/similarity.ts
+++ b/packages/mcp-server/src/core/read/similarity.ts
@@ -20,7 +20,7 @@ import {
   type ScoredNote,
 } from './embeddings.js';
 import { selectByMmr, type MmrCandidate } from './mmr.js';
-import { STOPWORDS_EN } from '@velvetmonkey/vault-core';
+import { STOPWORDS_EN, escapeFts5Query } from '@velvetmonkey/vault-core';
 
 export interface SimilarNote {
   path: string;
@@ -84,8 +84,10 @@ export function findSimilarNotes(
   const terms = extractKeyTerms(content);
   if (terms.length === 0) return [];
 
-  // Build FTS5 query: OR the terms together
-  const query = terms.join(' OR ');
+  // Build FTS5 query: OR the terms together (escape each so column-name collisions
+  // and FTS5-reserved tokens like NEAR can't break the MATCH clause).
+  const query = escapeFts5Query(terms.join(' '));
+  if (!query) return [];
 
   try {
     // BM25 weights: path=0, title=5x, frontmatter=10x, content=1x

--- a/packages/mcp-server/src/core/write/memory.ts
+++ b/packages/mcp-server/src/core/write/memory.ts
@@ -7,7 +7,7 @@
  */
 
 import type { StateDb } from '@velvetmonkey/vault-core';
-import { recordEntityMention } from '@velvetmonkey/vault-core';
+import { recordEntityMention, escapeFts5Query } from '@velvetmonkey/vault-core';
 import { updateStoredNoteLinks } from './wikilinkFeedback.js';
 
 // =============================================================================
@@ -338,6 +338,9 @@ export function searchMemories(
 
   const where = conditions.length > 0 ? `AND ${conditions.join(' AND ')}` : '';
 
+  const escaped = escapeFts5Query(query);
+  if (!escaped) return [];
+
   try {
     const results = stateDb.db.prepare(`
       SELECT m.* FROM memories_fts
@@ -346,11 +349,11 @@ export function searchMemories(
       ${where}
       ORDER BY bm25(memories_fts)
       LIMIT ?
-    `).all(query, ...params, limit) as Memory[];
+    `).all(escaped, ...params, limit) as Memory[];
 
     return results;
   } catch (err) {
-    if (err instanceof Error && err.message.includes('fts5: syntax error')) {
+    if (err instanceof Error && (err.message.includes('fts5: syntax error') || err.message.includes('no such column'))) {
       throw new Error(`Invalid search query: ${query}. Check FTS5 syntax.`);
     }
     throw err;

--- a/packages/mcp-server/src/tools/read/query.ts
+++ b/packages/mcp-server/src/tools/read/query.ts
@@ -7,6 +7,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { VaultIndex, VaultNote } from '../../core/read/types.js';
 import { MAX_LIMIT } from '../../core/read/constants.js';
 import { requireIndex } from '../../core/read/indexGuard.js';
+import { serverLog } from '../../core/shared/serverLog.js';
 import {
   searchFTS5,
   buildFTS5Index,
@@ -600,7 +601,11 @@ export function registerQueryTools(
           try {
             const rawMemories = searchMemories(stateDbEntity, { query, limit });
             memoryResults = scoreAndRankMemories(rawMemories, limit);
-          } catch { /* memory search is best-effort */ }
+          } catch (err) {
+            // Best-effort: search must still return note/entity results, but surface
+            // the memory leg failure so regressions don't silently swallow memories.
+            serverLog('fts5', `memory search failed: ${err instanceof Error ? err.message : String(err)}`, 'warn');
+          }
         }
 
         // Entity section — enriched profiles + semantic entity search

--- a/packages/mcp-server/test/write/tools/memory-search-fts5.test.ts
+++ b/packages/mcp-server/test/write/tools/memory-search-fts5.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression: FTS5 column-injection in memory search.
+ *
+ * 2026-05-10 — scheduled jobs (zen-coach, morning-briefing, launch-monitor) failed
+ * with `no such column: 41252` / `no such column: memory` because raw user queries
+ * containing hyphenated alphanumeric tokens like `OC-41252` reached the
+ * `memories_fts MATCH ?` clause unescaped — SQLite FTS5 then parsed `OC-41252` as a
+ * column-qualified term and threw.
+ *
+ * The May 8 fix (#353) added `escapeFts5Query` but never reached the memory search
+ * call site at `core/write/memory.ts:349`. These tests pin the call site to the
+ * shared escape helper.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  openStateDb,
+  deleteStateDb,
+  type StateDb,
+} from '@velvetmonkey/vault-core';
+import { searchMemories, storeMemory } from '../../../src/core/write/memory.js';
+import { createTempVault, cleanupTempVault } from '../helpers/testUtils.js';
+
+describe('searchMemories FTS5 regressions', () => {
+  let tempVault: string;
+  let stateDb: StateDb | null = null;
+
+  beforeEach(async () => {
+    tempVault = await createTempVault();
+    stateDb = openStateDb(tempVault);
+
+    storeMemory(stateDb, {
+      key: 'oc-41252-deploy',
+      value: 'OC-41252 still not deployed to stage. Tesla dent photos overdue.',
+      type: 'observation',
+    });
+    storeMemory(stateDb, {
+      key: 'fwg-prep',
+      value: 'FWG experiment Phase 0 prep not yet started. Witness theory expanding.',
+      type: 'observation',
+    });
+    storeMemory(stateDb, {
+      key: 'morning-briefing',
+      value: 'Morning briefing: research findings overnight on flywheel concept.',
+      type: 'summary',
+    });
+  });
+
+  afterEach(async () => {
+    if (stateDb) {
+      stateDb.close();
+      stateDb = null;
+    }
+    deleteStateDb(tempVault);
+    await cleanupTempVault(tempVault);
+  });
+
+  // Today's failing queries — all observed in flywheel-engine logs 2026-05-10.
+  it('handles hyphenated alphanumeric tokens (OC-41252)', () => {
+    if (!stateDb) throw new Error('StateDb not initialized');
+    expect(() => searchMemories(stateDb!, { query: 'OC-41252' })).not.toThrow();
+  });
+
+  it('handles the zen-coach query verbatim', () => {
+    if (!stateDb) throw new Error('StateDb not initialized');
+    const query = 'FWG experiment flywheel concept OC-41252 Tesla';
+    expect(() => searchMemories(stateDb!, { query })).not.toThrow();
+  });
+
+  it('handles the morning-briefing query verbatim', () => {
+    if (!stateDb) throw new Error('StateDb not initialized');
+    const query = 'morning briefing research findings overnight FWG OC-41252 Tesla';
+    expect(() => searchMemories(stateDb!, { query })).not.toThrow();
+  });
+
+  // `memory` is a column-name lookalike in some FTS5 contexts; left unquoted it
+  // produced `no such column: memory` in today's logs.
+  it('handles a bare `memory` token without column-reference injection', () => {
+    if (!stateDb) throw new Error('StateDb not initialized');
+    expect(() => searchMemories(stateDb!, { query: 'memory' })).not.toThrow();
+  });
+
+  it('handles ISO dates like 2026-05-08 (May 8 regression class)', () => {
+    if (!stateDb) throw new Error('StateDb not initialized');
+    expect(() => searchMemories(stateDb!, { query: '2026-05-08 briefing' })).not.toThrow();
+  });
+
+  it('returns matching memories for a normal alphanumeric query', () => {
+    if (!stateDb) throw new Error('StateDb not initialized');
+    const results = searchMemories(stateDb!, { query: 'flywheel' });
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty array (not throw) on an all-stripped query', () => {
+    if (!stateDb) throw new Error('StateDb not initialized');
+    const results = searchMemories(stateDb!, { query: '---' });
+    expect(results).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The May 8 fix (#353) quoted bare tokens in `escapeFts5Query` but never reached three call sites that build FTS5 `MATCH` clauses from raw user input. Today's flywheel-engine logs show recurring `no such column` failures in scheduled jobs:

| Time (UTC) | Job | Error |
|---|---|---|
| 02:01 | zen-coach | `no such column: 41252` |
| 05:01 | morning-briefing | `no such column: 41252` (x2) |
| 11:02 | flywheel-launch-monitor | `no such column: memory` |

All three came from memory-search queries containing hyphenated alphanumeric tokens like `OC-41252` reaching `memories_fts MATCH ?` unescaped. SQLite FTS5 then parses `OC-41252` as `col:term` and throws.

## Changes

- **`core/write/memory.ts`** — wrap `query` with `escapeFts5Query` before `MATCH`; broaden the catch to also intercept `no such column` so future bypasses surface as `Invalid search query` instead of leaking raw SQL.
- **`core/read/fts5.ts`** — retire local `sanitizeFTS5Query` (a weaker sibling that left tokens unquoted) in favour of the shared `escapeFts5Query`. Same fix unblocks date-bearing note queries like `2026-05-08`.
- **`core/read/similarity.ts`** — escape extracted terms defense-in-depth so column-name lookalikes (`title`, `content`) and FTS5-reserved tokens (`NEAR`) can't break the MATCH.
- **`tools/read/query.ts`** — log memory-search failures via `serverLog` instead of silently swallowing them. The same `catch {}` was hiding today's bug from regular vault search; only the scheduled jobs surfaced it because they log raw tool_result.
- **`core/src/index.ts`** — re-export `escapeFts5Query` from vault-core root so consumers don't reach into subpaths.

## Test plan

- [x] `vault-core` test suite (296 tests) green — no regressions from the new export.
- [x] Targeted new regression tests in `test/write/tools/memory-search-fts5.test.ts` (7 tests) cover every query string observed in today's logs:
  - `OC-41252` (hyphenated alphanumeric)
  - Full zen-coach query: `FWG experiment flywheel concept OC-41252 Tesla`
  - Full morning-briefing query: `morning briefing research findings overnight FWG OC-41252 Tesla`
  - Bare `memory` token (the `no such column: memory` case)
  - ISO date `2026-05-08 briefing` (the May 8 regression class)
  - A normal alphanumeric query still returns results
  - All-stripped query returns `[]` instead of throwing
- [x] Build clean (`npm run build`)
- [x] Lint clean (`npm run lint` / `tsc --noEmit` across all workspaces)
- [x] Neighbouring `entity-search` and `memory` tool tests (41 tests) still green
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)