### PR TITLE
fix(shard): honor caller wikilink flags in sharded audit writes

### DIFF
--- a/packages/mcp-server/src/tools/write/editSection.ts
+++ b/packages/mcp-server/src/tools/write/editSection.ts
@@ -135,7 +135,8 @@ async function ensureShardNote(vaultPath: string, canonicalNotePath: string, tar
       tags: ['#daily', '#audit-log'],
       shard: options.mode || 'audit',
       shard_index: target.index,
-      skipWikilinks: true,
+      // No skipWikilinks stamp: shards must stay eligible for on-write linking and the
+      // background enrich pass (enrich.ts skips any note whose frontmatter sets it true).
       flywheel_indexing: options.lightIndex === false ? undefined : 'light',
       description: `Operational audit log shard ${indexLabel} for ${date}`,
     }
@@ -556,8 +557,11 @@ async function handleShardedAdd(
       ...params,
       path: target.notePath,
       create_if_missing: false,
-      skipWikilinks: true,
-      suggestOutgoingLinks: false,
+      // Honor the caller's linking intent for shard content instead of forcing it off.
+      // mega-monkey passes skipWikilinks:false + suggestOutgoingLinks:true to keep the
+      // audit-log graph-building even while sharding stays enabled.
+      skipWikilinks: params.skipWikilinks ?? false,
+      suggestOutgoingLinks: params.suggestOutgoingLinks ?? false,
       shard: undefined,
     },
     getVaultPath,

--- a/packages/mcp-server/test/write/integration/mcp-write.test.ts
+++ b/packages/mcp-server/test/write/integration/mcp-write.test.ts
@@ -200,6 +200,61 @@ describe('MCP Write Integration', () => {
       expect(shard).toContain('Operational note for [[Project Alpha]]');
     });
 
+    it('auto-links sharded content and omits the skipWikilinks frontmatter stamp when the caller opts in', async () => {
+      await createTestNote(ctx.vaultPath, 'projects/Widget Engine.md', [
+        '# Widget Engine',
+        '',
+        'Project note.',
+      ].join('\n'));
+      createEntityCacheInStateDb(ctx.stateDb, ctx.vaultPath, {
+        projects: ['Widget Engine'],
+      });
+      await initializeEntityIndex(ctx.vaultPath);
+
+      await createTestNote(ctx.vaultPath, 'daily-notes/2099-03-10.md', [
+        '---',
+        'type: daily',
+        "date: '2099-03-10'",
+        '---',
+        '# 2099-03-10',
+        '',
+        '## Log',
+        '',
+      ].join('\n'));
+
+      const result = await client.callTool({
+        name: 'edit_section',
+        arguments: {
+          action: 'add',
+          path: 'daily-notes/2099-03-10.md',
+          section: 'Log',
+          content: '**11:00** 🐵 shipped the Widget Engine rollout',
+          format: 'bullet',
+          // mega-monkey's new audit-log behavior: link even inside shards.
+          skipWikilinks: false,
+          suggestOutgoingLinks: true,
+          shard: {
+            enabled: true,
+            pattern: 'daily-notes/logs/{date}-audit-{index}.md',
+            maxBytes: 262144,
+            maxEntries: 250,
+            mode: 'audit',
+            lightIndex: true,
+          },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const data = parseResult(result) as Record<string, unknown>;
+      expect(data.shardPath).toBe('daily-notes/logs/2099-03-10-audit-001.md');
+
+      const shard = readFileSync(path.join(ctx.vaultPath, 'daily-notes/logs/2099-03-10-audit-001.md'), 'utf-8');
+      // handleShardedAdd now honors the caller's flags → plain "Widget Engine" gets wrapped.
+      expect(shard).toContain('[[Widget Engine]]');
+      // ensureShardNote no longer stamps skipWikilinks, so enrich keeps processing the shard.
+      expect(shard).not.toMatch(/^skipWikilinks:\s*true\s*$/m);
+    });
+
     it('rolls sharded audit appends when the entry count limit is reached', async () => {
       await createTestNote(ctx.vaultPath, 'daily-notes/2099-02-04.md', [
         '---',


### PR DESCRIPTION
## Why

Once audit-log sharding became the default, mega-monkey's daily notes stopped opportunistically wikilinking. The Log section is routed into shard notes, and the shard write path made them link-dead:

- `handleShardedAdd` hardcoded `skipWikilinks: true` + `suggestOutgoingLinks: false` when forwarding to `handleAdd`, ignoring the caller's intent.
- `ensureShardNote` stamped `skipWikilinks: true` into the shard frontmatter, which `enrich.ts` (`hasSkipWikilinks`) treats as "never link this note" — so shards were also permanently excluded from the background re-link pass.

## What

- `handleShardedAdd` now forwards the caller's `skipWikilinks` / `suggestOutgoingLinks` (defaulting to `false`, matching `handleAdd`).
- `ensureShardNote` no longer stamps `skipWikilinks: true` — shards auto-link on write and stay eligible for enrich.
- `flywheel_indexing: light` is unchanged: forward-link extraction still iterates shard events (`pipeline.ts`), only embeddings/feedback stay light.

## Compatibility note

flywheel-memory on `:3111` is multi-tenant. After this change, any caller using `shard` **without** an explicit `skipWikilinks: true` will start auto-linking shard content. That is the intended behavior here (mega-monkey passes `skipWikilinks:false` + `suggestOutgoingLinks:true`), but it is a global server behavior change.

## Test

New integration test in `mcp-write.test.ts`: a sharded add with `skipWikilinks:false` + `suggestOutgoingLinks:true` wraps a known entity (`[[Widget Engine]]`) in the shard and emits no `skipWikilinks: true` frontmatter. Full write suite: 23/23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)