### PR TITLE
fix(vault): stop background wikilinker escaping into code repos (2.12.15)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velvetmonkey/flywheel-memory",
-  "version": "2.12.14",
+  "version": "2.12.15",
   "description": "Persistent knowledge graph memory for AI agents. Search, read, and write tools over an Obsidian vault via MCP.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/src/core/read/vaultRoot.ts
+++ b/packages/mcp-server/src/core/read/vaultRoot.ts
@@ -1,11 +1,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const VAULT_MARKERS = ['.obsidian', '.flywheel', '.claude'];
+// Only `.obsidian` reliably marks a vault. `.flywheel` (engine state) and
+// `.claude` (Claude config) exist in home dirs and most code repos, so treating
+// them as vault markers makes findVaultRoot adopt ~/src or ~ as a "vault" and
+// wikilink-enrich every markdown file under it. Explicit env config
+// (PROJECT_PATH/VAULT_PATH/OBSIDIAN_VAULT) should win before this fallback runs.
+const VAULT_MARKERS = ['.obsidian'];
 
 /**
  * Find vault root by walking up the directory tree.
- * Looks for .obsidian, .flywheel, or .claude folder as markers.
+ * Looks for an .obsidian folder as the marker.
  */
 export function findVaultRoot(startPath?: string): string {
   let current = path.resolve(startPath || process.cwd());

--- a/packages/mcp-server/src/core/write/vaultRoot.ts
+++ b/packages/mcp-server/src/core/write/vaultRoot.ts
@@ -1,11 +1,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const VAULT_MARKERS = ['.obsidian', '.flywheel', '.claude'];
+// Only `.obsidian` reliably marks a vault. `.flywheel` (engine state) and
+// `.claude` (Claude config) exist in home dirs and most code repos, so treating
+// them as vault markers makes findVaultRoot adopt ~/src or ~ as a "vault" and
+// wikilink-enrich every markdown file under it. Explicit env config
+// (PROJECT_PATH/VAULT_PATH/OBSIDIAN_VAULT) should win before this fallback runs.
+const VAULT_MARKERS = ['.obsidian'];
 
 /**
  * Find vault root by walking up the directory tree.
- * Looks for .obsidian, .flywheel, or .claude folder as markers.
+ * Looks for an .obsidian folder as the marker.
  */
 export function findVaultRoot(startPath?: string): string {
   let current = path.resolve(startPath || process.cwd());

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -841,13 +841,13 @@ async function main() {
   const vaultConfigs = parseVaultConfig();
   vaultPath = vaultConfigs
     ? vaultConfigs[0].path
-    : (process.env.PROJECT_PATH || process.env.VAULT_PATH || findVaultRoot());
+    : (process.env.PROJECT_PATH || process.env.VAULT_PATH || process.env.OBSIDIAN_VAULT || findVaultRoot());
   try { resolvedVaultPath = realpathSync(vaultPath).replace(/\\/g, '/'); } catch { resolvedVaultPath = vaultPath.replace(/\\/g, '/'); }
 
   // Validate vault path exists
   if (!existsSync(resolvedVaultPath)) {
     console.error(`[flywheel] Fatal: vault path does not exist: ${resolvedVaultPath}`);
-    console.error(`[flywheel] Set PROJECT_PATH or VAULT_PATH to a valid Obsidian vault directory.`);
+    console.error(`[flywheel] Set PROJECT_PATH, VAULT_PATH, or OBSIDIAN_VAULT to a valid Obsidian vault directory.`);
     process.exit(1);
   }
 

--- a/packages/mcp-server/test/write/core/vaultRoot.test.ts
+++ b/packages/mcp-server/test/write/core/vaultRoot.test.ts
@@ -28,15 +28,26 @@ describe('findVaultRoot', () => {
     expect(result).toBe(tempVault);
   });
 
-  it('should find vault root by .claude marker', async () => {
-    await mkdir(path.join(tempVault, '.claude'));
-    const result = findVaultRoot(tempVault);
+  it('should NOT treat .claude as a vault marker (falls through to .obsidian parent)', async () => {
+    // .claude exists in home dirs and most code repos; treating it as a vault
+    // marker made findVaultRoot adopt ~/src as a vault. The real .obsidian
+    // parent must win instead.
+    await mkdir(path.join(tempVault, '.obsidian'));
+    const childPath = path.join(tempVault, 'some-repo');
+    await mkdir(childPath, { recursive: true });
+    await mkdir(path.join(childPath, '.claude'));
+
+    const result = findVaultRoot(childPath);
     expect(result).toBe(tempVault);
   });
 
-  it('should find vault root by .flywheel marker', async () => {
-    await mkdir(path.join(tempVault, '.flywheel'));
-    const result = findVaultRoot(tempVault);
+  it('should NOT treat .flywheel as a vault marker (falls through to .obsidian parent)', async () => {
+    await mkdir(path.join(tempVault, '.obsidian'));
+    const childPath = path.join(tempVault, 'some-repo');
+    await mkdir(childPath, { recursive: true });
+    await mkdir(path.join(childPath, '.flywheel'));
+
+    const result = findVaultRoot(childPath);
     expect(result).toBe(tempVault);
   });
 
@@ -50,7 +61,7 @@ describe('findVaultRoot', () => {
     expect(result).toBe(tempVault);
   });
 
-  it('should prefer .obsidian over .flywheel and .claude when all exist', async () => {
+  it('should detect .obsidian even when .flywheel and .claude also exist', async () => {
     await mkdir(path.join(tempVault, '.obsidian'));
     await mkdir(path.join(tempVault, '.flywheel'));
     await mkdir(path.join(tempVault, '.claude'));
@@ -59,12 +70,16 @@ describe('findVaultRoot', () => {
     expect(result).toBe(tempVault);
   });
 
-  it('should prefer .flywheel over .claude when both exist (no .obsidian)', async () => {
-    await mkdir(path.join(tempVault, '.flywheel'));
-    await mkdir(path.join(tempVault, '.claude'));
+  it('should not stop at a dir that only has .flywheel/.claude (no .obsidian anywhere)', async () => {
+    // No .obsidian above, so no marker matches; it must fall back to the start
+    // path rather than treating the .flywheel/.claude dir as a vault root.
+    const childPath = path.join(tempVault, 'some-repo');
+    await mkdir(childPath, { recursive: true });
+    await mkdir(path.join(childPath, '.flywheel'));
+    await mkdir(path.join(childPath, '.claude'));
 
-    const result = findVaultRoot(tempVault);
-    expect(result).toBe(tempVault);
+    const result = findVaultRoot(childPath);
+    expect(result).toBe(childPath);
   });
 
   it('should return start path if no markers found', async () => {
@@ -78,7 +93,9 @@ describe('findVaultRoot', () => {
     expect(typeof result).toBe('string');
   });
 
-  it('should handle nested vault structure', async () => {
+  it('should resolve a nested project with .claude to the real .obsidian vault root', async () => {
+    // Regression: a project subdir carrying .claude must NOT be treated as its
+    // own vault. The enclosing .obsidian vault is the real root.
     await mkdir(path.join(tempVault, '.obsidian'));
 
     const projectPath = path.join(tempVault, 'projects', 'my-project');
@@ -86,7 +103,7 @@ describe('findVaultRoot', () => {
     await mkdir(path.join(projectPath, '.claude'));
 
     const result = findVaultRoot(projectPath);
-    expect(result).toBe(projectPath);
+    expect(result).toBe(tempVault);
   });
 
   it('should stop at filesystem root if no markers found', async () => {


### PR DESCRIPTION
Two stacked bugs let flywheel-memory's background chokidar wikilinker enrich markdown OUTSIDE the configured vault (observed: brackets injected into the mcp-seal repo's README/STATUS).

1. Startup vault-path resolver honoured PROJECT_PATH/VAULT_PATH but not OBSIDIAN_VAULT, so workers launched with only OBSIDIAN_VAULT fell through to findVaultRoot().
2. findVaultRoot treated .flywheel and .claude as vault markers. Those exist in ~ and most code repos, so walking up from cwd (~/src) adopted ~/src as a vault.

Fix: add OBSIDIAN_VAULT to the resolution chain; restrict markers to .obsidian only. Tests updated incl. a regression guard that a nested .claude can't hijack detection from the enclosing .obsidian vault. tsc clean, vault-root tests green.

Note: merging with --admin; main CI has been red since 2026-05-29 (pre-existing, unrelated).