### PR TITLE
feat(observer): emit "considered but discarded" near-miss candidates

### DIFF
--- a/packages/mcp-server/src/core/shared/observer.ts
+++ b/packages/mcp-server/src/core/shared/observer.ts
@@ -59,6 +59,13 @@ export interface Observation {
   duration_ms?: number;
   session_id?: string;
   results?: ScoredHit[];
+  /**
+   * "Considered but discarded" candidates: items the ranker scored just BELOW
+   * the returned cutoff (ranks limit+1..limit+K). Same ScoredHit shape as
+   * `results`. Lets the cockpit show pulled-vs-near-miss — the retrieval
+   * boundary — without changing what the LLM receives. Hybrid search only.
+   */
+  near_miss?: ScoredHit[];
 }
 
 const MAX_OBSERVED_HITS = 8;
@@ -72,6 +79,13 @@ const MAX_OBSERVED_BYTES = 8_000; // keep the side-channel POST well under the e
  * serialized and never reaches the MCP client.
  */
 export const observedHits = new WeakMap<object, ScoredHit[]>();
+
+/**
+ * Parallel bridge for the "considered but discarded" near-miss candidates
+ * (ranks just below the returned cutoff). Same identity-keyed WeakMap pattern
+ * as observedHits; read by the observer wrapper, never serialized to the client.
+ */
+export const observedNearMisses = new WeakMap<object, ScoredHit[]>();
 
 /**
  * Map ranked result rows → a capped, size-guarded ScoredHit[]. Returns undefined

--- a/packages/mcp-server/src/tool-registry.ts
+++ b/packages/mcp-server/src/tool-registry.ts
@@ -35,7 +35,7 @@ import {
   extractSearchMethod,
   getActivationSignals,
 } from './tool-registry/activation.js';
-import { emitObservation, summariseInput, summariseResult, observedHits } from './core/shared/observer.js';
+import { emitObservation, summariseInput, summariseResult, observedHits, observedNearMisses } from './core/shared/observer.js';
 import { shouldSuppressMemoryTool } from './tool-registry/clientSuppressions.js';
 import { runCrossVaultSearch } from './tool-registry/crossVault.js';
 import { shouldEnableTieredTool, getDirectCallPromotion } from './tool-registry/tiering.js';
@@ -408,6 +408,8 @@ export function applyToolGating(
               session_id: obsSession,
               // Scored hits a search-family handler stashed pre-strip (by result identity).
               results: success && result ? observedHits.get(result) : undefined,
+              // "Considered but discarded" candidates stashed alongside (same identity key).
+              near_miss: success && result ? observedNearMisses.get(result) : undefined,
             });
           }
         } catch {

--- a/packages/mcp-server/src/tools/read/query.ts
+++ b/packages/mcp-server/src/tools/read/query.ts
@@ -8,7 +8,11 @@ import type { VaultIndex, VaultNote } from '../../core/read/types.js';
 import { MAX_LIMIT } from '../../core/read/constants.js';
 import { requireIndex } from '../../core/read/indexGuard.js';
 import { serverLog } from '../../core/shared/serverLog.js';
-import { extractObservedHits, observedHits } from '../../core/shared/observer.js';
+import { extractObservedHits, observedHits, observedNearMisses } from '../../core/shared/observer.js';
+
+// How many below-cutoff candidates to surface as "considered but discarded".
+// The observer caps internally to MAX_OBSERVED_HITS (8) + a byte guard.
+const NEAR_MISS_K = 8;
 import {
   searchFTS5,
   buildFTS5Index,
@@ -721,6 +725,13 @@ export function registerQueryTools(
             // Capture scored hits in relevance order BEFORE the llm strip below
             // deletes rrf_score/_combined_score and re-orders for the sandwich.
             const observed = extractObservedHits(results, 'hybrid');
+            // "Considered but discarded" — the next slice of the ranked set, just
+            // below the returned cutoff. `filtered` is the full RRF-sorted list;
+            // these rows already carry rrf_score + in_* flags, so extract reads
+            // them directly. Observer-only; never enters `results` (the LLM payload).
+            const nearMiss = filtered.length > limit
+              ? extractObservedHits(filtered.slice(limit, limit + NEAR_MISS_K), 'hybrid-near-miss')
+              : undefined;
             if (consumer === 'llm') {
               applySandwichOrdering(results);
               await expandToSections(results, index, vaultPath, expandN);
@@ -737,6 +748,7 @@ export function registerQueryTools(
               ...(memoryResults.length > 0 ? { memories: memoryResults } : {}),
             }, null, 2) }] };
             if (observed) observedHits.set(out, observed);
+            if (nearMiss && nearMiss.length) observedNearMisses.set(out, nearMiss);
             return out;
           } catch (err) {
             // Semantic failed, fall back to FTS5 + entity only

--- a/packages/mcp-server/test/shared/observer.test.ts
+++ b/packages/mcp-server/test/shared/observer.test.ts
@@ -3,6 +3,7 @@ import {
   summariseInput,
   summariseResult,
   emitObservation,
+  extractObservedHits,
 } from '../../src/core/shared/observer.js';
 
 /** Build an MCP-style content array from one JSON-or-text block. */
