### PR TITLE
fix(wikilinks): stop single-note churn auto-suppressing entities + durable unsuppress

### DIFF
--- a/packages/core/src/migrations.ts
+++ b/packages/core/src/migrations.ts
@@ -27,6 +27,7 @@ export const SALVAGE_TABLES = [
   'wikilink_applications',
   'suggestion_events',
   'wikilink_suppressions',
+  'wikilink_suppression_overrides',
   'note_links',
   'note_link_history',
   'memories',
@@ -541,6 +542,13 @@ export function initSchema(db: Database.Database): void {
       db.exec(`CREATE INDEX IF NOT EXISTS idx_memories_owner_scope ON memories(owner_scope)`);
 
       db.prepare('INSERT OR REPLACE INTO schema_version (version) VALUES (?)').run(42);
+    }
+
+    // v43: wikilink_suppression_overrides — durable manual-unsuppress overrides.
+    // The table is created by SCHEMA_SQL (CREATE TABLE IF NOT EXISTS) at the top
+    // of this run; nothing to ALTER. Gated on v40Applied like v41/v42.
+    if (currentVersion < 43 && v40Applied) {
+      db.prepare('INSERT OR REPLACE INTO schema_version (version) VALUES (?)').run(43);
     }
 
     // Only stamp SCHEMA_VERSION at the end if every migration ran. Dry-run

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -10,7 +10,7 @@
 // =============================================================================
 
 /** Current schema version - bump when schema changes */
-export const SCHEMA_VERSION = 42;
+export const SCHEMA_VERSION = 43;
 
 /** State database filename */
 export const STATE_DB_FILENAME = 'state.db';
@@ -170,6 +170,16 @@ CREATE TABLE IF NOT EXISTS wikilink_suppressions (
   entity TEXT PRIMARY KEY,
   false_positive_rate REAL NOT NULL,
   updated_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Manual unsuppress overrides (v43): an explicit user decision that
+-- auto-suppression must NOT undo. unsuppressEntity() records the entity here;
+-- updateSuppressionList / isSuppressed / getAllSuppressionPenalties skip
+-- overridden entities so a manual unsuppress survives every recompute.
+-- suppressEntity() clears the override (explicit re-suppress escape hatch).
+CREATE TABLE IF NOT EXISTS wikilink_suppression_overrides (
+  entity TEXT PRIMARY KEY COLLATE NOCASE,
+  created_at TEXT DEFAULT (datetime('now'))
 );
 
 -- Wikilink applications tracking (v5: implicit feedback, v38: source provenance)

--- a/packages/mcp-server/src/core/read/watch/pipeline.ts
+++ b/packages/mcp-server/src/core/read/watch/pipeline.ts
@@ -65,6 +65,7 @@ import {
   updateStoredNoteLinks,
   diffNoteLinks,
   recordFeedback,
+  recordImplicitRemoved,
   getStoredNoteTags,
   updateStoredNoteTags,
   isSuppressed,
@@ -1115,7 +1116,9 @@ export class PipelineRunner {
               (e.aliases ?? []).some((a: string) => a.toLowerCase() === target)
           );
           if (entity) {
-            recordFeedback(p.sd, entity.name, 'implicit:removed', diff.file, false);
+            // Cooldown-guarded (24h per entity+note) so single-note link churn
+            // doesn't cast repeated false-positive votes. Keeps confidence 1.0.
+            recordImplicitRemoved(p.sd, entity.name, diff.file, 1.0);
             feedbackResults.push({ entity: entity.name, file: diff.file });
           }
         }

--- a/packages/mcp-server/src/core/write/wikilinkFeedback.ts
+++ b/packages/mcp-server/src/core/write/wikilinkFeedback.ts
@@ -412,6 +412,8 @@ function getWeightedFolderStats(
  */
 export function updateSuppressionList(stateDb: StateDb, now?: Date): number {
   const weightedStats = getWeightedEntityStats(stateDb, now);
+  // Manually-unsuppressed entities are never re-suppressed by the recompute.
+  const overrides = getSuppressionOverrides(stateDb);
 
   let updated = 0;
 
@@ -435,6 +437,11 @@ export function updateSuppressionList(stateDb: StateDb, now?: Date): number {
     ).run(SUPPRESSION_TTL_DAYS);
 
     for (const stat of weightedStats) {
+      // Manual override wins: ensure no suppression row, never re-suppress.
+      if (overrides.has(stat.entity.toLowerCase())) {
+        remove.run(stat.entity);
+        continue;
+      }
       const effectiveAlpha = getEffectiveAlpha(stat.entity);
       const posteriorMean = computePosteriorMean(stat.weightedCorrect, stat.weightedFp, effectiveAlpha);
       const totalObs = effectiveAlpha + stat.weightedCorrect + PRIOR_BETA + stat.weightedFp;
@@ -464,11 +471,19 @@ export function updateSuppressionList(stateDb: StateDb, now?: Date): number {
  * Used for explicit negative feedback where user says "this is wrong."
  */
 export function suppressEntity(stateDb: StateDb, entity: string): void {
-  stateDb.db.prepare(`
-    INSERT INTO wikilink_suppressions (entity, false_positive_rate, updated_at)
-    VALUES (?, 1.0, datetime('now'))
-    ON CONFLICT(entity) DO UPDATE SET false_positive_rate = 1.0, updated_at = datetime('now')
-  `).run(entity);
+  // Explicit suppress clears any manual override (the user is deliberately
+  // putting the entity back under auto-suppression control) and force-suppresses.
+  const txn = stateDb.db.transaction(() => {
+    stateDb.db.prepare(
+      'DELETE FROM wikilink_suppression_overrides WHERE entity = ? COLLATE NOCASE'
+    ).run(entity);
+    stateDb.db.prepare(`
+      INSERT INTO wikilink_suppressions (entity, false_positive_rate, updated_at)
+      VALUES (?, 1.0, datetime('now'))
+      ON CONFLICT(entity) DO UPDATE SET false_positive_rate = 1.0, updated_at = datetime('now')
+    `).run(entity);
+  });
+  txn();
 }
 
 /**
@@ -476,10 +491,34 @@ export function suppressEntity(stateDb: StateDb, entity: string): void {
  * Returns true if the entity was actually suppressed (and is now removed).
  */
 export function unsuppressEntity(stateDb: StateDb, entity: string): boolean {
-  const result = stateDb.db.prepare(
-    'DELETE FROM wikilink_suppressions WHERE entity = ? COLLATE NOCASE'
-  ).run(entity);
-  return result.changes > 0;
+  // One transaction: clear the suppression row AND record a durable manual
+  // override. The override is what makes the unsuppress STICK — without it the
+  // next updateSuppressionList() recompute re-derives suppression from the
+  // unchanged feedback history. Honored in updateSuppressionList / isSuppressed
+  // / getAllSuppressionPenalties so the entity is never auto-suppressed again
+  // until an explicit re-suppress (which clears the override).
+  const txn = stateDb.db.transaction(() => {
+    const result = stateDb.db.prepare(
+      'DELETE FROM wikilink_suppressions WHERE entity = ? COLLATE NOCASE'
+    ).run(entity);
+    stateDb.db.prepare(
+      'INSERT OR IGNORE INTO wikilink_suppression_overrides (entity) VALUES (?)'
+    ).run(entity);
+    return result.changes > 0;
+  });
+  return txn();
+}
+
+/**
+ * Entities the user manually unsuppressed — a durable override that
+ * auto-suppression must not undo. Lowercased for case-insensitive checks
+ * (mirrors the suppressedSet pattern in entity.ts).
+ */
+export function getSuppressionOverrides(stateDb: StateDb): Set<string> {
+  const rows = stateDb.db.prepare(
+    'SELECT entity FROM wikilink_suppression_overrides'
+  ).all() as Array<{ entity: string }>;
+  return new Set(rows.map(r => r.entity.toLowerCase()));
 }
 
 /**
@@ -488,6 +527,13 @@ export function unsuppressEntity(stateDb: StateDb, entity: string): boolean {
  * @param now - Optional reference date for testability (decay computation)
  */
 export function isSuppressed(stateDb: StateDb, entity: string, folder?: string, now?: Date): boolean {
+  // Manual override always wins — never report a user-unsuppressed entity as
+  // suppressed (covers the folder-posterior path below too).
+  const overridden = stateDb.db.prepare(
+    'SELECT 1 FROM wikilink_suppression_overrides WHERE entity = ? COLLATE NOCASE'
+  ).get(entity);
+  if (overridden) return false;
+
   // Global suppression check first (with TTL)
   const row = stateDb.db.prepare(
     `SELECT entity, updated_at FROM wikilink_suppressions
@@ -699,8 +745,12 @@ export function getAllFeedbackBoosts(stateDb: StateDb, folder?: string, now?: Da
 export function getAllSuppressionPenalties(stateDb: StateDb, now?: Date): Map<string, number> {
   const penalties = new Map<string, number>();
   const weightedStats = getWeightedEntityStats(stateDb, now);
+  // Manually-unsuppressed entities get NO soft/hard penalty — else suggestion
+  // ranking would still demote them while the cockpit badge says unsuppressed.
+  const overrides = getSuppressionOverrides(stateDb);
 
   for (const stat of weightedStats) {
+    if (overrides.has(stat.entity.toLowerCase())) continue;
     const effectiveAlpha = getEffectiveAlpha(stat.entity);
     const posteriorMean = computePosteriorMean(stat.weightedCorrect, stat.weightedFp, effectiveAlpha);
     const totalObs = effectiveAlpha + stat.weightedCorrect + PRIOR_BETA + stat.weightedFp;
@@ -727,6 +777,7 @@ export function getAllSuppressionPenalties(stateDb: StateDb, now?: Date): Map<st
   ).all(SUPPRESSION_TTL_DAYS) as Array<{ entity: string; updated_at: string }>;
 
   for (const row of rows) {
+    if (overrides.has(row.entity.toLowerCase())) continue;
     if (!penalties.has(row.entity)) {
       penalties.set(row.entity, MAX_SUPPRESSION_PENALTY);
     }
@@ -953,6 +1004,43 @@ export function updateStoredNoteTags(
   tx();
 }
 
+/** 24h per-(entity,note) cooldown for implicit:removed — symmetric with the
+ *  implicit:survived cooldown in processImplicitFeedback. */
+const IMPLICIT_REMOVED_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Record `implicit:removed` feedback with a 24h per-(entity,note) cooldown.
+ *
+ * Both implicit-removal writers (this module's processImplicitFeedback and the
+ * watcher diff path in core/read/watch/pipeline.ts) route through here. Without
+ * the cooldown, a single note's add→remove→re-add link churn casts dozens of
+ * negative votes for the same (entity,note) — e.g. 74 rows for one note in one
+ * day — which wrongly tips legitimate entities below the suppression threshold.
+ * Mirrors the positive-side survival cooldown. Caller supplies `confidence`
+ * (each writer keeps its own model). Returns true if a row was recorded.
+ */
+export function recordImplicitRemoved(
+  stateDb: StateDb,
+  entity: string,
+  notePath: string,
+  confidence: number,
+  matchedTerm?: string,
+): boolean {
+  const last = stateDb.db.prepare(
+    `SELECT MAX(created_at) as last FROM wikilink_feedback
+     WHERE entity = ? COLLATE NOCASE AND context = 'implicit:removed' AND note_path = ?`
+  ).get(entity, notePath) as { last: string | null } | undefined;
+  if (last?.last) {
+    // SQLite datetime is 'YYYY-MM-DD HH:MM:SS' (UTC) — normalize for JS parsing.
+    const normalized = last.last.includes('T') ? last.last : last.last.replace(' ', 'T') + 'Z';
+    if (Date.now() - new Date(normalized).getTime() < IMPLICIT_REMOVED_COOLDOWN_MS) {
+      return false;
+    }
+  }
+  recordFeedback(stateDb, entity, 'implicit:removed', notePath, false, confidence, matchedTerm);
+  return true;
+}
+
 /**
  * Detect removed auto-applied wikilinks and record implicit negative feedback
  *
@@ -981,7 +1069,8 @@ export function processImplicitFeedback(
     for (const { entity, applied_at, matched_term } of trackedWithTime) {
       if (!currentLinks.has(entity.toLowerCase())) {
         const confidence = computeImplicitRemovalConfidence(applied_at);
-        recordFeedback(stateDb, entity, 'implicit:removed', notePath, false, confidence, matched_term ?? undefined);
+        // Cooldown-guarded — collapses same-(entity,note) churn to one vote/24h.
+        recordImplicitRemoved(stateDb, entity, notePath, confidence, matched_term ?? undefined);
         markRemoved.run(entity, notePath);
         removed.push(entity);
       }

--- a/packages/mcp-server/test/write/core/suppression-override.test.ts
+++ b/packages/mcp-server/test/write/core/suppression-override.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Suppression: implicit:removed cooldown + durable manual-unsuppress override.
+ *
+ * Regression coverage for two bugs:
+ *  1. Single-note link churn cast dozens of implicit:removed votes (no cooldown
+ *     on the negative side, unlike implicit:survived), wrongly auto-suppressing
+ *     legitimate entities (e.g. "puff": 74 removals from ONE note in one day).
+ *  2. Manual unsuppress was a bare DELETE — the next updateSuppressionList()
+ *     recompute re-suppressed from unchanged feedback. Now a durable override
+ *     is recorded and honored everywhere suppression is decided.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { openStateDb, deleteStateDb, type StateDb } from '@velvetmonkey/vault-core';
+import {
+  recordFeedback,
+  recordImplicitRemoved,
+  trackWikilinkApplications,
+  processImplicitFeedback,
+  updateSuppressionList,
+  isSuppressed,
+  suppressEntity,
+  unsuppressEntity,
+  getAllSuppressionPenalties,
+  getSuppressionOverrides,
+} from '../../../src/core/write/wikilinkFeedback.js';
+
+function removedCount(stateDb: StateDb, entity: string, notePath?: string): number {
+  const sql = notePath
+    ? `SELECT COUNT(*) n FROM wikilink_feedback WHERE entity = ? COLLATE NOCASE AND context = 'implicit:removed' AND note_path = ?`
+    : `SELECT COUNT(*) n FROM wikilink_feedback WHERE entity = ? COLLATE NOCASE AND context = 'implicit:removed'`;
+  const args = notePath ? [entity, notePath] : [entity];
+  return (stateDb.db.prepare(sql).get(...args) as { n: number }).n;
+}
+
+describe('wikilink suppression: cooldown + durable override', () => {
+  let tempDir: string;
+  let stateDb: StateDb;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'supp-test-'));
+    stateDb = openStateDb(tempDir);
+  });
+
+  afterEach(async () => {
+    try { stateDb.db.close(); } catch { /* ignore */ }
+    try { deleteStateDb(tempDir); } catch { /* ignore */ }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('Fix 1 — implicit:removed cooldown', () => {
+    it('recordImplicitRemoved collapses same-(entity,note) repeats to one per 24h', () => {
+      const note = 'daily-notes/2026-05-08.md';
+      const first = recordImplicitRemoved(stateDb, 'puff', note, 1.0);
+      const second = recordImplicitRemoved(stateDb, 'puff', note, 1.0);
+      const third = recordImplicitRemoved(stateDb, 'PUFF', note, 0.8); // case-insensitive
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+      expect(third).toBe(false);
+      expect(removedCount(stateDb, 'puff', note)).toBe(1);
+    });
+
+    it('distinct notes are NOT collapsed (each genuine removal counts)', () => {
+      expect(recordImplicitRemoved(stateDb, 'puff', 'a.md', 1.0)).toBe(true);
+      expect(recordImplicitRemoved(stateDb, 'puff', 'b.md', 1.0)).toBe(true);
+      expect(removedCount(stateDb, 'puff')).toBe(2);
+    });
+
+    it('processImplicitFeedback add→remove→re-add churn yields ONE removed row', () => {
+      const note = 'daily-notes/churn.md';
+      for (let i = 0; i < 5; i++) {
+        trackWikilinkApplications(stateDb, note, ['puff']);
+        processImplicitFeedback(stateDb, note, 'content with no links at all');
+      }
+      expect(removedCount(stateDb, 'puff', note)).toBe(1);
+    });
+  });
+
+  describe('Fix 2 — durable manual-unsuppress override', () => {
+    // Seed enough false-positive feedback (distinct notes, bypassing the
+    // cooldown) to push the entity below the suppression posterior threshold.
+    function seedSuppressible(entity: string): void {
+      for (let i = 0; i < 20; i++) {
+        recordFeedback(stateDb, entity, 'implicit:removed', `note-${i}.md`, false, 1.0);
+      }
+    }
+
+    it('unsuppress sticks across updateSuppressionList recomputes', () => {
+      seedSuppressible('puff');
+      updateSuppressionList(stateDb);
+      expect(isSuppressed(stateDb, 'puff')).toBe(true);
+
+      const wasSuppressed = unsuppressEntity(stateDb, 'puff');
+      expect(wasSuppressed).toBe(true);
+      expect(getSuppressionOverrides(stateDb).has('puff')).toBe(true);
+      expect(isSuppressed(stateDb, 'puff')).toBe(false);
+
+      // The recompute must NOT re-suppress (the override wins).
+      updateSuppressionList(stateDb);
+      expect(isSuppressed(stateDb, 'puff')).toBe(false);
+
+      // And suggestion ranking must not demote it either.
+      expect(getAllSuppressionPenalties(stateDb).has('puff')).toBe(false);
+    });
+
+    it('explicit suppressEntity clears the override (re-suppressible)', () => {
+      seedSuppressible('puff');
+      unsuppressEntity(stateDb, 'puff');
+      expect(isSuppressed(stateDb, 'puff')).toBe(false);
+
+      suppressEntity(stateDb, 'puff');
+      expect(getSuppressionOverrides(stateDb).has('puff')).toBe(false);
+      expect(isSuppressed(stateDb, 'puff')).toBe(true);
+    });
+
+    it('override is case-insensitive', () => {
+      seedSuppressible('Puff');
+      updateSuppressionList(stateDb);
+      unsuppressEntity(stateDb, 'puff'); // different case than seeded
+      expect(isSuppressed(stateDb, 'Puff')).toBe(false);
+      updateSuppressionList(stateDb);
+      expect(isSuppressed(stateDb, 'PUFF')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Problem
Entities like **puff** show suppressed in the cockpit, and manual unsuppress only lasts a while. Diagnosed against the live state DB:
- puff: **140 `implicit:removed` vs 102 positive** → posterior ~0.36 < 0.45 → suppressed. **All 140 are implicit (zero explicit rejections); 74 came from re-scanning ONE note on ONE day** (`daily-notes/2026-05-08.md`) — the linker's add→remove→re-add churn.
- **Root bug:** `implicit:survived` has a 24h per-(entity,note) cooldown; `implicit:removed` had **none** → one note's churn casts dozens of negative votes.
- **Unsuppress didn't stick:** `unsuppressEntity` was a bare DELETE; the next `updateSuppressionList` recompute re-suppressed from unchanged history.

## Fix 1 — cooldown on `implicit:removed` (both writers)
New `recordImplicitRemoved()` with a 24h per-(entity,note) cooldown (symmetric with the survived side). Routes **both** writers through it — `processImplicitFeedback` and the watcher diff path (`pipeline.ts`) — each keeping its own confidence. Same-note repeats collapse to one vote/24h; distinct notes still count.

## Fix 2 — durable manual-unsuppress override
- New `wikilink_suppression_overrides` table (`SCHEMA_VERSION` 42→43, v43 migration gated on `v40Applied`, added to `SALVAGE_TABLES`).
- `unsuppressEntity` records the override (txn); `suppressEntity` clears it (txn) — explicit re-suppress escape hatch.
- Honored in **`updateSuppressionList`** (skip + clear), **`isSuppressed`** (return false, incl. folder path), **`getAllSuppressionPenalties`** (no demotion) — ranking and badge agree.

Roundtabled (Codex + Gemini); all must-fixes folded in.

## Tests
`suppression-override.test.ts` — cooldown (both paths incl. processImplicitFeedback churn) + override persistence through recompute / `isSuppressed` / penalties + re-suppress + case-insensitive. **6/6 pass; full suite 3380 pass** (8 failures are pre-existing flaky `traces/no-refresh` tests — pass in isolation, fail only under full-suite concurrent load).

## Deploy notes (operator)
- Rebuild **vault-core first** then mcp-server, and restart the flywheel MCP (`:3111`). The schema migrates to v43 on open.
- ⚠️ A **stale `packages/mcp-server/node_modules/@velvetmonkey/vault-core` copy** (real dir, not the workspace symlink) was shadowing `packages/core` and must be removed/refreshed or the new schema won't load at runtime. I removed it locally; ensure the deploy build resolves vault-core to the workspace package.
- No mega-monkey change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)