### PR TITLE
chore: bump vault-core to 2.12.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5966,7 +5966,7 @@
     },
     "packages/core": {
       "name": "@velvetmonkey/vault-core",
-      "version": "2.12.11",
+      "version": "2.12.12",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/vault-core",
-  "version": "2.12.11",
+  "version": "2.12.12",
   "description": "Shared vault utilities for Flywheel ecosystem (entity scanning, wikilinks, protected zones)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,6 +119,7 @@ export {
   saveFlywheelConfigToDb,
   loadFlywheelConfigFromDb,
   getStateDbMetadata,
+  escapeFts5Query,
   // Merge Dismissals
   recordMergeDismissal,
   getDismissedMergePairs,


### PR DESCRIPTION
Bump vault-core to 2.12.12. **Already published to npm.**

## Change

Adds `escapeFts5Query` to vault-core's public exports — same helper that's been the canonical FTS5 token-quoting function since #353 (2026-05-08), now reachable from outside the package.

## Why

`mcp-server` consumers (memory search, note search, similarity) need this export to fix today's `no such column: 41252` / `no such column: memory` failures observed in flywheel-engine logs. Follow-up PR #358 depends on this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)