### PR TITLE
chore: bump flywheel-memory to 2.12.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5992,7 +5992,7 @@
     },
     "packages/mcp-server": {
       "name": "@velvetmonkey/flywheel-memory",
-      "version": "2.12.11",
+      "version": "2.12.12",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.11",
+  "version": "2.12.12",
   "description": "MCP tools that search, write, and auto-link your Obsidian vault — and learn from your edits.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bump flywheel-memory to 2.12.12. **Already published to npm.**

## What's New

- **FTS5 column-injection fix** (PR #358): memory + note + similarity searches now route user queries through `escapeFts5Query` before `MATCH`. Resolves recurring `no such column: 41252` / `no such column: memory` failures observed in flywheel-engine logs on 2026-05-10.
- **Memory-search observability**: `tools/read/query.ts` no longer silently swallows memory-search failures — they now surface via `serverLog`.
- **Dep**: `@velvetmonkey/vault-core` bumped to `^2.12.12` (released earlier today via #359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)