@@ -161,5 +162,50 @@ describe('emitObservation', () => {
       throw new Error('boom');
     }) as any;
     expect(() => emitObservation({ tool: 'search' })).not.toThrow();
+  });
+
+  it('serializes near_miss candidates in the POST body', () => {
+    process.env.FLYWHEEL_OBSERVER_URL = 'http://localhost:3124/mcp-observed';
+    const spy = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = spy as any;
+    emitObservation({
+      tool: 'search',
+      results: [{ path: 'a.md', score: 0.9, method: 'hybrid' }],
+      near_miss: [{ path: 'b.md', score: 0.4, method: 'hybrid-near-miss' }],
+    });
+    const body = JSON.parse(spy.mock.calls[0][1].body);
+    expect(body.results).toHaveLength(1);
+    expect(body.near_miss).toHaveLength(1);
+    expect(body.near_miss[0].path).toBe('b.md');
+    expect(body.near_miss[0].method).toBe('hybrid-near-miss');
+  });
+});
+
+describe('extractObservedHits (shared by pulled results + near-miss)', () => {
+  afterEach(() => { delete process.env.FLYWHEEL_OBSERVER_URL; });
+
+  it('returns undefined when the observer is not configured', () => {
+    delete process.env.FLYWHEEL_OBSERVER_URL;
+    expect(extractObservedHits([{ path: 'a.md', rrf_score: 0.5 }], 'hybrid')).toBeUndefined();
+  });
+
+  it('maps ranked rows → ScoredHit with score + method + index flags', () => {
+    process.env.FLYWHEEL_OBSERVER_URL = 'http://localhost:3124/mcp-observed';
+    const hits = extractObservedHits(
+      [{ path: 'a.md', title: 'A', rrf_score: 0.5, in_fts5: true, in_semantic: true, backlink_count: 3 }],
+      'hybrid-near-miss',
+    );
+    expect(hits).toBeDefined();
+    expect(hits![0]).toMatchObject({
+      path: 'a.md', title: 'A', score: 0.5, method: 'hybrid-near-miss',
+      backlink_count: 3, in_fts5: true, in_semantic: true,
+    });
+  });
+
+  it('caps at 8 hits (so a near-miss slice can never bloat the POST)', () => {
+    process.env.FLYWHEEL_OBSERVER_URL = 'http://localhost:3124/mcp-observed';
+    const rows = Array.from({ length: 20 }, (_, i) => ({ path: `${i}.md`, rrf_score: 1 - i / 20 }));
+    const hits = extractObservedHits(rows, 'hybrid-near-miss');
+    expect(hits!.length).toBe(8);
   });
 });


### PR DESCRIPTION
Producer half of mega-monkey crank-EOL **PR 3a** (retrieval graph data). Builds on the Stage 1b observer side-channel.

## What
Hybrid search computes the full RRF-ranked candidate set, then discards everything below `filtered.slice(0, limit)`. This surfaces the next slice (ranks limit+1..limit+8) to the observer as `near_miss`, so the cockpit can render **pulled vs near-miss** — the retrieval boundary — which is the diagnostic the retrieval-graph overlay hangs on.

- `observer.ts`: `near_miss?: ScoredHit[]` on `Observation` + parallel `observedNearMisses` WeakMap (identity-keyed, mirrors `observedHits`).
- `query.ts` (hybrid branch): extract the below-cutoff slice via the existing `extractObservedHits` (those rows already carry `rrf_score` + `in_*`), stash by result identity. Guarded by `filtered.length > limit`.
- `tool-registry.ts`: include `near_miss` in the emit.

## Safety
Zero LLM-facing impact — `near_miss` rides ONLY in the side-channel, never in the tool's returned `results`. No-op when `FLYWHEEL_OBSERVER_URL` unset. Capped to 8 + byte-guarded (POST stays under the engine 16KB cap). Hybrid only.

## Tests
`observer.test.ts` +4: near_miss serialized in the POST body; `extractObservedHits` mapping + 8-cap (now shared by pulled + near-miss). tsc clean; observer suite 23/23.

Next: the engine persists + exposes `near_miss` (PR 3a consumer), then the cockpit overlay (PR 3b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)