### PR TITLE
feat: emit tool-call observations to an optional observer URL

### DIFF
--- a/packages/mcp-server/src/core/shared/observer.ts
+++ b/packages/mcp-server/src/core/shared/observer.ts
@@ -1,0 +1,167 @@
+/**
+ * Retrieval observation side-channel.
+ *
+ * When FLYWHEEL_OBSERVER_URL is set, every tool call emits a compact
+ * observation (tool, input summary, result summary, char count, latency)
+ * to that URL via a fire-and-forget POST. This lets an external surface
+ * (the Mega Monkey cockpit) show what the vault is being asked and what
+ * comes back — WITHOUT putting the observer in the vault's data path.
+ *
+ * Invariants (load-bearing — see Stage 1b roundtable):
+ *   - If FLYWHEEL_OBSERVER_URL is unset, every export here is a no-op.
+ *     flywheel-memory behaves exactly as a standalone server.
+ *   - emitObservation NEVER awaits the fetch and NEVER throws. A slow or
+ *     dead observer cannot block, error, or back-pressure a tool call.
+ *   - The summarisers only scan capped slices of the result — no
+ *     full-payload retention, negligible cost.
+ */
+
+const MAX_RESULT_SUMMARY = 280;
+const MAX_INPUT_SUMMARY = 280;
+const OBSERVER_TIMEOUT_MS = 1500;
+
+/** Fields we surface as the "what was asked" summary, in priority order. */
+const INPUT_FIELDS = [
+  'query',
+  'focus',
+  'analysis',
+  'entity',
+  'heading',
+  'path',
+  'note_path',
+  'source',
+  'target',
+  'field',
+  'date',
+  'concept',
+  'key',
+  'action',
+] as const;
+
+export interface Observation {
+  tool: string;
+  input_summary?: string;
+  result_summary?: string;
+  result_chars?: number;
+  is_error?: boolean;
+  duration_ms?: number;
+  session_id?: string;
+}
+
+/** Join the text blocks of an MCP result into one string (capped scan). */
+function joinContent(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    const b = block as { type?: string; text?: string };
+    if (b?.type === 'text' && typeof b.text === 'string') parts.push(b.text);
+    if (parts.length >= 8) break; // cap — never walk an enormous result
+  }
+  return parts.join('\n');
+}
+
+function truncate(s: string, max: number): string {
+  const flat = s.replace(/\s+/g, ' ').trim();
+  return flat.length > max ? flat.slice(0, max - 1) + '…' : flat;
+}
+
+/**
+ * Tool-aware one-line summary of a result. Best-effort: the leading text
+ * block of most flywheel tools is JSON, so we try to read structured
+ * shape first and fall back to a truncated text snippet.
+ */
+export function summariseResult(tool: string, content: unknown): string | undefined {
+  const text = joinContent(content);
+  if (!text) return undefined;
+
+  // Parse the FULL text — slicing first would truncate large results into
+  // invalid JSON. Skip the parse only for pathologically huge payloads.
+  let parsed: any;
+  if (text.length <= 2_000_000) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = undefined;
+    }
+  }
+
+  if (parsed && typeof parsed === 'object') {
+    switch (tool) {
+      case 'search':
+      case 'find_notes': {
+        const results = parsed.results ?? parsed.notes ?? parsed.matches;
+        if (Array.isArray(results)) {
+          const count = parsed.total_results ?? parsed.total ?? results.length;
+          const titles = results
+            .slice(0, 2)
+            .map((r: any) => r?.title ?? r?.path ?? r?.name)
+            .filter(Boolean);
+          const head = `${count} result${count === 1 ? '' : 's'}`;
+          return truncate(titles.length ? `${head}: ${titles.join(', ')}` : head, MAX_RESULT_SUMMARY);
+        }
+        break;
+      }
+      case 'read': {
+        const wc = parsed.word_count ?? parsed.words;
+        const p = parsed.path ?? parsed.note_path ?? parsed.title;
+        if (p) return truncate(wc != null ? `${p} (${wc} words)` : String(p), MAX_RESULT_SUMMARY);
+        break;
+      }
+      case 'memory': {
+        const bits = [parsed.action, parsed.key, parsed.count != null ? `${parsed.count} items` : undefined]
+          .filter(Boolean)
+          .join(' ');
+        if (bits) return truncate(bits, MAX_RESULT_SUMMARY);
+        break;
+      }
+      case 'graph':
+      case 'link':
+      case 'insights': {
+        const arr = parsed.results ?? parsed.suggestions ?? parsed.links ?? parsed.nodes ?? parsed.items;
+        if (Array.isArray(arr)) return truncate(`${arr.length} ${tool} items`, MAX_RESULT_SUMMARY);
+        break;
+      }
+    }
+  }
+
+  return truncate(text, MAX_RESULT_SUMMARY);
+}
+
+/** One-line summary of the tool input from its params. */
+export function summariseInput(params: unknown): string | undefined {
+  if (!params || typeof params !== 'object') return undefined;
+  const p = params as Record<string, unknown>;
+  const parts: string[] = [];
+  for (const field of INPUT_FIELDS) {
+    const v = p[field];
+    if (typeof v === 'string' && v.trim()) parts.push(`${field}=${v.trim()}`);
+    else if (Array.isArray(v) && v.length) parts.push(`${field}=[${v.length}]`);
+    if (parts.length >= 3) break;
+  }
+  if (!parts.length) return undefined;
+  return truncate(parts.join(' '), MAX_INPUT_SUMMARY);
+}
+
+/**
+ * Fire-and-forget POST the observation to FLYWHEEL_OBSERVER_URL.
+ * No-op when the env var is unset. Never awaited, never throws.
+ */
+export function emitObservation(obs: Observation): void {
+  const url = process.env.FLYWHEEL_OBSERVER_URL;
+  if (!url) return;
+  try {
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    const token = process.env.FLYWHEEL_OBSERVER_TOKEN;
+    if (token) headers['authorization'] = `Bearer ${token}`;
+    void fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(obs),
+      signal: AbortSignal.timeout(OBSERVER_TIMEOUT_MS),
+    }).catch(() => {
+      /* observer down/slow — drop silently, never affect the tool path */
+    });
+  } catch {
+    /* synchronous fetch/JSON/abort error — swallow */
+  }
+}

