### PR TITLE
fix: bump index staleness threshold to 30 min

### DIFF
--- a/packages/mcp-server/src/tools/read/health.ts
+++ b/packages/mcp-server/src/tools/read/health.ts
@@ -29,7 +29,11 @@ import { searchFTS5 } from '../../core/read/fts5.js';
 import { recordBenchmark, getBenchmarkHistory, getBenchmarkTrends } from '../../core/shared/benchmarks.js';
 
 /** Staleness threshold in seconds (5 minutes) */
-const STALE_THRESHOLD_SECONDS = 300;
+// 30 min — a quiet period of half an hour is a more honest threshold for
+// "the watcher might have stopped" than 5 min (which trips on every coffee
+// break on an actively-watched vault). Pair this with the previous fix
+// that makes freshness count watcher batches, not just full rebuilds.
+const STALE_THRESHOLD_SECONDS = 1800;
 
 /**
  * Register vault health tools

--- a/packages/mcp-server/test/read/tools/health.test.ts
+++ b/packages/mcp-server/test/read/tools/health.test.ts
@@ -192,7 +192,7 @@ describe('flywheel_doctor report=health (formerly health_check)', () => {
     // last_watcher_batch_at lines up with watcherAgoSeconds.
     expect(data.last_watcher_batch_at).toBeGreaterThanOrEqual(now - (watcherAgoSeconds + 5) * 1000);
     expect(data.last_watcher_batch_at).toBeLessThanOrEqual(now - (watcherAgoSeconds - 5) * 1000);
-    // With watcherAgoSeconds=30s under the 300s threshold, index is NOT stale.
+    // With watcherAgoSeconds=30s under the staleness threshold, index is NOT stale.
     expect(data.index_stale).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- `STALE_THRESHOLD_SECONDS`: 300 → 1800.
- 5 min was too aggressive on healthy actively-watched vaults — every coffee break tripped the flag.

## Why
Stacks on #366. With #366, freshness now correctly counts watcher batches as fresh signal. But the 5 min threshold still tripped during quiet periods (no edits = no batches), recreating the "watcher down" misperception this flag was supposed to *resolve*. 30 min is a more honest threshold for "the watcher is genuinely silent and you should look".

## Test plan
- [x] `npx vitest run packages/mcp-server/test/read/tools/health.test.ts` → 13/13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)