### PR TITLE
fix: watcher batches count toward index freshness

### DIFF
--- a/packages/mcp-server/src/tools/read/health.ts
+++ b/packages/mcp-server/src/tools/read/health.ts
@@ -361,8 +361,23 @@ export function registerHealthTools(
       } catch { /* ignore */ }
     }
 
-    // Use last full rebuild for freshness, not watcher activity
-    const freshnessTimestamp = lastFullRebuildAt ?? (indexBuilt && index.builtAt ? index.builtAt.getTime() : undefined);
+    // Freshness = newest of {last full rebuild, last successful watcher
+    // batch}. The watcher's 25-step incremental pipeline (fts5, embeddings,
+    // hub scores, etc.) keeps the index current between full rebuilds —
+    // treating it otherwise produces a false-positive "stale" flag 5 min
+    // after every manual refresh on actively-watched vaults.
+    //
+    // index.builtAt is the in-memory load timestamp — it always equals
+    // "right now" for a freshly-loaded server. Only use it as a last-resort
+    // fallback when no index_events rows exist at all (e.g. brand-new DB
+    // before the first watcher batch lands).
+    const freshnessTimestamp = (() => {
+      const events = [lastFullRebuildAt, lastWatcherBatchAt].filter(
+        (t): t is number => typeof t === 'number' && t > 0,
+      );
+      if (events.length) return Math.max(...events);
+      return indexBuilt && index.builtAt ? index.builtAt.getTime() : undefined;
+    })();
     const indexAge = freshnessTimestamp
       ? Math.floor((Date.now() - freshnessTimestamp) / 1000)
       : -1;

--- a/packages/mcp-server/test/read/tools/health.test.ts
+++ b/packages/mcp-server/test/read/tools/health.test.ts
@@ -145,7 +145,12 @@ describe('flywheel_doctor report=health (formerly health_check)', () => {
     }
   });
 
-  test('uses the last full rebuild for freshness instead of watcher activity', async () => {
+  test('counts recent watcher batches as freshness (incremental pipeline keeps index live)', async () => {
+    // Contract: index_age is min-age across {full rebuild, watcher batch, build}.
+    // The watcher's 25-step pipeline (fts5_incremental, embeddings, hub scores,
+    // etc.) IS a fresh-index signal — treating only full rebuilds as freshness
+    // caused doctor to recommend `refresh_index` 5 min after every manual
+    // refresh on actively-watched vaults, even though the index was current.
     expect(context.stateDb).toBeTruthy();
     const stateDb = context.stateDb!;
     const now = Date.now();
@@ -176,12 +181,19 @@ describe('flywheel_doctor report=health (formerly health_check)', () => {
     const result = await client.callTool('doctor', { action: 'health' });
     const data = JSON.parse(result.content[0].text);
 
-    expect(data.index_age_seconds).toBeGreaterThanOrEqual(rebuildAgoSeconds - 5);
-    expect(data.index_age_seconds).toBeLessThanOrEqual(rebuildAgoSeconds + 5);
+    // index_age tracks the watcher batch (newer than the rebuild).
+    expect(data.index_age_seconds).toBeGreaterThanOrEqual(watcherAgoSeconds - 5);
+    expect(data.index_age_seconds).toBeLessThanOrEqual(watcherAgoSeconds + 5);
+    // last_rebuild still reports the full rebuild — we still surface that
+    // separately so users can see when the last full rebuild ran.
     expect(data.last_rebuild.trigger).toBe('startup_build');
     expect(data.last_rebuild.ago_seconds).toBeGreaterThanOrEqual(rebuildAgoSeconds - 5);
     expect(data.last_rebuild.ago_seconds).toBeLessThanOrEqual(rebuildAgoSeconds + 5);
-    expect(Math.abs(data.last_rebuild.ago_seconds - data.index_age_seconds)).toBeLessThanOrEqual(1);
+    // last_watcher_batch_at lines up with watcherAgoSeconds.
+    expect(data.last_watcher_batch_at).toBeGreaterThanOrEqual(now - (watcherAgoSeconds + 5) * 1000);
+    expect(data.last_watcher_batch_at).toBeLessThanOrEqual(now - (watcherAgoSeconds - 5) * 1000);
+    // With watcherAgoSeconds=30s under the 300s threshold, index is NOT stale.
+    expect(data.index_stale).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Doctor health flagged `index_stale: true` 5 min after every manual refresh, even with the watcher actively keeping the index current.
- Freshness is now `max(lastFullRebuildAt, lastWatcherBatchAt)` — the watcher's 25-step incremental pipeline counts as a freshness signal.
- `last_rebuild` is still surfaced separately for visibility into the last full rebuild.

## Why
The user noticed the index "kept going stale" and assumed the watcher had stopped — actually the watcher was healthy (1d 6h uptime, processing files every batch). The misleading staleness flag created a feedback loop: run `refresh_index`, see stale again 5 min later, run it again. Triggered debugging that showed the watcher was fine; only the doctor's stale heuristic was lying.

## Test plan
- [x] `npx vitest run packages/mcp-server/test/read/tools/health.test.ts` → 13/13 pass
- [x] `tsc --noEmit` clean across all packages
- [ ] Manual: restart flywheel-memory service, hit `doctor health` 10 min after last refresh — `index_stale` should be `false` if watcher batches happened in that window

🤖 Generated with [Claude Code](https://claude.com/claude-code)