--- a/packages/mcp-server/src/tool-registry.ts
+++ b/packages/mcp-server/src/tool-registry.ts
@@ -35,6 +35,7 @@ import {
   extractSearchMethod,
   getActivationSignals,
 } from './tool-registry/activation.js';
+import { emitObservation, summariseInput, summariseResult } from './core/shared/observer.js';
 import { shouldSuppressMemoryTool } from './tool-registry/clientSuppressions.js';
 import { runCrossVaultSearch } from './tool-registry/crossVault.js';
 import { shouldEnableTieredTool, getDirectCallPromotion } from './tool-registry/tiering.js';
@@ -378,6 +379,37 @@ export function applyToolGating(
           } catch {
             // Never let tracking errors affect tool execution
           }
+        }
+
+        // Stage 1b — capture-at-source retrieval observation. Fire-and-forget
+        // side-channel to FLYWHEEL_OBSERVER_URL (no-op when unset). Wrapped in
+        // its own guard so a summariser/emit fault can never reach the tool
+        // path; mirrors the "Never let tracking errors affect tool execution"
+        // contract above. Runs whether or not a stateDb is present.
+        try {
+          if (process.env.FLYWHEEL_OBSERVER_URL) {
+            let obsSession: string | undefined;
+            try { obsSession = getSessionId(); } catch { /* no session */ }
+            let resultChars: number | undefined;
+            if (result?.content && Array.isArray(result.content)) {
+              let total = 0;
+              for (const block of result.content) {
+                if (block?.type === 'text' && typeof block.text === 'string') total += block.text.length;
+              }
+              if (total > 0) resultChars = total;
+            }
+            emitObservation({
+              tool: toolName,
+              input_summary: summariseInput(params),
+              result_summary: success ? summariseResult(toolName, result?.content) : undefined,
+              result_chars: resultChars,
+              is_error: !success,
+              duration_ms: Date.now() - start,
+              session_id: obsSession,
+            });
+          }
+        } catch {
+          // Never let observation errors affect tool execution
         }
       }
     };

