### PR TITLE
feat(observer): tag observations with X-Flywheel-Caller for deterministic attribution

### DIFF
--- a/packages/mcp-server/src/caller-scope.ts
+++ b/packages/mcp-server/src/caller-scope.ts
@@ -1,0 +1,36 @@
+/**
+ * CallerScope — per-request caller attribution via AsyncLocalStorage.
+ *
+ * A consumer of the retrieval observer side-channel (the Mega Monkey engine)
+ * runs ONE shared flywheel-memory HTTP instance for many callers: the warm
+ * Claude of each chat scope, the conductor, ad-hoc sessions, roundtable seats.
+ * `session_id` is process-wide, so it cannot tell those callers apart.
+ *
+ * The caller tags its requests with an `X-Flywheel-Caller` header (e.g.
+ * `tg:12345` — the engine's conversation scope key). The HTTP transport binds
+ * that value to the current async context for the duration of the request, so
+ * the observer wrapper (deep inside the tool handler) can read it and stamp the
+ * observation with `caller_id`. The consumer then maps caller → its serial
+ * current turn deterministically — surviving concurrent callers.
+ *
+ * No-op outside an HTTP request (stdio is single-client; no header) — getter
+ * returns undefined and the observation simply carries no caller_id.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const callerAls = new AsyncLocalStorage<string>();
+
+/**
+ * Run `fn` within an async context tagged with `callerId`. When `callerId` is
+ * absent/empty the function runs unwrapped (no caller attribution).
+ */
+export function runWithCaller<T>(callerId: string | undefined, fn: () => T): T {
+  if (!callerId) return fn();
+  return callerAls.run(callerId, fn);
+}
+
+/** The current request's caller tag, or undefined when none is bound. */
+export function getCurrentCaller(): string | undefined {
+  return callerAls.getStore();
+}

--- a/packages/mcp-server/src/core/shared/observer.ts
+++ b/packages/mcp-server/src/core/shared/observer.ts
@@ -58,6 +58,14 @@ export interface Observation {
   is_error?: boolean;
   duration_ms?: number;
   session_id?: string;
+  /**
+   * Stable caller tag from the `X-Flywheel-Caller` request header (e.g. the
+   * consumer's conversation scope key `tg:12345`). Lets a consumer that runs
+   * one shared flywheel instance for many callers attribute each observation
+   * deterministically — `session_id` is process-wide and cannot. Absent on the
+   * stdio path / when no header was sent.
+   */
+  caller_id?: string;
   results?: ScoredHit[];
   /**
    * "Considered but discarded" candidates: items the ranker scored just BELOW

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -146,6 +146,7 @@ import {
   type VaultContext,
 } from './vault-registry.js';
 import { runInVaultScope, setFallbackScope, getActiveScopeOrNull, type VaultScope } from './vault-scope.js';
+import { runWithCaller } from './caller-scope.js';
 
 // Config (tool categories, presets, instructions)
 import {
@@ -921,12 +922,18 @@ async function main() {
       const acquireMs = performance.now() - t0;
 
       const httpTransport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      // Caller attribution: a consumer (the Mega Monkey engine) tags each
+      // request with its conversation scope so the observer side-channel can
+      // map observation → caller. Bound to the async context for the whole
+      // request via runWithCaller, read by the observer wrapper at emit time.
+      const callerHeader = req.headers['x-flywheel-caller'];
+      const callerId = Array.isArray(callerHeader) ? callerHeader[0] : callerHeader;
       let cleanExit = false;
       try {
         await httpServer.connect(httpTransport);
         const connectMs = performance.now() - t0;
         httpRequestCount++;
-        await httpTransport.handleRequest(req, res, req.body);
+        await runWithCaller(callerId, () => httpTransport.handleRequest(req, res, req.body));
         cleanExit = true;
         const totalMs = performance.now() - t0;
         if (totalMs > 25 || acquireMs > 5 || (connectMs - acquireMs) > 5) {

--- a/packages/mcp-server/src/tool-registry.ts
+++ b/packages/mcp-server/src/tool-registry.ts
@@ -30,6 +30,7 @@ import { getSessionId } from '@velvetmonkey/vault-core';
 import { ALL_CATEGORIES, TOOL_CATEGORY, type ToolCategory, type ToolTier, type ToolTierOverride } from './config.js';
 import { VaultRegistry, type VaultContext } from './vault-registry.js';
 import { runInVaultScope, getActiveScopeOrNull } from './vault-scope.js';
+import { getCurrentCaller } from './caller-scope.js';
 import {
   extractQueryContext,
   extractSearchMethod,
@@ -406,6 +407,10 @@ export function applyToolGating(
               is_error: !success,
               duration_ms: Date.now() - start,
               session_id: obsSession,
+              // Per-request caller tag (X-Flywheel-Caller). Read synchronously
+              // here, still inside the request's async context, so a consumer
+              // can map this observation to the originating caller's turn.
+              caller_id: getCurrentCaller(),
               // Scored hits a search-family handler stashed pre-strip (by result identity).
               // For non-search tools, fall through to detail extraction from result content.
               results: success && result


### PR DESCRIPTION
## Why

The retrieval observer side-channel sends `session_id`, but a single shared flywheel HTTP instance (`:3111`) serves **many** callers — the per-chat warm Claude, the conductor, ad-hoc sessions, roundtable seats — and `session_id` is **process-wide**. It cannot tell them apart, so a consumer (the Mega Monkey cockpit) can't reliably attribute an observation to the turn that caused it.

## What

A per-request **caller tag**:
- Callers send an `X-Flywheel-Caller` header (e.g. `tg:12345` — the consumer's conversation scope key).
- New `caller-scope.ts` (`callerAls` + `runWithCaller` + `getCurrentCaller`) — a sibling AsyncLocalStorage to the existing `vault-scope` ALS.
- The HTTP transport binds the header to the async context for the whole request (wraps `handleRequest`).
- The observer wrapper reads it at emit time and includes it as `caller_id` on the POST.

## Invariants preserved
- **No-op on stdio / when the header is absent** — `getCurrentCaller()` returns undefined, the observation simply carries no `caller_id`. Standalone behavior unchanged.
- Read happens synchronously inside the request's async context (the existing fire-and-forget `emitObservation` call), so the tag is always in scope.

Consumer side (maps `caller_id` → turn) ships in mega-monkey#(engine PR). Order-independent: if this lands first, the consumer ignores the new field until updated.

`npm run lint` (tsc --noEmit, all 3 workspaces): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)