### PR TITLE
fix(observer): coerce structure heading objects (no more "[object Object]")

### DIFF
--- a/packages/mcp-server/src/core/shared/observer.ts
+++ b/packages/mcp-server/src/core/shared/observer.ts
@@ -242,14 +242,23 @@ export function extractObservedDetails(
   try {
     switch (tool) {
       case 'read': {
-        // action=sections → array of {path, heading, level, line}
+        // action=sections → [{path, heading, ...}] (heading is a string);
+        // action=structure → [{heading: {text, level}, ...}] (heading is an
+        // OBJECT). Coerce both so we never stringify an object into
+        // "[object Object]".
         const sects = parsed.sections;
         if (Array.isArray(sects) && sects.length) {
-          return sects.slice(0, MAX_OBSERVED_DETAILS).map((s: any) => ({
-            path: String(s.path ?? '').slice(0, 200),
-            title: s.heading ? String(s.heading).slice(0, 200) : undefined,
-            score: null,
-          }));
+          return sects.slice(0, MAX_OBSERVED_DETAILS).map((s: any) => {
+            const h = s.heading;
+            const headingStr = typeof h === 'string'
+              ? h
+              : (h && typeof h === 'object' ? String(h.text ?? h.heading ?? h.title ?? '') : '');
+            return {
+              path: String(s.path ?? '').slice(0, 200),
+              title: headingStr ? headingStr.slice(0, 200) : undefined,
+              score: null,
+            };
+          });
         }
         // action=structure or action=read → single note metadata
         const p = parsed.path ?? parsed.note_path;

--- a/packages/mcp-server/test/shared/observer.test.ts
+++ b/packages/mcp-server/test/shared/observer.test.ts
@@ -4,6 +4,7 @@ import {
   summariseResult,
   emitObservation,
   extractObservedHits,
+  extractObservedDetails,
 } from '../../src/core/shared/observer.js';
 
 /** Build an MCP-style content array from one JSON-or-text block. */
@@ -207,5 +208,37 @@ describe('extractObservedHits (shared by pulled results + near-miss)', () => {
     const rows = Array.from({ length: 20 }, (_, i) => ({ path: `${i}.md`, rrf_score: 1 - i / 20 }));
     const hits = extractObservedHits(rows, 'hybrid-near-miss');
     expect(hits!.length).toBe(8);
+  });
+});
+
+describe('extractObservedDetails (non-search tools)', () => {
+  beforeEach(() => { process.env.FLYWHEEL_OBSERVER_URL = 'http://localhost:3124/mcp-observed'; });
+  afterEach(() => { delete process.env.FLYWHEEL_OBSERVER_URL; });
+
+  const text = (o: unknown) => [{ type: 'text', text: JSON.stringify(o) }];
+
+  it('read action=structure: heading OBJECTS become their .text, not "[object Object]"', () => {
+    // Regression: structure returns sections[].heading = { text, level }.
+    const hits = extractObservedDetails('read', text({
+      sections: [
+        { heading: { text: "Open", level: 3 } },
+        { heading: { text: "Emerging", level: 3 } },
+      ],
+    }));
+    expect(hits).toBeDefined();
+    expect(hits!.map((h) => h.title)).toEqual(["Open", "Emerging"]);
+    expect(hits!.every((h) => h.title !== "[object Object]")).toBe(true);
+  });
+
+  it('read action=sections: string headings + paths still work', () => {
+    const hits = extractObservedDetails('read', text({
+      sections: [{ path: "a.md", heading: "Background" }],
+    }));
+    expect(hits![0]).toMatchObject({ path: "a.md", title: "Background" });
+  });
+
+  it('no-ops when observer is unset', () => {
+    delete process.env.FLYWHEEL_OBSERVER_URL;
+    expect(extractObservedDetails('read', text({ sections: [{ heading: { text: "x" } }] }))).toBeUndefined();
   });
 });


### PR DESCRIPTION
`read action=structure` returns `sections[].heading` as an **object** `{text, level}` (vs a string for `action=sections`). `extractObservedDetails` stringified it → every structure detail row showed `[object Object]` with an empty path in the Retrieval panel.

Fix: coerce — string heading as-is, else `h.text ?? h.heading ?? h.title`. Tests +3; lint + observer suite (26) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)