--- a/packages/mcp-server/test/shared/observer.test.ts
+++ b/packages/mcp-server/test/shared/observer.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  summariseInput,
+  summariseResult,
+  emitObservation,
+} from '../../src/core/shared/observer.js';
+
+/** Build an MCP-style content array from one JSON-or-text block. */
+function content(text: string) {
+  return [{ type: 'text', text }];
+}
+
+describe('summariseResult', () => {
+  it('summarises a search result as "N results" + leading titles', () => {
+    const c = content(
+      JSON.stringify({ results: [{ title: 'Kuramoto' }, { title: 'Sync' }, { title: 'Third' }] }),
+    );
+    const s = summariseResult('search', c);
+    expect(s).toContain('3 results');
+    expect(s).toContain('Kuramoto');
+    expect(s).toContain('Sync');
+    // only the first two titles, not the third
+    expect(s).not.toContain('Third');
+  });
+
+  it('prefers total_results over the truncated page length', () => {
+    const c = content(JSON.stringify({ total_results: 22, results: [{ title: 'First' }, { title: 'Second' }] }));
+    const s = summariseResult('search', c);
+    expect(s).toContain('22 results');
+    expect(s).toContain('First');
+  });
+
+  it('parses a large (>20k char) search result without corrupting the JSON', () => {
+    // Regression: slicing the text before JSON.parse truncated big results
+    // into invalid JSON and fell back to a raw dump. Must still summarise.
+    const results = Array.from({ length: 40 }, (_, i) => ({
+      title: `Note ${i}`,
+      snippet: 'x'.repeat(800),
+    }));
+    const big = JSON.stringify({ total_results: 40, results });
+    expect(big.length).toBeGreaterThan(20000);
+    const s = summariseResult('search', content(big));
+    expect(s).toContain('40 results');
+    expect(s).toContain('Note 0');
+    expect(s!.length).toBeLessThanOrEqual(280);
+  });
+
+  it('singularises one result', () => {
+    const s = summariseResult('search', content(JSON.stringify({ results: [{ title: 'Solo' }] })));
+    expect(s).toContain('1 result');
+    expect(s).not.toContain('1 results');
+  });
+
+  it('summarises a read result with path + word count', () => {
+    const s = summariseResult('read', content(JSON.stringify({ path: 'tech/x.md', word_count: 412 })));
+    expect(s).toBe('tech/x.md (412 words)');
+  });
+
+  it('summarises a memory result with action + key', () => {
+    const s = summariseResult('memory', content(JSON.stringify({ action: 'store', key: 'sprint' })));
+    expect(s).toContain('store');
+    expect(s).toContain('sprint');
+  });
+
+  it('summarises graph/link/insights by item count', () => {
+    const s = summariseResult('link', content(JSON.stringify({ suggestions: [1, 2, 3, 4] })));
+    expect(s).toBe('4 link items');
+  });
+
+  it('falls back to a truncated text snippet for unknown shapes', () => {
+    const s = summariseResult('doctor', content('plain non-json health output line'));
+    expect(s).toContain('plain non-json health output');
+  });
+
+  it('caps very long summaries', () => {
+    const s = summariseResult('doctor', content('x'.repeat(5000)));
+    expect(s!.length).toBeLessThanOrEqual(280);
+    expect(s!.endsWith('…')).toBe(true);
+  });
+
+  it('returns undefined for empty content', () => {
+    expect(summariseResult('search', [])).toBeUndefined();
+    expect(summariseResult('search', undefined)).toBeUndefined();
+  });
+});
+
+describe('summariseInput', () => {
+  it('surfaces query field', () => {
+    expect(summariseInput({ query: 'kuramoto sync' })).toBe('query=kuramoto sync');
+  });
+
+  it('shows array fields as a count', () => {
+    expect(summariseInput({ paths: ['a.md', 'b.md'] })).toBeUndefined(); // paths not an INPUT_FIELD
+    expect(summariseInput({ path: 'a.md' })).toBe('path=a.md');
+  });
+
+  it('returns undefined when no recognised fields', () => {
+    expect(summariseInput({ unrelated: true })).toBeUndefined();
+    expect(summariseInput(undefined)).toBeUndefined();
+    expect(summariseInput('nope')).toBeUndefined();
+  });
+
+  it('caps at three fields', () => {
+    const s = summariseInput({ query: 'q', focus: 'f', analysis: 'a', entity: 'e' });
+    expect(s!.split(' ').length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('emitObservation', () => {
+  const realFetch = globalThis.fetch;
+  beforeEach(() => {
+    delete process.env.FLYWHEEL_OBSERVER_URL;
+    delete process.env.FLYWHEEL_OBSERVER_TOKEN;
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.FLYWHEEL_OBSERVER_URL;
+    delete process.env.FLYWHEEL_OBSERVER_TOKEN;
+    vi.restoreAllMocks();
+  });
+
+  it('no-ops when FLYWHEEL_OBSERVER_URL is unset', () => {
+    const spy = vi.fn();
+    globalThis.fetch = spy as any;
+    emitObservation({ tool: 'search' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('POSTs to the observer url when set', () => {
+    process.env.FLYWHEEL_OBSERVER_URL = 'http://localhost:3124/mcp-observed';
+    const spy = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = spy as any;
+    emitObservation({ tool: 'search', input_summary: 'q=x', result_chars: 10 });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toBe('http://localhost:3124/mcp-observed');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body).tool).toBe('search');
+  });
+
+  it('attaches a bearer token when FLYWHEEL_OBSERVER_TOKEN is set', () => {
+    process.env.FLYWHEEL_OBSERVER_URL = 'http://localhost:3124/mcp-observed';
+    process.env.FLYWHEEL_OBSERVER_TOKEN = 'secret';
+    const spy = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = spy as any;
+    emitObservation({ tool: 'read' });
+    expect(spy.mock.calls[0][1].headers['authorization']).toBe('Bearer secret');
+  });
+
+  it('swallows a rejected fetch (never throws)', async () => {
+    process.env.FLYWHEEL_OBSERVER_URL = 'http://localhost:3124/mcp-observed';
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('connrefused')) as any;
+    expect(() => emitObservation({ tool: 'search' })).not.toThrow();
+    // let the rejected microtask settle — must not become an unhandled rejection
+    await new Promise((r) => setTimeout(r, 5));
+  });
+
+  it('swallows a synchronous fetch throw', () => {
+    process.env.FLYWHEEL_OBSERVER_URL = 'http://localhost:3124/mcp-observed';
+    globalThis.fetch = vi.fn(() => {
+      throw new Error('boom');
+    }) as any;
+    expect(() => emitObservation({ tool: 'search' })).not.toThrow();
+  });
+});

--- a/packages/mcp-server/test/write/security/sovereignty.test.ts
+++ b/packages/mcp-server/test/write/security/sovereignty.test.ts
@@ -33,6 +33,10 @@ async function collectTsFiles(dir: string): Promise<string[]> {
 // Known allowed network call sites (file path substring => reason)
 const ALLOWED_NETWORK_SITES: Record<string, string> = {
   'core/read/embeddings.ts': '@huggingface/transformers model download (one-time, cached locally)',
+  'core/shared/observer.ts':
+    'Retrieval observation side-channel. OPT-IN ONLY — no-op unless FLYWHEEL_OBSERVER_URL ' +
+    'is set, so default configuration makes zero outbound calls. Fire-and-forget, ' +
+    'non-awaited, 1.5s timeout, swallowed; sends a compact summary (no full payloads).',
 };
 
 // Network call patterns to detect


### PR DESCRIPTION
## What

When `FLYWHEEL_OBSERVER_URL` is set, every tool call emits a compact observation (tool, input summary, tool-aware result summary, result char count, latency, error flag, session id) to that URL via a **fire-and-forget POST**. This lets an external surface (the Mega Monkey cockpit's Retrieval panel) show what the vault is asked and what comes back — **without putting the observer in the vault's data path**.

Captured at the single `wrapWithTracking` choke point, so every client (bot, conductor, ad-hoc claude-code, roundtable seats) is covered automatically.

## Invariants (load-bearing)

- **Unset env var → no-op.** flywheel-memory behaves exactly as a standalone server for everyone who doesn't set it.
- `emitObservation` **never awaits** the fetch and **never throws** (1.5s `AbortSignal` timeout + swallow). A slow or dead observer cannot block, error, or back-pressure a tool call.
- The whole capture block in `wrapWithTracking`'s `finally` is wrapped in its own `try/catch` defaulting to no-op — mirrors the existing *"Never let tracking errors affect tool execution"* guard right above it.
- Summarisers scan only capped slices; no full-payload retention. `summariseResult` parses the **full** result text (skipped above 2MB) so large results aren't truncated into invalid JSON.

## Verified live

- Real `:3111` search → observation lands at the observer with a correct `"N results: title, title"` summary.
- **Decoupling proof:** observer pointed at a dead port → vault search still returns full results, observation silently dropped.
- `FLYWHEEL_OBSERVER_TOKEN` (optional) attaches a bearer header for when the observer's auth gate is on.

## Tests

`observer.test.ts` — 19 cases: per-tool summariser shapes, large-result (>20k char) regression, env-gated no-op, bearer token, synchronous + async fetch-error swallow. Full build + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)