### PR TITLE
feat(memory): unsupersede action (thread-identity slice 4 prereq)

### DIFF
--- a/packages/mcp-server/src/core/write/memory.ts
+++ b/packages/mcp-server/src/core/write/memory.ts
@@ -66,6 +66,22 @@ export interface SupersedeMemoryResult {
   already_superseded: number;
 }
 
+export interface UnsupersedeMemoryOptions {
+  /** Reverse the thread-resolution tombstone on every row carrying this id. */
+  thread_id: string;
+  agent_id?: string;
+}
+
+export interface UnsupersedeMemoryResult {
+  restored: Array<{ id: number; key: string; owner_scope: string }>;
+  /**
+   * Rows matched on the thread but left untouched: either already live
+   * (superseded_by IS NULL) or superseded by a *successor* (replaced, not
+   * thread-tombstoned). The undo only reverses self-tombstones.
+   */
+  skipped: number;
+}
+
 export interface SearchMemoryOptions {
   query: string;
   type?: MemoryType;
@@ -520,6 +536,72 @@ export function supersedeMemories(
   return {
     superseded: current.map((m) => ({ id: m.id, key: m.key, owner_scope: m.owner_scope })),
     already_superseded: alreadySuperseded,
+  };
+}
+
+/**
+ * Unsupersede memories — the undo consumer for a reversed thread resolution
+ * (thread-identity slice 4).
+ *
+ * Reverses supersedeMemories for one thread: clears superseded_by +
+ * supersede_reason so the facts reappear in get/search/list/brief, and
+ * restores the graph edges that supersede removed.
+ *
+ * Only SELF-TOMBSTONED rows are reversible — those with `superseded_by = id`,
+ * the exact marker supersede writes. A row superseded by a *successor*
+ * (`superseded_by != id`) was replaced by a newer fact, not tombstoned by a
+ * thread resolution; reviving it would resurrect a stale value, so it is left
+ * untouched and counted in `skipped`. Already-live rows skip the same way.
+ *
+ * Idempotent: the SQL guard `superseded_by = id` means a second call (or a
+ * call on rows already cleared) is a no-op.
+ */
+export function unsupersedeMemories(
+  stateDb: StateDb,
+  options: UnsupersedeMemoryOptions,
+): UnsupersedeMemoryResult {
+  const { thread_id, agent_id } = options;
+
+  if (!thread_id) {
+    throw new Error('unsupersede requires thread_id');
+  }
+
+  const conditions: string[] = ['thread_id = ?'];
+  const params: unknown[] = [thread_id];
+  // Same visibility scope as supersede: a caller may only reverse facts it can
+  // see — global rows plus its own agent scope.
+  applyVisibilityFilter(conditions, params, agent_id);
+
+  const matched = stateDb.db.prepare(
+    `SELECT id, key, owner_scope, visibility, entities_json, superseded_by FROM memories WHERE ${conditions.join(' AND ')}`
+  ).all(...params) as Array<Pick<Memory, 'id' | 'key' | 'owner_scope' | 'visibility' | 'entities_json' | 'superseded_by'>>;
+
+  const reversible = matched.filter((m) => m.superseded_by !== null && m.superseded_by === m.id);
+  const skipped = matched.length - reversible.length;
+
+  const now = Date.now();
+  const clear = stateDb.db.prepare(
+    'UPDATE memories SET superseded_by = NULL, supersede_reason = NULL, updated_at = ? WHERE id = ? AND superseded_by = id'
+  );
+
+  for (const m of reversible) {
+    clear.run(now, m.id);
+    // Restore graph edges removed at supersede time, from the stored entity
+    // list (mirrors storeMemory's shared/global rule — private/agent rows never
+    // entered the shared graph).
+    if (m.visibility === 'shared' && m.owner_scope === GLOBAL_OWNER_SCOPE && m.entities_json) {
+      try {
+        const entities = JSON.parse(m.entities_json) as string[];
+        if (Array.isArray(entities) && entities.length > 0) {
+          updateGraphSignals(stateDb, m.key, entities);
+        }
+      } catch { /* malformed entities_json — skip graph restore, fact is still revived */ }
+    }
+  }
+
+  return {
+    restored: reversible.map((m) => ({ id: m.id, key: m.key, owner_scope: m.owner_scope })),
+    skipped,
   };
 }
 

--- a/packages/mcp-server/src/tools/write/memory.ts
+++ b/packages/mcp-server/src/tools/write/memory.ts
@@ -13,6 +13,7 @@ import {
   listMemories,
   forgetMemory,
   supersedeMemories,
+  unsupersedeMemories,
   storeSessionSummary,
 } from '../../core/write/memory.js';
 import { runBrief } from '../read/brief.js';
@@ -28,9 +29,9 @@ export function registerMemoryTools(
     'memory',
     'Entity-linked vault facts and session summaries. action: store — save a fact (auto-links entities). get — by key. search — FTS5. list — browse. forget — delete. supersede — idempotent tombstone by thread_id or key (kept for audit). summarize_session. Returns stored content. Does not operate on vault note bodies. e.g. { action:"store", key:"sarah.pref" }',
     {
-      action: z.enum(['store', 'get', 'search', 'list', 'forget', 'supersede', 'summarize_session', 'brief']).describe('Operation to perform'),
+      action: z.enum(['store', 'get', 'search', 'list', 'forget', 'supersede', 'unsupersede', 'summarize_session', 'brief']).describe('Operation to perform'),
       key: z.string().optional().describe('[store|get|forget|supersede] Memory key (e.g., "user.pref.theme", "project.x.deadline")'),
-      thread_id: z.string().optional().describe('[store|supersede] Thread correlation id (short GUID minted by the engine threads registry). store: stamps the fact. supersede: tombstones every current fact carrying the id.'),
+      thread_id: z.string().optional().describe('[store|supersede|unsupersede] Thread correlation id (short GUID minted by the engine threads registry). store: stamps the fact. supersede: tombstones every current fact carrying the id. unsupersede: reverses a thread-resolution tombstone (self-tombstoned rows only).'),
       reason: z.string().optional().describe('[supersede] Audit reason recorded on each superseded row (e.g. "thread-resolved: shipped in PR #12")'),
       value: z.string().optional().describe('[store] The fact/preference/observation to store (up to 2000 chars)'),
       type: z.enum(['fact', 'preference', 'observation', 'summary']).optional().describe('[store|search] Memory type'),
@@ -249,6 +250,29 @@ export function registerMemoryTools(
                 superseded_count: result.superseded.length,
                 superseded: result.superseded,
                 already_superseded: result.already_superseded,
+              }, null, 2),
+            }],
+          };
+        }
+
+        case 'unsupersede': {
+          if (!args.thread_id) {
+            return {
+              content: [{ type: 'text' as const, text: JSON.stringify({ error: 'unsupersede requires thread_id' }) }],
+              isError: true,
+            };
+          }
+          const result = unsupersedeMemories(stateDb, {
+            thread_id: args.thread_id,
+            agent_id: agentId,
+          });
+          return {
+            content: [{
+              type: 'text' as const,
+              text: JSON.stringify({
+                restored_count: result.restored.length,
+                restored: result.restored,
+                skipped: result.skipped,
               }, null, 2),
             }],
           };

--- a/packages/mcp-server/test/write/core/memoryUnsupersede.test.ts
+++ b/packages/mcp-server/test/write/core/memoryUnsupersede.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for thread-identity slice 4: unsupersedeMemories — the undo consumer
+ * for a reversed thread resolution.
+ *
+ * Contract: unsupersede reverses supersedeMemories for one thread, but ONLY
+ * for self-tombstoned rows (superseded_by = id). Rows replaced by a successor
+ * stay closed. Idempotent. Graph edges restored for shared/global rows.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createTempVault,
+  cleanupTempVault,
+  openStateDb,
+  deleteStateDb,
+  type StateDb,
+} from '../../helpers/testUtils.js';
+import {
+  storeMemory,
+  getMemory,
+  searchMemories,
+  listMemories,
+  supersedeMemories,
+  unsupersedeMemories,
+  type Memory,
+} from '../../../src/core/write/memory.js';
+
+describe('unsupersedeMemories (thread-resolution undo)', () => {
+  let tempVault: string;
+  let stateDb: StateDb;
+
+  beforeEach(async () => {
+    tempVault = await createTempVault();
+    stateDb = openStateDb(tempVault);
+  });
+
+  afterEach(async () => {
+    stateDb.db.close();
+    deleteStateDb(tempVault);
+    await cleanupTempVault(tempVault);
+  });
+
+  function rawRow(key: string): Memory | undefined {
+    return stateDb.db.prepare('SELECT * FROM memories WHERE key = ?').get(key) as Memory | undefined;
+  }
+
+  it('round-trip: supersede then unsupersede restores all current facts on the thread', () => {
+    storeMemory(stateDb, { key: 'fact.a', value: 'alpha fact', type: 'fact', thread_id: 'thr-abc123' });
+    storeMemory(stateDb, { key: 'fact.b', value: 'beta fact', type: 'fact', thread_id: 'thr-abc123' });
+    storeMemory(stateDb, { key: 'fact.c', value: 'gamma fact', type: 'fact', thread_id: 'thr-other' });
+
+    supersedeMemories(stateDb, { thread_id: 'thr-abc123', reason: 'thread-resolved' });
+    expect(getMemory(stateDb, 'fact.a')).toBeNull();
+    expect(getMemory(stateDb, 'fact.b')).toBeNull();
+
+    const result = unsupersedeMemories(stateDb, { thread_id: 'thr-abc123' });
+    expect(result.restored.map((m) => m.key).sort()).toEqual(['fact.a', 'fact.b']);
+    expect(result.skipped).toBe(0);
+
+    // Facts reappear in every read path; reason cleared; other thread untouched
+    expect(getMemory(stateDb, 'fact.a')).not.toBeNull();
+    expect(getMemory(stateDb, 'fact.b')).not.toBeNull();
+    expect(listMemories(stateDb).map((m) => m.key).sort()).toEqual(['fact.a', 'fact.b', 'fact.c']);
+    expect(searchMemories(stateDb, { query: 'alpha' })).toHaveLength(1);
+
+    const row = rawRow('fact.a')!;
+    expect(row.superseded_by).toBeNull();
+    expect(row.supersede_reason).toBeNull();
+  });
+
+  it('is idempotent: a second unsupersede (or one on live rows) is a no-op', () => {
+    storeMemory(stateDb, { key: 'fact.a', value: 'alpha', type: 'fact', thread_id: 'thr-x' });
+    supersedeMemories(stateDb, { thread_id: 'thr-x' });
+
+    const first = unsupersedeMemories(stateDb, { thread_id: 'thr-x' });
+    expect(first.restored).toHaveLength(1);
+    expect(first.skipped).toBe(0);
+
+    // Second call: the row is already live → skipped, not restored again
+    const second = unsupersedeMemories(stateDb, { thread_id: 'thr-x' });
+    expect(second.restored).toHaveLength(0);
+    expect(second.skipped).toBe(1);
+  });
+
+  it('does NOT revive a row superseded by a successor (only self-tombstones)', () => {
+    // Simulate a real successor supersession: row replaced by a newer fact.
+    storeMemory(stateDb, { key: 'fact.s', value: 'v1', type: 'fact', thread_id: 'thr-succ' });
+    const original = rawRow('fact.s')!;
+    // Insert a successor and point the original at it (superseded_by != id).
+    storeMemory(stateDb, { key: 'fact.s2', value: 'v2 successor', type: 'fact', thread_id: 'thr-succ' });
+    const successor = rawRow('fact.s2')!;
+    stateDb.db.prepare('UPDATE memories SET superseded_by = ? WHERE id = ?').run(successor.id, original.id);
+
+    const result = unsupersedeMemories(stateDb, { thread_id: 'thr-succ' });
+    // fact.s was replaced, not thread-tombstoned → left closed
+    expect(result.restored.map((m) => m.key)).not.toContain('fact.s');
+    expect(rawRow('fact.s')!.superseded_by).toBe(successor.id);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+  });
+
+  it('requires thread_id', () => {
+    expect(() => unsupersedeMemories(stateDb, { thread_id: '' })).toThrow(/thread_id/);
+  });
+
+  it('scope rule: caller without agent_id cannot unsupersede private facts on the thread', () => {
+    storeMemory(stateDb, { key: 'fact.private', value: 'secret', type: 'fact', thread_id: 'thr-z', agent_id: 'agent-1', visibility: 'private' });
+    storeMemory(stateDb, { key: 'fact.global', value: 'public', type: 'fact', thread_id: 'thr-z' });
+    supersedeMemories(stateDb, { thread_id: 'thr-z', agent_id: 'agent-1' }); // owner closes both (sees global + own)
+
+    // Global caller can only restore the global row
+    const result = unsupersedeMemories(stateDb, { thread_id: 'thr-z' });
+    expect(result.restored.map((m) => m.key)).toEqual(['fact.global']);
+    expect(getMemory(stateDb, 'fact.private', 'agent-1')).toBeNull();
+
+    // Owner restores the private one
+    const owned = unsupersedeMemories(stateDb, { thread_id: 'thr-z', agent_id: 'agent-1' });
+    expect(owned.restored.map((m) => m.key)).toEqual(['fact.private']);
+    expect(getMemory(stateDb, 'fact.private', 'agent-1')).not.toBeNull();
+  });
+
+  it('restores graph edges for shared/global facts on undo', () => {
+    stateDb.db.prepare(`
+      INSERT INTO entities (name, name_lower, path, category) VALUES ('Kuramoto', 'kuramoto', 'notes/Kuramoto.md', 'concepts')
+    `).run();
+
+    storeMemory(stateDb, { key: 'fact.edge', value: 'Kuramoto sync threshold proven', type: 'fact', thread_id: 'thr-e' });
+    supersedeMemories(stateDb, { thread_id: 'thr-e' });
+    const edgesAfterSupersede = stateDb.db.prepare(
+      "SELECT COUNT(*) as c FROM note_links WHERE note_path = 'memory:fact.edge'"
+    ).get() as { c: number };
+    expect(edgesAfterSupersede.c).toBe(0);
+
+    unsupersedeMemories(stateDb, { thread_id: 'thr-e' });
+    const edgesAfterUndo = stateDb.db.prepare(
+      "SELECT COUNT(*) as c FROM note_links WHERE note_path = 'memory:fact.edge'"
+    ).get() as { c: number };
+    expect(edgesAfterUndo.c).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Adds `memory(action:"unsupersede", thread_id)` — the undo consumer the engine's `unresolveThread` needs to reverse a thread resolution.

## What
- **`unsupersedeMemories`** (core/write/memory.ts): clears `superseded_by` + `supersede_reason` ONLY on self-tombstoned rows (`superseded_by = id`) carrying the thread_id. Rows superseded by a *successor* (replaced, not thread-tombstoned) stay closed and count in `skipped`. Idempotent via the SQL `superseded_by = id` guard. Restores graph edges from stored `entities_json` for shared/global rows (mirrors `storeMemory`). Same visibility scope as supersede.
- **Tool** (tools/write/memory.ts): `unsupersede` added to the action enum + handler.

## Manifest / contract safety
The tool **description string is unchanged**, so the catalog `descriptionHash` and the `tool-embeddings.generated.ts` manifest stay valid — no regeneration, and the tier-1 description-length contract holds. Verified against `tool-routing` / `tool-tiering` / `tool-counts` suites (74 passed).

## Tests
6 new cases in `memoryUnsupersede.test.ts`: round-trip restore, idempotency, successor-skip, thread_id-required, visibility scope, graph-edge restore. Full memory suite 16/16.

Pre-existing `traces/no-refresh` failures (8, "MCP error … is not valid JSON") reproduce on clean `main` — sandbox artifact, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)